### PR TITLE
[Bugfix] Fix Weixin text-send retry on ret=-2 stale-context errors

### DIFF
--- a/src/deepscientist/bridges/connectors.py
+++ b/src/deepscientist/bridges/connectors.py
@@ -1021,8 +1021,13 @@ class WeixinConnectorBridge(BaseConnectorBridge):
     @classmethod
     def _retry_delays_for_item(cls, item: dict[str, Any], exc: Exception) -> tuple[float, ...]:
         message = str(exc or "").strip().lower()
-        if "ret=-2" in message and cls._item_type(item) in {4, 5}:
+        if "ret=-2" not in message:
+            return ()
+        item_type = cls._item_type(item)
+        if item_type in {4, 5}:
             return cls._MEDIA_SEND_RETRY_DELAYS_SECONDS
+        if item_type == 1:
+            return cls._TEXT_SEND_RETRY_DELAYS_SECONDS
         return ()
 
     def _send_items(
@@ -1044,7 +1049,8 @@ class WeixinConnectorBridge(BaseConnectorBridge):
             if media_item:
                 time.sleep(self._MEDIA_SEND_INITIAL_DELAY_SECONDS)
             retry_delays: tuple[float, ...] = ()
-            for attempt in range(1 + len(self._MEDIA_SEND_RETRY_DELAYS_SECONDS)):
+            max_retries = max(len(self._TEXT_SEND_RETRY_DELAYS_SECONDS), len(self._MEDIA_SEND_RETRY_DELAYS_SECONDS))
+            for attempt in range(1 + max_retries):
                 client_id = self._next_client_id()
                 try:
                     send_weixin_message(


### PR DESCRIPTION
## What changed

`_retry_delays_for_item` only returned retry delays for **media items** (types 4, 5) but ignored **text items** (type 1). This meant `_TEXT_SEND_RETRY_DELAYS_SECONDS` was defined at line 788 but never actually used — text sends that hit a `ret=-2` stale-context error raised immediately instead of retrying with the configured `(0.8s, 1.5s, 3.0s)` back-off schedule.

## Why it changed

The existing test `test_bridge_direct_outbound_weixin_retries_text_send_after_ret_minus_2` explicitly expects text retry behavior on `ret=-2`, but was failing because the production code path never reached the text delay schedule.

This is a real user-facing bug: when a Weixin session context becomes stale (common after inactivity), text messages fail permanently on the first attempt instead of retrying with back-off like media messages do.

## Changes

**`src/deepscientist/bridges/connectors.py`**:
- `_retry_delays_for_item`: now returns `_TEXT_SEND_RETRY_DELAYS_SECONDS` for type 1 items on `ret=-2`, matching the existing media retry path for types 4/5
- `_send_items`: retry loop upper bound now derived from `max(len(TEXT_DELAYS), len(MEDIA_DELAYS))` instead of hard-coding `MEDIA_DELAYS` length, so the loop stays correct if the two tuples diverge in the future

## Tests run

```
$ pytest tests/test_connector_bridges.py -v
19 passed
```

Previously: `test_bridge_direct_outbound_weixin_retries_text_send_after_ret_minus_2` was FAILING. Now passes.

## AI disclosure

AI-assisted. All changes reviewed line by line and validated against the test suite.