### PR TITLE
fix: replace undefined CONFIG_META with SETTINGS_META

### DIFF
--- a/src/ui/src/components/settings/SettingsPage.tsx
+++ b/src/ui/src/components/settings/SettingsPage.tsx
@@ -728,7 +728,7 @@ export function SettingsPage({
       : selectedName && selectedName in SPECIAL_META
         ? SPECIAL_META[selectedName as keyof typeof SPECIAL_META]
         : selectedName
-          ? CONFIG_META[selectedName as ConfigDocumentName]
+          ? SETTINGS_META[selectedName as keyof typeof SETTINGS_META]
           : null
   const helpMarkdown = translateSettingsHelpMarkdown(
     locale,


### PR DESCRIPTION
## Summary
- Fix ReferenceError on connector settings page where `CONFIG_META` was referenced but never defined
- Changed to use existing `SETTINGS_META` constant

## Test plan
- [x] Build the UI
- [x] Access http://127.0.0.1:20999/settings/connector and verify no ReferenceError