### PR TITLE
[Core] Recover stalled running turns when new user messages arrive

### DIFF
--- a/src/deepscientist/daemon/app.py
+++ b/src/deepscientist/daemon/app.py
@@ -1866,6 +1866,9 @@ class DaemonApp:
                 return
             pending_user_count = int(snapshot.get("pending_user_message_count") or 0)
             if pending_user_count > 0:
+                with self._turn_lock:
+                    state = self._turn_state.setdefault(quest_id, {"running": False, "pending": False})
+                    state.pop("recovery_pending", None)
                 self.schedule_turn(quest_id, reason=turn_reason)
                 return
 
@@ -1987,13 +1990,11 @@ class DaemonApp:
         turn_state = self._refresh_turn_worker_state(quest_id)
         with self._turn_lock:
             state = self._turn_state.setdefault(quest_id, {"running": False, "pending": False})
-            if state.get("recovery_pending") and state.get("running"):
+            if state.get("recovery_pending"):
                 return {
                     "snapshot": snapshot,
                     "blocked": True,
                 }
-            if state.get("recovery_pending") and not state.get("running"):
-                state.pop("recovery_pending", None)
         details = self._stalled_running_turn_details(
             quest_id,
             snapshot=snapshot,
@@ -2008,97 +2009,108 @@ class DaemonApp:
 
         active_run_id = str(snapshot.get("active_run_id") or "").strip()
         runner_name = self._runner_name_for(snapshot)
-        interrupted = False
-        try:
-            runner = self.get_runner(runner_name)
-        except KeyError:
-            runner = None
-        if runner is not None and hasattr(runner, "interrupt"):
-            interrupted = bool(getattr(runner, "interrupt")(quest_id))
         with self._turn_lock:
             state = self._turn_state.setdefault(quest_id, {"running": False, "pending": False})
+            if state.get("recovery_pending"):
+                return {
+                    "snapshot": snapshot,
+                    "blocked": True,
+                }
             state["pending"] = False
             state["stop_requested"] = True
             state["recovery_pending"] = True
-        stopped_bash_session_ids = self._stop_active_bash_exec_sessions(
-            quest_id,
-            run_id=active_run_id or None,
-            reason="stalled_turn_recovery",
-            user_id="auto:stalled-turn-recovery",
-        )
-        turn_state = self._wait_for_turn_worker_exit(
-            quest_id,
-            timeout_seconds=_STALLED_RUNNING_TURN_INTERRUPT_TIMEOUT_SECONDS,
-        )
-        if turn_state.get("running"):
-            self._ensure_recovery_resume_watch(quest_id, turn_reason="queued_user_messages")
+        interrupted = False
+        try:
+            try:
+                runner = self.get_runner(runner_name)
+            except KeyError:
+                runner = None
+            if runner is not None and hasattr(runner, "interrupt"):
+                interrupted = bool(getattr(runner, "interrupt")(quest_id))
+            stopped_bash_session_ids = self._stop_active_bash_exec_sessions(
+                quest_id,
+                run_id=active_run_id or None,
+                reason="stalled_turn_recovery",
+                user_id="auto:stalled-turn-recovery",
+            )
+            turn_state = self._wait_for_turn_worker_exit(
+                quest_id,
+                timeout_seconds=_STALLED_RUNNING_TURN_INTERRUPT_TIMEOUT_SECONDS,
+            )
+            if turn_state.get("running"):
+                self._ensure_recovery_resume_watch(quest_id, turn_reason="queued_user_messages")
+                self.logger.log(
+                    "warning",
+                    "quest.turn_state_recovery_pending",
+                    quest_id=quest_id,
+                    abandoned_run_id=active_run_id or None,
+                    reason=turn_reason,
+                    silent_seconds=int(details.get("silent_seconds") or 0),
+                    pending_user_message_count=int(details.get("pending_user_count") or 0),
+                    interrupted=interrupted,
+                )
+                return {
+                    "snapshot": snapshot,
+                    "blocked": True,
+                }
+
+            previous_status = (
+                str(snapshot.get("runtime_status") or snapshot.get("status") or snapshot.get("display_status") or "running").strip()
+                or "running"
+            )
+            normalized_status = "active" if previous_status == "running" else previous_status
+            summary = (
+                f"Recovered stalled running turn `{active_run_id}` after "
+                f"{int(details.get('silent_seconds') or 0)} seconds without tool activity while "
+                f"{int(details.get('pending_user_count') or 0)} queued user message(s) were waiting."
+            )
+            if interrupted:
+                summary = f"{summary} The active runner process was interrupted."
+            if stopped_bash_session_ids:
+                summary = f"{summary} Stopped {len(stopped_bash_session_ids)} bash_exec session(s)."
+            quest_root = self.quest_service._quest_root(quest_id)
+            append_jsonl(
+                quest_root / ".ds" / "events.jsonl",
+                {
+                    "event_id": generate_id("evt"),
+                    "type": "quest.turn_state_reconciled",
+                    "quest_id": quest_id,
+                    "abandoned_run_id": active_run_id or None,
+                    "previous_status": previous_status,
+                    "status": normalized_status,
+                    "completed_at": None,
+                    "exit_code": None,
+                    "summary": summary,
+                    "recovery_kind": "stalled_live_turn",
+                    "interrupted": interrupted,
+                    "stopped_bash_session_ids": stopped_bash_session_ids,
+                    "created_at": utc_now(),
+                },
+            )
             self.logger.log(
                 "warning",
-                "quest.turn_state_recovery_pending",
+                "quest.turn_state_reconciled",
                 quest_id=quest_id,
                 abandoned_run_id=active_run_id or None,
-                reason=turn_reason,
-                silent_seconds=int(details.get("silent_seconds") or 0),
-                pending_user_message_count=int(details.get("pending_user_count") or 0),
+                previous_status=previous_status,
+                status=normalized_status,
+                recovery_kind="stalled_live_turn",
                 interrupted=interrupted,
+                stopped_bash_session_count=len(stopped_bash_session_ids),
             )
+            snapshot = self.quest_service.mark_turn_finished(quest_id, status=normalized_status)
+            with self._turn_lock:
+                state = self._turn_state.setdefault(quest_id, {"running": False, "pending": False})
+                state.pop("recovery_pending", None)
             return {
                 "snapshot": snapshot,
-                "blocked": True,
+                "blocked": False,
             }
-
-        previous_status = (
-            str(snapshot.get("runtime_status") or snapshot.get("status") or snapshot.get("display_status") or "running").strip()
-            or "running"
-        )
-        normalized_status = "active" if previous_status == "running" else previous_status
-        summary = (
-            f"Recovered stalled running turn `{active_run_id}` after "
-            f"{int(details.get('silent_seconds') or 0)} seconds without tool activity while "
-            f"{int(details.get('pending_user_count') or 0)} queued user message(s) were waiting."
-        )
-        if interrupted:
-            summary = f"{summary} The active runner process was interrupted."
-        if stopped_bash_session_ids:
-            summary = f"{summary} Stopped {len(stopped_bash_session_ids)} bash_exec session(s)."
-        quest_root = self.quest_service._quest_root(quest_id)
-        append_jsonl(
-            quest_root / ".ds" / "events.jsonl",
-            {
-                "event_id": generate_id("evt"),
-                "type": "quest.turn_state_reconciled",
-                "quest_id": quest_id,
-                "abandoned_run_id": active_run_id or None,
-                "previous_status": previous_status,
-                "status": normalized_status,
-                "completed_at": None,
-                "exit_code": None,
-                "summary": summary,
-                "recovery_kind": "stalled_live_turn",
-                "interrupted": interrupted,
-                "stopped_bash_session_ids": stopped_bash_session_ids,
-                "created_at": utc_now(),
-            },
-        )
-        self.logger.log(
-            "warning",
-            "quest.turn_state_reconciled",
-            quest_id=quest_id,
-            abandoned_run_id=active_run_id or None,
-            previous_status=previous_status,
-            status=normalized_status,
-            recovery_kind="stalled_live_turn",
-            interrupted=interrupted,
-            stopped_bash_session_count=len(stopped_bash_session_ids),
-        )
-        snapshot = self.quest_service.mark_turn_finished(quest_id, status=normalized_status)
-        with self._turn_lock:
-            state = self._turn_state.setdefault(quest_id, {"running": False, "pending": False})
-            state.pop("recovery_pending", None)
-        return {
-            "snapshot": snapshot,
-            "blocked": False,
-        }
+        except Exception:
+            with self._turn_lock:
+                state = self._turn_state.setdefault(quest_id, {"running": False, "pending": False})
+                state.pop("recovery_pending", None)
+            raise
 
     def control_quest(self, quest_id: str, *, action: str, source: str = "local") -> dict:
         normalized_action = str(action or "").strip().lower()

--- a/tests/test_daemon_api.py
+++ b/tests/test_daemon_api.py
@@ -4834,6 +4834,130 @@ def test_stalled_live_turn_recovery_pending_respects_later_control_action(
     assert state.get("pending") is False
     assert runner.requests == []
 
+
+def test_schedule_turn_recovers_stalled_live_turn_only_once_under_concurrency(
+    temp_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ensure_home_layout(temp_home)
+    ConfigManager(temp_home).ensure_files()
+    app = DaemonApp(temp_home)
+    quest = app.quest_service.create("concurrent stalled live turn recovery schedule quest")
+    quest_id = quest["quest_id"]
+    quest_root = Path(quest["quest_root"])
+    app.quest_service.set_continuation_state(quest_root, policy="none")
+    app.quest_service.append_message(
+        quest_id,
+        role="user",
+        content="Recover the queued message once the stalled turn is cleared.",
+        source="web-react",
+    )
+
+    stale_run_id = "run-stalled-live-concurrent-001"
+    _mark_turn_started_with_retry(app, quest_id, run_id=stale_run_id, status="running")
+
+    release_worker = threading.Event()
+
+    def _old_worker() -> None:
+        while not release_worker.is_set():
+            time.sleep(0.02)
+
+    old_worker = threading.Thread(target=_old_worker, daemon=True, name=f"pytest-stalled-concurrent-{quest_id}")
+    old_worker.start()
+
+    class RecoveryRunner:
+        binary = ""
+
+        def __init__(self) -> None:
+            self.interrupt_calls: list[str] = []
+
+        def interrupt(self, target_quest_id: str) -> bool:
+            self.interrupt_calls.append(target_quest_id)
+            release_worker.set()
+            time.sleep(0.2)
+            return True
+
+    runner = RecoveryRunner()
+    app.runners["codex"] = runner
+    app._turn_state[quest_id] = {
+        "running": True,
+        "pending": False,
+        "stop_requested": False,
+        "reason": "user_message",
+        "worker": old_worker,
+    }
+
+    def _fake_stalled_running_turn_details(
+        target_quest_id: str,
+        *,
+        snapshot: dict | None = None,
+        turn_state: dict[str, object] | None = None,
+        turn_reason: str,
+    ) -> dict[str, int] | None:
+        if target_quest_id != quest_id or turn_reason != "user_message":
+            return None
+        if not dict(turn_state or {}).get("running"):
+            return None
+        return {
+            "pending_user_count": int((snapshot or {}).get("pending_user_message_count") or 1),
+            "silent_seconds": _STALLED_RUNNING_TURN_INACTIVITY_SECONDS,
+        }
+
+    monkeypatch.setattr(app, "_stalled_running_turn_details", _fake_stalled_running_turn_details)
+
+    barrier = threading.Barrier(3)
+    payloads: list[dict[str, object]] = []
+    errors: list[Exception] = []
+    run_turn_calls: list[str] = []
+
+    def _fake_run_quest_turn(target_quest_id: str) -> None:
+        run_turn_calls.append(target_quest_id)
+
+    monkeypatch.setattr(app, "_run_quest_turn", _fake_run_quest_turn)
+
+    def _schedule_turn() -> None:
+        barrier.wait()
+        try:
+            payloads.append(app.schedule_turn(quest_id, reason="user_message"))
+        except Exception as exc:  # pragma: no cover - exercised only on failure
+            errors.append(exc)
+
+    workers = [threading.Thread(target=_schedule_turn, daemon=True) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    barrier.wait()
+    for worker in workers:
+        worker.join(timeout=2)
+
+    assert errors == []
+    assert len(payloads) == 2
+    assert sum(1 for item in payloads if item["started"] is True) == 1
+    assert sum(1 for item in payloads if item["reason"] == "stalled_turn_recovery_pending") == 1
+
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if len(run_turn_calls) == 1 and not old_worker.is_alive():
+            break
+        time.sleep(0.05)
+    else:
+        raise AssertionError("concurrent stalled live turn recovery did not finish exactly one replacement turn")
+
+    assert runner.interrupt_calls == [quest_id]
+    assert run_turn_calls == [quest_id]
+
+    events = [
+        item
+        for item in app.quest_service.events(quest_id)["events"]
+        if item.get("type") == "quest.turn_state_reconciled"
+        and item.get("abandoned_run_id") == stale_run_id
+        and item.get("recovery_kind") == "stalled_live_turn"
+    ]
+    assert len(events) == 1
+
+    state = dict(app._turn_state.get(quest_id) or {})
+    assert state.get("recovery_pending") is None
+    assert state.get("recovery_watch_active") is None
+
 def test_run_quest_turn_clears_active_run_when_assistant_append_fails(
     temp_home: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

This PR fixes a daemon/runtime bug where a quest could remain in a stale `running` state after the active turn stopped making progress. In that state, new user messages could stay queued indefinitely even though no bash job was running and no new tool activity was happening.

The fix reconciles stale active turns before scheduling and adds explicit recovery for stalled live turns when queued user messages are waiting, no bash session is active, and tool activity has been silent for 30 minutes. It also adds regression coverage for this recovery path while preserving the existing mailbox behavior for healthy running turns.

## Related Issue

No public issue linked for this fix.

- Closes #
- Related #

## PR Type

[Core]

## Scope

- `src/deepscientist/daemon/app.py`
- `tests/test_daemon_api.py`

## User-Facing Impact

Users and operators should no longer see quests stuck in a fake `running` state while new messages are ignored. When a running turn has gone stale and is no longer making progress, the daemon can now safely recover it and start a fresh turn for the queued user request.

## Tests

```text
- pytest tests/test_daemon_api.py -k "test_submit_user_message_reconciles_stale_active_turn_and_starts_new_run or test_submit_user_message_recovers_stalled_live_turn_and_starts_new_run or test_running_turn_consumes_queued_user_messages_via_artifact_without_duplicate_follow_up_turn"
- pytest tests/test_daemon_api.py -k "test_submit_user_message_reconciles_stale_active_turn_and_starts_new_run or test_daemon_auto_resumes_recent_reconciled_quest or test_daemon_does_not_auto_resume_old_reconciled_quest or test_daemon_suppresses_auto_resume_after_repeated_crash_loop"
- Gap: I did not run the full test suite in this PR flow.