### PR TITLE
[Bugfix] Fix 3 stale test assertions broken by recent config/prompt changes

### DIFF
--- a/tests/test_config_testing.py
+++ b/tests/test_config_testing.py
@@ -363,17 +363,18 @@ def test_config_save_reloads_system_connector_visibility(temp_home: Path) -> Non
     manager.ensure_files()
     app = DaemonApp(temp_home)
 
-    assert "telegram" not in {item["name"] for item in app.handlers.connectors()}
+    # discord is disabled by default in default_system_enabled_connectors()
+    assert "discord" not in {item["name"] for item in app.handlers.connectors()}
 
     structured = manager.load_named("config")
-    structured["connectors"]["system_enabled"]["telegram"] = True
+    structured["connectors"]["system_enabled"]["discord"] = True
 
     payload = app.handlers.config_save("config", {"structured": structured})
 
     assert payload["ok"] is True
     assert payload["runtime_reload"]["ok"] is True
-    assert "telegram" in payload["runtime_reload"]["system_enabled_connectors"]
-    assert "telegram" in {item["name"] for item in app.handlers.connectors()}
+    assert "discord" in payload["runtime_reload"]["system_enabled_connectors"]
+    assert "discord" in {item["name"] for item in app.handlers.connectors()}
 
 
 def test_structured_connector_test_passes_delivery_targets(monkeypatch, temp_home: Path) -> None:

--- a/tests/test_init_and_quest.py
+++ b/tests/test_init_and_quest.py
@@ -45,7 +45,7 @@ def test_init_creates_required_files(temp_home: Path) -> None:
     assert config["connectors"]["system_enabled"]["whatsapp"] is True
     assert config["connectors"]["system_enabled"]["lingzhu"] is True
     assert runners["codex"]["profile"] == ""
-    assert runners["codex"]["model"] == "gpt-5.4"
+    assert runners["codex"]["model"] == "inherit"
     assert runners["codex"]["model_reasoning_effort"] == "xhigh"
     assert runners["codex"]["retry_initial_backoff_sec"] == 10.0
     assert runners["codex"]["retry_backoff_multiplier"] == 6.0

--- a/tests/test_skill_contracts.py
+++ b/tests/test_skill_contracts.py
@@ -139,7 +139,7 @@ def test_system_prompt_strengthens_bash_exec_only_terminal_contract() -> None:
 
     assert "## 0. Hard execution redlines" in text
     assert "Native `shell_command` / `command_execution` is forbidden for this workflow." in text
-    assert "Even if the runner or model surface exposes a native shell tool, do not use it." in text
+    assert "Do not use `shell_command` even if the runner, model, or surface still exposes it." in text
     assert "All terminal or shell-like command execution must use `bash_exec`." in text
     assert "including `curl`, `python`, `python3`, `bash`, `sh`, `node`, `npm`, `uv`, `git`, `ls`, `cat`, `sed`" in text
     assert "Do not use any direct terminal, subprocess, or implicit shell path outside `bash_exec`." in text


### PR DESCRIPTION
## What changed

Three test assertions were out of sync with the current codebase defaults, causing failures on every `pytest` run.

## Why it changed

Recent changes to connector defaults, the system prompt wording, and the runner model default were not reflected in the corresponding test expectations.

## Changes

### 1. `tests/test_config_testing.py` — `test_config_save_reloads_system_connector_visibility`

**Problem**: The test used `telegram` as a connector that should be disabled by default, but `default_system_enabled_connectors()` now includes `telegram=True`.

**Fix**: Switched to `discord`, which is still disabled by default (`discord=False` in `SYSTEM_CONNECTOR_NAMES` defaults). The test logic is identical — it verifies that toggling `system_enabled` for a previously-disabled connector makes it visible.

### 2. `tests/test_skill_contracts.py` — `test_system_prompt_strengthens_bash_exec_only_terminal_contract`

**Problem**: The test asserted the old prompt wording:
> `"Even if the runner or model surface exposes a native shell tool, do not use it."`

But `src/prompts/system.md` was rewritten to:
> `"Do not use shell_command even if the runner, model, or surface still exposes it."`

**Fix**: Updated the assertion string to match the current prompt text.

### 3. `tests/test_init_and_quest.py` — `test_init_creates_required_files`

**Problem**: The test expected `runners["codex"]["model"] == "gpt-5.4"`, but `config/models.py` now sets `"model": "inherit"`.

**Fix**: Updated the assertion to expect `"inherit"`.

## Tests run

```
$ pytest tests/test_config_testing.py tests/test_skill_contracts.py tests/test_init_and_quest.py -q
91 passed
```

All three previously-failing tests now pass, and no regressions in their respective test files.

## AI disclosure

AI-assisted. All changes reviewed line by line and validated against the test suite.