### PR TITLE
Fix worktree-backed document asset previews

### DIFF
--- a/src/deepscientist/daemon/api/handlers.py
+++ b/src/deepscientist/daemon/api/handlers.py
@@ -1387,10 +1387,7 @@ npm --prefix src/ui run build</pre>
             mime_type = mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
             content = quest_service._read_git_bytes(quest_root, revision, relative)
             return 200, self._asset_headers(mime_type), content
-        path, _writable, _scope, _source_kind = quest_service._resolve_document(
-            quest_service._quest_root(quest_id),
-            document_id,
-        )
+        path, _writable, _scope, _source_kind = quest_service.resolve_document(quest_id, document_id)
         if not path.exists() or not path.is_file():
             return 404, {"Content-Type": "text/plain; charset=utf-8"}, b"Not Found"
         mime_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"

--- a/src/deepscientist/quest/service.py
+++ b/src/deepscientist/quest/service.py
@@ -4193,23 +4193,7 @@ class QuestService:
                 },
             }
 
-        resolution_root = (
-            quest_root
-            if document_id.startswith(("questpath::", "memory::"))
-            else workspace_root
-        )
-        try:
-            path, writable, scope, source_kind = self._resolve_document(resolution_root, document_id)
-        except FileNotFoundError:
-            legacy_relative = None
-            if document_id.startswith("path::"):
-                legacy_relative = document_id.split("::", 1)[1].lstrip("/")
-            if legacy_relative and legacy_relative.startswith("literature/arxiv/"):
-                path, writable, scope, source_kind = self._resolve_document(
-                    quest_root, f"questpath::{legacy_relative}"
-                )
-            else:
-                raise
+        path, writable, scope, source_kind = self.resolve_document(quest_id, document_id)
         renderer_hint, mime_type = self._renderer_hint_for(path)
         is_text = self._is_text_document(path, mime_type, renderer_hint)
         content = read_text(path) if is_text else ""
@@ -4236,6 +4220,24 @@ class QuestService:
                 "renderer_hint": renderer_hint,
             },
         }
+
+    def resolve_document(self, quest_id: str, document_id: str) -> tuple[Path, bool, str, str]:
+        quest_root = self._quest_root(quest_id)
+        workspace_root = self.active_workspace_root(quest_root)
+        resolution_root = self._document_resolution_root(
+            quest_root=quest_root,
+            workspace_root=workspace_root,
+            document_id=document_id,
+        )
+        try:
+            return self._resolve_document(resolution_root, document_id)
+        except FileNotFoundError:
+            legacy_relative = None
+            if document_id.startswith("path::"):
+                legacy_relative = document_id.split("::", 1)[1].lstrip("/")
+            if legacy_relative and legacy_relative.startswith("literature/arxiv/"):
+                return self._resolve_document(quest_root, f"questpath::{legacy_relative}")
+            raise
 
     def save_document(self, quest_id: str, document_id: str, content: str, previous_revision: str | None = None) -> dict:
         current = self.open_document(quest_id, document_id)
@@ -5302,6 +5304,12 @@ class QuestService:
             "queued_message_count_before_delivery": len(pending),
             "queued_message_count_after_delivery": len(queue_payload.get("pending") or []),
         }
+
+    @staticmethod
+    def _document_resolution_root(quest_root: Path, workspace_root: Path, document_id: str) -> Path:
+        if document_id.startswith(("questpath::", "memory::")):
+            return quest_root
+        return workspace_root
 
     @staticmethod
     def _resolve_document(quest_root: Path, document_id: str) -> tuple[Path, bool, str, str]:

--- a/tests/test_daemon_api.py
+++ b/tests/test_daemon_api.py
@@ -143,6 +143,49 @@ def test_handlers_quest_layout_roundtrip(temp_home: Path) -> None:
     assert refreshed["layout_json"]["preferences"]["curveMode"] == "full"
 
 
+@pytest.mark.parametrize(
+    ("relative_path", "expected_mime", "content"),
+    [
+        ("paper/figures/generated/figure2.svg", "image/svg+xml", b"<svg xmlns='http://www.w3.org/2000/svg'></svg>"),
+        ("paper/figures/generated/figure2.png", "image/png", b"\x89PNG\r\n\x1a\nworktree-preview"),
+        ("paper/figures/generated/figure2.pdf", "application/pdf", b"%PDF-1.4\nworktree-preview"),
+    ],
+)
+def test_document_asset_resolves_path_documents_from_active_worktree(
+    temp_home: Path,
+    relative_path: str,
+    expected_mime: str,
+    content: bytes,
+) -> None:
+    ensure_home_layout(temp_home)
+    ConfigManager(temp_home).ensure_files()
+    app = DaemonApp(temp_home)
+    quest = app.quest_service.create("worktree binary preview quest")
+    quest_id = quest["quest_id"]
+    quest_root = Path(quest["quest_root"])
+
+    worktree_root = quest_root / ".ds" / "worktrees" / "analysis-branch-001"
+    asset_path = worktree_root / relative_path
+    asset_path.parent.mkdir(parents=True, exist_ok=True)
+    asset_path.write_bytes(content)
+    (worktree_root / "brief.md").write_text("# Worktree brief\n", encoding="utf-8")
+    app.quest_service.update_research_state(
+        quest_root,
+        current_workspace_root=str(worktree_root),
+        research_head_worktree_root=str(worktree_root),
+    )
+
+    opened = app.handlers.document_open(quest_id, {"document_id": f"path::{relative_path}"})
+
+    assert opened["path"] == str(asset_path)
+
+    status, headers, body = app.handlers.document_asset(quest_id, opened["asset_url"])
+
+    assert status == 200
+    assert headers["Content-Type"] == expected_mime
+    assert body == content
+
+
 def test_handlers_workflow_includes_optimization_frontier_when_available(temp_home: Path) -> None:
     ensure_home_layout(temp_home)
     ConfigManager(temp_home).ensure_files()


### PR DESCRIPTION
## Summary
- centralize document resolution so document asset requests use the same active workspace/worktree rules as document open
- preserve the existing legacy `path::literature/arxiv/...` fallback in the shared resolution path
- add regression coverage for svg/png/pdf assets that exist only in the active worktree

## Testing
- rtk proxy pytest -q tests/test_daemon_api.py -k test_document_asset_resolves_path_documents_from_active_worktree
- rtk proxy pytest -q tests/test_memory_and_artifact.py -k "test_memory_document_open_uses_quest_root_when_active_workspace_is_worktree or test_open_document_supports_legacy_path_arxiv_ids_from_worktree"