### PR TITLE
fix: resolve 'npmBinary is not defined' error during auto-update

### DIFF
--- a/bin/ds.js
+++ b/bin/ds.js
@@ -4279,6 +4279,7 @@ async function performSelfUpdate(home, options = {}) {
     };
   }
 
+  const npmBinary = resolveNpmBinary();
   const installResult = runNpmInstallLatest(home, npmBinary);
   if (!installResult.ok) {
     const message = summarizeUpdateFailure(installResult);


### PR DESCRIPTION
**Description**
When the user accepts the prompt to update DeepScientist (`[y/N]: y`), the CLI crashes with a `ReferenceError: npmBinary is not defined`.

**Cause**
At line ~4282 in `bin/ds.js`, `runNpmInstallLatest` is called with the `npmBinary` argument, but this variable is not defined or resolved within that specific scope/block.

**Fix**
Added `const npmBinary = resolveNpmBinary();` before the installation call to ensure the variable is properly initialized.