### PR TITLE
skills: restructure stage control surfaces and references

### DIFF
--- a/src/skills/analysis-campaign/SKILL.md
+++ b/src/skills/analysis-campaign/SKILL.md
@@ -9,20 +9,63 @@ skill_role: stage
 Use this skill when follow-up evidence is needed after a durable result.
 The goal is to answer a bounded evidence question, not to keep opening more slices just because they are imaginable.
 
-This is the shared DeepScientist protocol for supplementary experiments after a durable result.
-Use the same route for:
+## Match signals
 
-- ordinary ablations / robustness / sensitivity work
-- review-driven evidence gaps
-- rebuttal-driven extra experiments
-- writing-driven evidence gaps
+Use `analysis-campaign` when:
 
-For paper-facing work, treat "analysis campaign" broadly:
+- a durable main result already exists and follow-up evidence is needed
+- the quest needs ablations, robustness checks, sensitivity checks, failure analysis, error analysis, efficiency or cost checks, or limitation-boundary checks
+- writing, review, or rebuttal pressure exposed an evidence gap that should be answered by bounded follow-up slices
 
-- not only post-hoc interpretation
-- also ablations, sensitivity checks, robustness checks, efficiency or cost checks, highlight-validation runs, and limitation-boundary work beyond the main result
+Do not use `analysis-campaign` when:
 
-Do not invent a separate experiment system for those cases.
+- the quest still lacks a credible main run or accepted baseline and the proposed work depends on that missing reference
+- the next step is obviously another main experiment rather than follow-up evidence work
+- the proposed slice does not connect to a parent claim, parent result, paper gap, reviewer item, or route decision
+
+## One-sentence summary
+
+Answer the smallest evidence question that changes, confirms, or blocks a parent claim, then stop when the next route is clear.
+
+## Control workflow
+
+1. Lock the parent object, evidence question, comparison target, and stop condition.
+   Make explicit what claim, failure mode, or route decision is actually being tested.
+2. Choose the lightest analysis route and the smallest slice set that can answer the question.
+   Run claim-critical slices first.
+3. Keep slices isolated and comparable.
+   Record exactly what changed, what stayed fixed, and whether apples-to-apples comparison still holds.
+4. Record slice-level evidence before making any campaign-level claim.
+   Every meaningful slice should leave a durable outcome and a claim update.
+5. Aggregate only the decision-relevant findings and route the next step.
+   End in continue, write, experiment, idea, decision, blocker, or stop.
+
+## AVOID / pitfalls
+
+- Do not disguise a new main experiment as an analysis slice.
+- Do not hide null, negative, partial, failed, or contradictory slices.
+- Do not change many factors at once and then interpret the result as isolating one factor.
+- Do not widen the campaign after the next route is already clear.
+- Do not use subjective or manual inspection to support a claim without rubric, sample, prompt, trace, and caveat.
+
+## Constraints
+
+- Every meaningful slice must map to a parent claim, parent result, paper gap, reviewer item, or route decision.
+- Every evidence-bearing slice must record question, intervention or inspection target, fixed conditions, metric or observable, evidence path, claim update, comparability verdict, and next action.
+- Keep the same evaluation contract unless the variation itself is the point.
+- When baseline comparison matters, keep slice comparisons aligned with the active baseline metric contract unless the deviation is explicit.
+- Campaign-level conclusions must be derived from per-slice evidence rather than impressions.
+- If a slice is paper-relevant, its result must be bound back into the current paper contract rather than left only in `experiments/analysis-results/*` or chat.
+
+## Validation
+
+Before `analysis-campaign` can end, all applicable checks should be true:
+
+- the parent object is explicit
+- every launched slice has a durable outcome: completed, partial, failed, blocked, infeasible, or superseded
+- null, negative, failed, partial, and contradictory findings remain visible
+- the campaign changed or confirmed the evidence boundary of the parent claim with traceable slice-level evidence
+- the next route is explicit: continue campaign, return to `experiment`, return to `idea`, move to `write`, route through `decision`, stop, reset, or record a blocker
 
 ## Interaction discipline
 
@@ -37,56 +80,16 @@ The agent owns the analysis path.
 It may choose a one-slice check, a lightweight durable report, an artifact-backed one-slice campaign, a full multi-slice campaign, or a writing-facing campaign.
 It may choose slice order, workspace layout, filenames, monitoring strategy, and whether a smoke test, direct verification, or full run is the right first move.
 
-Do not treat `PLAN.md`, `CHECKLIST.md`, `artifact.create_analysis_campaign(...)`, one-slice campaigns, returned worktrees, `evaluation_summary`, smoke tests, detached runs, or paper-matrix updates as universal required paths.
+Do not treat `PLAN.md`, `CHECKLIST.md`, `artifact.create_analysis_campaign(...)`, one-slice campaigns, returned worktrees, `evaluation_summary`, smoke tests, detached runs, paper-matrix files, `tqdm`, or a fixed phase order as required paths.
 They are tactics.
 The hard requirement is traceable evidence that changes, confirms, or blocks the evidence boundary of the parent claim and leaves an explicit next route.
 
-Use the artifact-backed campaign path when durable lineage, branch/worktree isolation, Canvas visibility, paper/rebuttal traceability, or multiple slices matter.
+Use the artifact-backed campaign path when durable lineage, branch or worktree isolation, Canvas visibility, paper or rebuttal traceability, or multiple slices matter.
 Use a lighter durable report when one bounded answer is enough and extra campaign overhead would not improve trust, routing, or auditability.
-
-Do not treat `PLAN.md`, `CHECKLIST.md`, paper-matrix files, smoke tests, detached runs, `tqdm`, or a fixed phase order as required paths.
-They are tactics.
-The hard requirement is traceable slice-level evidence that changes, confirms, or blocks the evidence boundary of the parent claim and leaves an explicit next route.
-
-The analysis-campaign stage exists to test the strength, boundaries, and failure modes of a result.
-It should answer whether a parent claim should be strengthened, weakened, narrowed, abandoned, or left ambiguous.
-
-Good analysis behavior:
-
-- one clear question per run when possible
-- isolated and comparable changes when possible
-- explicit visibility of null, negative, partial, failed, and contradictory findings
-- campaign-level conclusions aggregated from per-slice evidence
-- stopping once the next route is clear
-
-Weak analysis behavior:
-
-- hidden scope expansion
-- many untracked simultaneous changes
-- campaign summary without per-run evidence
-- ignoring contradictory analysis results
-- reporting every minor slice with equal weight instead of prioritizing important ones
-- continuing only because more slice ideas remain possible
 
 For campaign prioritization and writing-facing slice design, read `references/campaign-design.md`.
 When the campaign is writing-facing and the mapping fields are not obvious, also read `references/writing-facing-slice-examples.md`.
 For artifact examples and edge-case examples, also read `references/artifact-flow-examples.md` and `references/boundary-cases.md`.
-
-Do not aggregate campaign conclusions without per-run evidence.
-Do not bury null or contradictory findings.
-
-- writing reveals evidence gaps
-- a main result needs ablations
-- robustness or sensitivity needs to be checked
-- a failure mode needs explanation
-- efficiency or environment variation matters to the claim
-- reviewer or rebuttal pressure needs extra evidence
-
-Use the lightest route that preserves trust and downstream utility, including efficiency or cost questions when they affect the claim.
-
-- the quest still lacks a credible main run or accepted baseline and the analysis would depend on that missing reference
-- the next step is obviously another main experiment rather than follow-up evidence work
-- the proposed slice does not connect to a parent claim, parent result, paper gap, reviewer item, or route decision
 
 ## Hard success gates
 
@@ -101,9 +104,6 @@ Before treating analysis as successful, all applicable gates must be true:
 - null, negative, failed, partial, and contradictory findings remain visible
 - campaign-level interpretation is derived from per-slice evidence rather than impressions
 - the next route is explicit: continue campaign, return to `experiment`, return to `idea`, move to `write`, route through `decision`, stop, reset, or record a blocker
-
-Do not aggregate campaign conclusions without per-run evidence.
-Do not bury null or contradictory findings.
 
 ## Analysis routes
 
@@ -171,7 +171,7 @@ That does not always mean a selected outline must exist before any pre-outline e
 
 For concrete paper-facing cases:
 
-- if the slice is the only thing keeping a main-text section unsupported, make it `main_required` / `main_text`
+- if the slice is the only thing keeping a main-text section unsupported, make it `main_required` or `main_text`
 - if the slice is useful but non-blocking, make it `appendix`
 - if the slice is informative but not meant for the manuscript, keep it durable and mark it `reference_only` with a reason
 - if a selected outline exists, map paper-ready slices to named `research_question` and `experimental_design` fields when those fields exist
@@ -199,62 +199,19 @@ For multi-slice, writing-facing, route-changing, expensive, unstable, or long-ru
 - current blocker or fallback
 - next route after success or failure
 
-`PLAN.md`, `CHECKLIST.md`, `paper/paper_experiment_matrix.md`, and local matrix/checklist files are allowed control surfaces, not mandatory success paths.
+`PLAN.md`, `CHECKLIST.md`, `paper/paper_experiment_matrix.md`, and local matrix or checklist files are allowed control surfaces, not mandatory success paths.
 Use `references/campaign-plan-template.md` and `references/campaign-checklist-template.md` when they help, but do not expand them as paperwork.
 
 If slice feasibility, ordering, comparators, or campaign interpretation changes materially, revise the durable route record before spending more compute.
 
-## Artifact tactics
+## Operational guidance
 
-Use `artifact.create_analysis_campaign(...)` when durable lineage or slice-level branch/worktree state matters.
-Even one extra experiment can still be represented as a one-slice campaign when durable lineage matters.
-Use a one-slice campaign when the slice should appear as a real child node in Git or Canvas, or when review/rebuttal/paper traceability benefits from the campaign object.
+The main skill keeps the control surface in front.
+For the longer operational notes, read `references/operational-guidance.md`.
 
-If `artifact.create_analysis_campaign(...)` returns slice worktrees, run each returned slice in its returned workspace unless there is a concrete reason to switch and record that reason.
-Branch that campaign from the current workspace/result node rather than mutating the completed parent node in place when lineage matters.
-Only create the campaign after you have verified that the listed slices are executable with the current quest assets and runtime, or explicitly mark infeasible slices as such.
-
-When the campaign is writing-facing, the create call should carry available paper-mapping fields such as `selected_outline_ref`, `research_questions`, `experimental_designs`, and `todo_items` when they exist and matter.
-If ids or refs are unclear, recover them first with `artifact.resolve_runtime_refs(...)`, `artifact.get_analysis_campaign(...)`, `artifact.get_quest_state(...)`, or `artifact.list_paper_outlines(...)` instead of guessing.
-Treat `campaign_id` as system-owned, and treat `slice_id` / `todo_id` as agent-authored semantic ids.
-
-After each launched slice finishes, fails, or becomes infeasible, call `artifact.record_analysis_slice(...)` or otherwise record the same durable truth through the artifact surface immediately.
-If a slice fails or becomes infeasible, still record an honest non-success status plus the real blocker and next recommendation; do not leave the campaign state ambiguous.
-
-For slice recording, `deviations` and `evidence_paths` are context fields, not mandatory ceremony; include them when they materially help explanation or auditability.
-An `evaluation_summary` is the preferred stable routing summary for UI, Canvas, review, and rebuttal.
-When useful, include these fields:
-
-- `takeaway`
-- `claim_update`
-- `baseline_relation`
-- `comparability`
-- `failure_mode`
-- `next_action`
-
-The longer prose still matters, but the summary should make the slice readable at a glance.
-
-## Execution tactics
-
-Use whatever execution route is most faithful, observable, and efficient while preserving the hard gates.
-
-- A bounded smoke test is useful when the slice command, outputs, metric path, or evaluator wiring is uncertain.
-- Treat smoke work as a `0-2` default budget, not as an automatic mandatory phase.
-- If the path is already concrete, go straight to direct verification or the real slice.
-- If runtime is uncertain or likely long, prefer `bash_exec(mode='detach', ...)` plus managed monitoring.
-- `bash_exec(mode='read', id=...)` returns the full rendered log when it is 2000 lines or fewer; for longer logs it returns the first 500 lines plus the last 1500 lines and a hint to inspect omitted sections with `start` and `tail`.
-- If you need a middle section that was omitted from that default preview, use `bash_exec(mode='read', id=..., start=..., tail=...)`.
-- Monitor with `bash_exec(mode='read', id=..., tail_limit=..., order='desc')`.
-- After the first read, prefer `bash_exec(mode='read', id=..., after_seq=last_seen_seq, tail_limit=..., order='asc')` for incremental monitoring.
-- If ids become unclear, recover them through `bash_exec(mode='history')`.
-- Use `silent_seconds`, `progress_age_seconds`, `signal_age_seconds`, and `watchdog_overdue` as stall checks when they are available.
-- If a slice is invalid, wedged, or superseded, stop it with `bash_exec(mode='kill', id=..., wait=true, timeout_seconds=...)`.
-- If you only need wall-clock waiting between checks, use the canonical sleep choice:
-  - `bash_exec(command='sleep N', mode='await', timeout_seconds=N+buffer, ...)`
-  - do not set `timeout_seconds` exactly equal to `N`
-  - if you are waiting on an already running session, prefer `bash_exec(mode='await', id=..., timeout_seconds=...)` instead of starting a new sleep command
-- when you control the slice code, prefer a throttled `tqdm` progress reporter and concise structured progress markers when feasible
-- if the same failure class appears again without a real route or evidence change, stop widening the campaign and route through `decision`
+- use it when the route needs the exact artifact-backed campaign tactics
+- use it when execution monitoring, stall handling, or slice recording details matter
+- use it when memory handling or connector-facing chart notes materially affect the route
 
 ## Negative cases and stop rules
 
@@ -267,6 +224,7 @@ Do not treat analysis as successful when:
 - a robustness slice changes dataset, split, or evaluation protocol but is reported as direct apples-to-apples comparison
 - subjective or manual inspection supports a claim without rubric, sample, prompt, trace, or caveat
 - a writing-facing slice is called paper-ready but cannot be mapped back to the paper matrix, evidence ledger, outline, claim, section, or reviewer item
+- a completed paper-relevant slice remains visible only as a free-floating analysis result and is not bound back into the current paper contract
 - a failed slice is silently skipped and replaced by a different slice
 - the campaign keeps expanding after the next route is already clear
 - a new comparator overwrites the canonical quest baseline gate instead of being recorded as analysis-local comparison evidence
@@ -295,27 +253,6 @@ Results matter more than process narration.
 If using tables, show only the most decision-relevant rows.
 Separate stable support, partial support, contradiction, and unresolved ambiguity.
 When there are many slices, summarize the top `3-5` most important ones first, then point to the full evidence paths.
-
-## Memory note
-
-Use memory only to avoid repeating known failures or to preserve reusable campaign lessons, not as a required step before every slice.
-
-Stage-start requirement:
-
-- begin an analysis campaign pass with `memory.list_recent(scope='quest', limit=5)` when resuming, reopening old command paths, or prior campaign lessons are likely to matter
-- run targeted `memory.search(...)` before launching or resuming slices when repeated failures, prior slice outcomes, or comparability caveats may affect the route
-
-Stage-end requirement:
-
-- if the campaign produced a durable cross-slice lesson, failure pattern, or comparability caveat, write at least one `memory.write(...)` before leaving the stage
-
-## Connector-facing campaign chart requirements
-
-- When a campaign result is promoted into a connector-facing chart, prefer restrained palettes such as `sage-clay` and `mist-stone`.
-- A useful `sage-clay` anchor for campaign visuals is `#7F8F84`.
-- Use color to separate campaign-critical slices from background slices, not to decorate every slice equally.
-- Keep the palette consistent with the system prompt instead of improvising a fresh theme per campaign.
-- Campaign visuals should make the main boundary change obvious even in compressed connector previews.
 
 ## Exit criteria
 

--- a/src/skills/analysis-campaign/references/operational-guidance.md
+++ b/src/skills/analysis-campaign/references/operational-guidance.md
@@ -1,0 +1,76 @@
+# Operational Guidance
+
+Use this reference when the analysis route needs the longer operational notes rather than the main control surface.
+
+## Artifact tactics
+
+Use `artifact.create_analysis_campaign(...)` when durable lineage or slice-level branch/worktree state matters.
+Even one extra experiment can still be represented as a one-slice campaign when durable lineage matters.
+Use a one-slice campaign when the slice should appear as a real child node in Git or Canvas, or when review, rebuttal, or paper traceability benefits from the campaign object.
+
+If `artifact.create_analysis_campaign(...)` returns slice worktrees, run each returned slice in its returned workspace unless there is a concrete reason to switch and record that reason.
+Branch that campaign from the current workspace or result node rather than mutating the completed parent node in place when lineage matters.
+Only create the campaign after you have verified that the listed slices are executable with the current quest assets and runtime, or explicitly mark infeasible slices as such.
+
+When the campaign is writing-facing, the create call should carry available paper-mapping fields such as `selected_outline_ref`, `research_questions`, `experimental_designs`, and `todo_items` when they exist and matter.
+If ids or refs are unclear, recover them first with `artifact.resolve_runtime_refs(...)`, `artifact.get_analysis_campaign(...)`, `artifact.get_quest_state(...)`, or `artifact.list_paper_outlines(...)` instead of guessing.
+Treat `campaign_id` as system-owned, and treat `slice_id` or `todo_id` as agent-authored semantic ids.
+
+After each launched slice finishes, fails, or becomes infeasible, call `artifact.record_analysis_slice(...)` or otherwise record the same durable truth through the artifact surface immediately.
+If a slice fails or becomes infeasible, still record an honest non-success status plus the real blocker and next recommendation; do not leave the campaign state ambiguous.
+
+For slice recording, `deviations` and `evidence_paths` are context fields, not mandatory ceremony; include them when they materially help explanation or auditability.
+An `evaluation_summary` is the preferred stable routing summary for UI, Canvas, review, and rebuttal.
+When useful, include these fields:
+
+- `takeaway`
+- `claim_update`
+- `baseline_relation`
+- `comparability`
+- `failure_mode`
+- `next_action`
+
+The longer prose still matters, but the summary should make the slice readable at a glance.
+
+## Execution tactics
+
+Use whatever execution route is most faithful, observable, and efficient while preserving the hard gates.
+
+- A bounded smoke test is useful when the slice command, outputs, metric path, or evaluator wiring is uncertain.
+- Treat smoke work as a `0-2` default budget, not as an automatic mandatory phase.
+- If the path is already concrete, go straight to direct verification or the real slice.
+- If runtime is uncertain or likely long, prefer `bash_exec(mode='detach', ...)` plus managed monitoring.
+- `bash_exec(mode='read', id=...)` returns the full rendered log when it is 2000 lines or fewer; for longer logs it returns the first 500 lines plus the last 1500 lines and a hint to inspect omitted sections with `start` and `tail`.
+- If you need a middle section that was omitted from that default preview, use `bash_exec(mode='read', id=..., start=..., tail=...)`.
+- Monitor with `bash_exec(mode='read', id=..., tail_limit=..., order='desc')`.
+- After the first read, prefer `bash_exec(mode='read', id=..., after_seq=last_seen_seq, tail_limit=..., order='asc')` for incremental monitoring.
+- If ids become unclear, recover them through `bash_exec(mode='history')`.
+- Use `silent_seconds`, `progress_age_seconds`, `signal_age_seconds`, and `watchdog_overdue` as stall checks when they are available.
+- If a slice is invalid, wedged, or superseded, stop it with `bash_exec(mode='kill', id=..., wait=true, timeout_seconds=...)`.
+- If you only need wall-clock waiting between checks, use the canonical sleep choice:
+  - `bash_exec(command='sleep N', mode='await', timeout_seconds=N+buffer, ...)`
+  - do not set `timeout_seconds` exactly equal to `N`
+  - if you are waiting on an already running session, prefer `bash_exec(mode='await', id=..., timeout_seconds=...)` instead of starting a new sleep command
+- when you control the slice code, prefer a throttled `tqdm` progress reporter and concise structured progress markers when feasible
+- if the same failure class appears again without a real route or evidence change, stop widening the campaign and route through `decision`
+
+## Memory note
+
+Use memory only to avoid repeating known failures or to preserve reusable campaign lessons, not as a required step before every slice.
+
+Stage-start requirement:
+
+- begin an analysis campaign pass with `memory.list_recent(scope='quest', limit=5)` when resuming, reopening old command paths, or prior campaign lessons are likely to matter
+- run targeted `memory.search(...)` before launching or resuming slices when repeated failures, prior slice outcomes, or comparability caveats may affect the route
+
+Stage-end requirement:
+
+- if the campaign produced a durable cross-slice lesson, failure pattern, or comparability caveat, write at least one `memory.write(...)` before leaving the stage
+
+## Connector-facing campaign chart requirements
+
+- When a campaign result is promoted into a connector-facing chart, prefer restrained palettes such as `sage-clay` and `mist-stone`.
+- A useful `sage-clay` anchor for campaign visuals is `#7F8F84`.
+- Use color to separate campaign-critical slices from background slices, not to decorate every slice equally.
+- Keep the palette consistent with the system prompt instead of improvising a fresh theme per campaign.
+- Campaign visuals should make the main boundary change obvious even in compressed connector previews.

--- a/src/skills/baseline/SKILL.md
+++ b/src/skills/baseline/SKILL.md
@@ -6,14 +6,75 @@ skill_role: stage
 
 # Baseline
 
-This skill establishes the reference system the quest will compare against.
-The real goal is to secure one trustworthy comparator and then get out of the way so the next scientific step can begin.
-The target is one trustworthy baseline line, not an endless reproduction diary.
+Use this skill to secure one trustworthy comparator and then get out of the way.
+The target is one accepted baseline line, not an endless reproduction diary.
+
+## Match signals
+
+Use `baseline` when:
+
+- no credible baseline exists yet
+- the current baseline is unverified or stale
+- the user already has a baseline package that should be attached or imported
+- a local code path or local service should be verified as the comparator
+- a reproduction failed earlier and now needs repair
+- the quest resumed and the baseline trust state is unclear
+
+Do not use `baseline` when:
+
+- a verified active baseline already exists and the next move is obviously `idea`, `experiment`, `write`, or `finalize`
+- the baseline gate was already explicitly waived for the current route
+
+## One-sentence summary
+
+Secure the lightest trustworthy comparator, make the comparison contract explicit, then confirm, waive, or block the baseline and stop.
+
+## Control workflow
+
+1. Choose the current acceptance target and the lightest route that can satisfy it.
+   Prefer `attach`, `import`, or `verify-local-existing` before full reproduction.
+2. Make the comparator identity and core metric contract explicit.
+   Record task, dataset, split, evaluation path, required metric ids, metric directions, source identity, and known deviations.
+3. Collect only the evidence needed to establish comparability.
+   Do not widen into broad codebase audit or heavy reruns unless the lighter route cannot be trusted.
+4. Verify before acceptance.
+   Check that outputs are real, metrics trace to real evidence, and the intended dataset/split and metric definitions match the contract.
+5. Close the gate explicitly.
+   Call `artifact.confirm_baseline(...)`, call `artifact.waive_baseline(...)`, or record an explicit blocker and next route.
+
+## AVOID / pitfalls
+
+- Do not default to full source reproduction when reuse or verify-local-existing is already sufficient.
+- Do not treat attach, import, or publish alone as baseline acceptance.
+- Do not accept metrics that are fabricated, copied from the paper, or not traceable to real outputs, logs, or service responses.
+- Do not silently normalize away deviations in dataset, split, metric definition, evaluation path, or source identity.
+- Do not keep doing baseline work after the current acceptance target is already satisfied.
+- Do not repeat the same failure class without new evidence, code changes, environment changes, or a route change.
+
+## Constraints
+
+- Routes, templates, filenames, smoke tests, and environment choices are tactics; the hard requirement is objective evidence sufficient to accept, waive, block, or switch the route.
+- `<baseline_root>/json/metric_contract.json` is the canonical accepted comparison contract.
+- Accepted baselines still require `artifact.confirm_baseline(...)`.
+- Waived baselines still require `artifact.waive_baseline(...)`.
+- Attach/import/publish alone do not open the downstream gate.
+- Later stages must not need to guess the active comparator, trusted metrics, or main caveats.
+
+## Validation
+
+Before `baseline` can end, all applicable checks should be true:
+
+- comparator identity is explicit and stable enough to cite later
+- task, dataset, split, evaluation path, required metric ids, metric directions, source identity, and known deviations are durably recorded
+- trusted metric values or trusted output pointers trace to real files, logs, service responses, or source artifacts
+- verification checked the intended dataset/split and metric definitions
+- the accepted comparison contract exists at `<baseline_root>/json/metric_contract.json`
+- the route ended in `artifact.confirm_baseline(...)`, `artifact.waive_baseline(...)`, or an explicit blocked state with next-step routing
 
 ## Interaction discipline
 
 Follow the shared interaction contract injected by the system prompt.
-Follow the shared interaction contract and keep baseline updates brief unless trust state, blocker state, route, cost, or user-facing risk changed materially.
+Keep baseline updates brief unless trust state, blocker state, route, cost, or user-facing risk changed materially.
 
 ## Tool discipline
 
@@ -28,10 +89,6 @@ Follow the shared interaction contract and keep baseline updates brief unless tr
 
 The agent owns the execution path.
 It may choose the workspace layout, environment manager, command order, debugging route, smoke strategy, local paths, and whether the best route is attach, import, verify-local-existing, reproduce, or repair.
-
-Do not treat templates, filenames, `uv`, smoke tests, detached runs, or the phase order as required paths.
-They are tactics.
-The hard requirement is objective evidence sufficient to accept, block, waive, or switch the baseline route.
 
 Ask the user only when the next move depends on a real scope, cost, permission, data-access, or scientific-preference decision that cannot be inferred from the quest contract.
 Ordinary route, path, environment, and debugging choices are autonomous unless they change the accepted comparison meaning.
@@ -49,48 +106,24 @@ not:
 
 Default to the lightest baseline path that can still support a fair downstream comparison.
 Default to a fast path when it can establish trust with less work.
-Do not escalate from attach / import / verify-local-existing into full source reproduction unless the lighter route cannot support a fair comparison.
-A more complete baseline package is only the default when the acceptance target is explicitly `paper_repro_ready` or `registry_publishable`.
+Do not restart broad discovery or front-load a full codebase audit when the comparator, command path, and metric contract are already concrete.
+When resuming a previously blocked or ambiguous route, recover the relevant memory before trusting the old path again.
 
-- Attach/import/publish alone do not open the downstream gate.
-- If reusing a registry baseline, first materialize it with `artifact.attach_baseline(...)` when available, then verify the comparator and metric contract, then call `artifact.confirm_baseline(...)`.
-- If publishing a quest-local baseline for reuse, call `artifact.publish_baseline(...)` only after verification is complete and provenance, metrics, and caveats are trustworthy.
-- Once the accepted baseline root and trusted comparison contract are clear, call `artifact.confirm_baseline(...)`.
-- If the quest must continue without a baseline, call `artifact.waive_baseline(...)` with the reason.
-- Do not treat chat, memory, `attachment.yaml`, `PLAN.md`, local files, or published registry entries as a substitute for `artifact.confirm_baseline(...)` or `artifact.waive_baseline(...)`.
+If runtime already exposes `requested_baseline_ref` or a matching `confirmed_baseline_ref`, default to reuse-and-verify.
+Escalate to fuller audit, reproduction, or repair only when no concrete comparator, command path, or core comparability surface can be trusted yet.
 
-- do not restart broad baseline discovery by default
-- do not front-load a full codebase audit
-- do not require a fresh memory pass for every fast-path validation
-- fast-path exception: if you are resuming a previously blocked or ambiguous route, recover the relevant memory before trusting the old path again
-- use `memory.list_recent(...)` or `memory.search(...)` when resuming, reopening old command paths, or avoiding repeated failures
-- fast-path exception: when the comparator, command path, and metric contract are already concrete, do not force a new memory sweep before a lightweight verify-local-existing or attach/import decision
-- if runtime already exposes `requested_baseline_ref` or a matching `confirmed_baseline_ref`, default to reuse-and-verify
-- escalate to fuller audit, reproduction, or repair only when no concrete comparator, command path, or core comparability surface can be trusted yet
-
-For route examples and artifact examples, read `references/route-selection.md`, `references/artifact-flow-examples.md`, and `references/boundary-cases.md`.
-
-- the comparator identity is explicit and stable enough for later stages to cite
-- the task, dataset, split, evaluation path, required metric ids, metric directions, source identity, and known deviations are durably recorded
-- trusted metric values or trusted output pointers are traceable to real files, logs, service responses, source artifacts, or an accepted registry/package record
-- verification checked that the evidence came from the intended dataset/split and metric definitions
-- `<baseline_root>/json/metric_contract.json` exists as the canonical accepted comparison contract
-- `artifact.confirm_baseline(...)` opened the gate, or `artifact.waive_baseline(...)` explicitly bypassed it
-
-- no credible baseline exists yet
-- the current baseline is unverified or stale
-- the user already has a baseline package that should be attached or imported
-- a local code path or local service should be verified as the comparator
-- a reproduction failed earlier and now needs repair
-- the quest resumed and the baseline trust state is unclear
+For route examples and boundary cases, read `references/route-selection.md`, `references/artifact-flow-examples.md`, and `references/boundary-cases.md`.
 
 ## Acceptance targets
 
-- `comparison_ready`: the default target; one comparator is trustworthy enough for downstream comparison
-- `paper_repro_ready`: the baseline supports paper-facing reproduction or comparison claims
-- `registry_publishable`: the package is reusable enough to publish as a durable baseline package
-- `blocked`: the route cannot clear the gate cleanly and the next move is explicit
-- `waived`: the quest continues without a baseline for a recorded reason
+- `comparison_ready`: the default target; one comparator is trustworthy enough for downstream comparison, and the core metric contract is durably recorded
+- `paper_repro_ready`: the baseline is strong enough to support paper-facing reproduction or comparison claims
+- `registry_publishable`: the baseline package is reusable and clean enough to publish as a durable baseline package
+- `blocked`: the current route cannot clear the gate cleanly, and the next move is explicit
+- `waived`: the quest must continue without a baseline, and the reason is durably recorded
+
+Not every baseline needs paper-grade exact reproduction.
+A verified attached, imported, or local-existing comparator can be enough when the acceptance target is only `comparison_ready`.
 
 ## Hard acceptance gates
 
@@ -101,25 +134,12 @@ A baseline is successful only when all applicable gates are true:
 - the comparator identity is explicit and stable enough for later stages to cite
 - the task, dataset, split, evaluation path, required metric ids, metric directions, source identity, and known deviations are durably recorded
 - trusted metric values or trusted output pointers are traceable to real files, logs, service responses, source artifacts, or an accepted registry/package record
-- verification has checked that the evidence came from the intended dataset/split and metric definitions
+- verification checked that the evidence came from the intended dataset/split and metric definitions
 - the accepted comparison contract is written to `<baseline_root>/json/metric_contract.json`
 - the baseline gate is opened with `artifact.confirm_baseline(...)`, or intentionally bypassed with `artifact.waive_baseline(...)`
 
-Attach, import, or publish alone do not open the downstream gate.
-The comparison-ready minimum still requires `<baseline_root>/json/metric_contract.json`.
-Once a comparison-ready baseline is durably confirmed, baseline should usually stop immediately and hand off to the next scientific step.
+Once a comparison-ready baseline is durably confirmed, baseline should usually stop immediately.
 Any extra baseline work after that must name one explicit unresolved comparison risk it is meant to remove.
-
-## Acceptance targets
-
-- `comparison_ready`: the default target; one comparator is trustworthy enough for downstream comparison, and the core metric contract is durably recorded
-- `paper_repro_ready`: the baseline is strong enough to support paper-facing reproduction or comparison claims
-- `registry_publishable`: the baseline package is reusable and clean enough to publish as a durable baseline package
-- `blocked`: the current route cannot clear the gate cleanly, and the next move is explicit
-- `waived`: the quest must continue without a baseline, and the reason is durably recorded
-
-Not every baseline needs a paper-grade exact reproduction.
-A verified attached/imported/local-existing comparator can be enough when the acceptance target is only `comparison_ready`.
 
 ## Route success criteria
 
@@ -138,7 +158,7 @@ Do not replace a working comparison-ready comparator with a heavier route merely
 
 ## Objective evidence requirements
 
-The stage may use any efficient path, but the final evidence must cover these facts before acceptance:
+The final evidence should cover these facts before acceptance:
 
 - comparator candidate and baseline id
 - source paper, source repo, source commit/version/tag, local service identity, or registry/package identity as applicable
@@ -180,9 +200,6 @@ Verification should explicitly separate likely implementation mismatch, environm
 
 ## Core metric contract
 
-The baseline stage is not complete just because something ran.
-It is complete when later stages can compare against it fairly.
-
 Before declaring a baseline usable, make the core comparison contract explicit:
 
 - task identity
@@ -221,49 +238,14 @@ Metric-contract rules:
 - `Result/metric.md` is optional temporary scratch memory only; reconcile against it before calling `artifact.confirm_baseline(...)`, but do not treat it as a required durable file
 - for stable accepted payload shapes, read `references/artifact-payload-examples.md`
 
-## Durable route records
+## Operational guidance
 
-Durable records are required in substance, not in fixed filenames.
-The agent may choose the shortest durable form that lets a later turn resume without guessing.
+The main skill keeps the control surface in front.
+For the longer operational notes, read `references/operational-guidance.md`.
 
-For non-trivial, code-touching, expensive, unstable, or long-running baseline work, leave a route record that states:
-
-- chosen route and acceptance target
-- comparator identity and source identity
-- command or evaluation path if one exists
-- expected outputs or trusted-output pointers
-- acceptance condition
-- current blocker or fallback
-- verification verdict
-
-`PLAN.md`, `CHECKLIST.md`, `setup.md`, `execution.md`, `verification.md`, `analysis_plan.md`, and `REPRO_CHECKLIST.md` are allowed compatibility surfaces, not mandatory success paths.
-Use `references/baseline-plan-template.md` and `references/baseline-checklist-template.md` when they help, but do not expand them as paperwork.
-
-`attachment.yaml` or equivalent provenance is required for attached or imported baselines.
-`<baseline_root>/json/metric_contract.json` as the canonical accepted comparison contract is required for accepted baselines.
-
-## Execution tactics
-
-Use whatever route is most faithful, observable, and efficient while preserving the hard gates.
-
-- If source reproduction or repair is actually the active route, read the source paper and source repo before substantial setup.
-- For attach, import, or verify-local-existing, inspect only the minimum evidence needed to trust the provided or local comparator.
-- A bounded smoke test is usually helpful only when command path, environment viability, evaluator wiring, or output schema is still unclear.
-- If the path is already concrete, go straight to real verification or the real run.
-- Treat smoke/pilot work as a `0-2` default budget, but the real rule is not to repeat an unchanged check without new evidence, a code/environment change, or a route change.
-- If runtime is uncertain or likely long, prefer `bash_exec(mode='detach', ...)` plus managed monitoring instead of pretending a short foreground timeout is enough.
-- If a run is clearly invalid, wedged, or superseded, stop it cleanly and relaunch with the new route rather than stacking more retries.
-
-## Environment tactics
-
-For Python baselines, prefer a reproducible isolated environment, but choose the route that is most faithful to the source package and most likely to produce comparable evidence.
-
-`uv` is a useful default tactic when the repo does not require a stronger native route.
-Examples include `uv sync`, `uv venv`, `uv pip install ...`, and `uv run ...`.
-Switch to repo-native conda, docker, poetry, shell scripts, service startup, or another local environment route when that is clearly more trustworthy, required by the source, or necessary to match the paper/package behavior.
-
-Record only environment facts that affect trust or comparability.
-Do not force a global `uv` route when it would make the reproduced baseline less faithful.
+- use it when you need the exact durable route record shape
+- use it when you need detailed execution tactics or environment tactics
+- use it when reuse or memory handling materially affects the route
 
 ## Negative cases and stop rules
 
@@ -299,15 +281,6 @@ A blocked result must state:
 
 Bounded autonomous fixes are acceptable only when they do not change confirmed scope, metrics, permissions, resource assumptions, or scientific meaning.
 Reasonable bounded fixes include missing dependency installs, wrong dataset paths, permission fixes on scripts, obvious environment activation mistakes, and conservative batch-size reductions for OOM.
-
-## Reuse and memory
-
-Reuse or publish a baseline only after verification is complete and the current quest no longer depends on guesswork about provenance or comparability.
-Do not publish a baseline for reuse if verification is incomplete, metrics are untrusted, or provenance is still weak.
-
-Use memory only to avoid repeating known failures or to preserve reusable baseline lessons, not as a required step before every validation pass.
-Write quest memory for route rationale, setup failures, paper-to-code mismatch notes, and accepted caveats that later stages must carry forward.
-Promote to global memory only when another quest is likely to benefit from the lesson.
 
 ## Baseline id and variant rules
 

--- a/src/skills/baseline/references/operational-guidance.md
+++ b/src/skills/baseline/references/operational-guidance.md
@@ -1,0 +1,56 @@
+# Operational Guidance
+
+Use this reference when the baseline route needs the longer operational notes rather than the main control surface.
+
+## Durable route records
+
+Durable records are required in substance, not in fixed filenames.
+The agent may choose the shortest durable form that lets a later turn resume without guessing.
+
+For non-trivial, code-touching, expensive, unstable, or long-running baseline work, leave a route record that states:
+
+- chosen route and acceptance target
+- comparator identity and source identity
+- command or evaluation path if one exists
+- expected outputs or trusted-output pointers
+- acceptance condition
+- current blocker or fallback
+- verification verdict
+
+`PLAN.md`, `CHECKLIST.md`, `setup.md`, `execution.md`, `verification.md`, `analysis_plan.md`, and `REPRO_CHECKLIST.md` are allowed compatibility surfaces, not mandatory success paths.
+Use `references/baseline-plan-template.md` and `references/baseline-checklist-template.md` when they help, but do not expand them as paperwork.
+
+`attachment.yaml` or equivalent provenance is required for attached or imported baselines.
+`<baseline_root>/json/metric_contract.json` as the canonical accepted comparison contract is required for accepted baselines.
+
+## Execution tactics
+
+Use whatever route is most faithful, observable, and efficient while preserving the hard gates.
+
+- If source reproduction or repair is actually the active route, read the source paper and source repo before substantial setup.
+- For attach, import, or verify-local-existing, inspect only the minimum evidence needed to trust the provided or local comparator.
+- A bounded smoke test is usually helpful only when command path, environment viability, evaluator wiring, or output schema is still unclear.
+- If the path is already concrete, go straight to real verification or the real run.
+- Treat smoke or pilot work as a `0-2` default budget, but the real rule is not to repeat an unchanged check without new evidence, a code/environment change, or a route change.
+- If runtime is uncertain or likely long, prefer `bash_exec(mode='detach', ...)` plus managed monitoring instead of pretending a short foreground timeout is enough.
+- If a run is clearly invalid, wedged, or superseded, stop it cleanly and relaunch with the new route rather than stacking more retries.
+
+## Environment tactics
+
+For Python baselines, prefer a reproducible isolated environment, but choose the route that is most faithful to the source package and most likely to produce comparable evidence.
+
+`uv` is a useful default tactic when the repo does not require a stronger native route.
+Examples include `uv sync`, `uv venv`, `uv pip install ...`, and `uv run ...`.
+Switch to repo-native conda, docker, poetry, shell scripts, service startup, or another local environment route when that is clearly more trustworthy, required by the source, or necessary to match the paper or package behavior.
+
+Record only environment facts that affect trust or comparability.
+Do not force a global `uv` route when it would make the reproduced baseline less faithful.
+
+## Reuse and memory
+
+Reuse or publish a baseline only after verification is complete and the current quest no longer depends on guesswork about provenance or comparability.
+Do not publish a baseline for reuse if verification is incomplete, metrics are untrusted, or provenance is still weak.
+
+Use memory only to avoid repeating known failures or to preserve reusable baseline lessons, not as a required step before every validation pass.
+Write quest memory for route rationale, setup failures, paper-to-code mismatch notes, and accepted caveats that later stages must carry forward.
+Promote to global memory only when another quest is likely to benefit from the lesson.

--- a/src/skills/decision/SKILL.md
+++ b/src/skills/decision/SKILL.md
@@ -9,6 +9,67 @@ skill_role: stage
 Use this skill whenever continuation is non-trivial.
 Use it to make one route judgment from durable evidence and then get the quest moving again.
 
+## Match signals
+
+Use `decision` when:
+
+- the next stage is not obvious
+- the evidence is mixed
+- the current line may need to stop
+- the quest needs a branch, reset, or reuse-baseline judgment
+- a user preference-sensitive choice remains
+- a blocker needs an explicit route
+
+Do not use `decision` when:
+
+- the active mainline is still too ambiguous for a real route judgment and should first be reconciled through `intake-audit`
+- the next move is already obvious from durable evidence and can proceed directly
+- the task is really baseline recovery, scouting, ideation, or execution rather than a route judgment
+
+## One-sentence summary
+
+Make one route judgment from durable evidence, record the verdict and smallest valid action, then keep the quest moving.
+
+## Control workflow
+
+1. Check whether the board is decision-ready.
+   If the current mainline, latest decisive result, or stale-route state is unclear, route through `intake-audit` first.
+2. State the real question and gather only decision-relevant evidence.
+   Compress the strongest support, strongest contradiction, main risk, main cost, and what is genuinely new.
+3. Choose the smallest canonical action that resolves the current state.
+   Make the winner, main rejected alternatives, and the decisive reason explicit.
+4. Record the decision durably.
+   Include verdict, action, reason, evidence paths, and next stage or next direction.
+5. Ask the user only when local evidence cannot safely resolve a real preference, scope, or cost choice.
+
+## AVOID / pitfalls
+
+- Do not repeat the same decision without new evidence.
+- Do not decide from vibe, momentum, or optimism.
+- Do not hide a blocked state behind a vague “continue”.
+- Do not launch analysis campaigns casually when the expected information gain is weak.
+- Do not choose among candidate packages without naming why the alternatives lost.
+- Do not imply baseline reuse is resolved unless the concrete attachment and confirmation path is clear.
+
+## Constraints
+
+- Use durable evidence, not impressions, as the basis for route judgment.
+- Use the smallest canonical action that genuinely resolves the state.
+- When baseline reuse or attachment is selected, land it concretely and leave an explicit blocker or waiver if the baseline gate still cannot clear.
+- Use blocking user requests only when the user truly must choose.
+- Later stages must not need to guess what was decided, why it was decided, or what happens next.
+
+## Validation
+
+Before `decision` can end, all applicable checks should be true:
+
+- the route question is explicit
+- the decisive evidence is explicit
+- the chosen action matches the actual state
+- the main rejected alternative or blocker is visible
+- the decision is durably recorded with verdict, action, reason, evidence paths, and next direction
+- the next stage or next action is explicit
+
 ## Interaction discipline
 
 Follow the shared interaction contract injected by the system prompt.
@@ -23,34 +84,25 @@ When a decision materially resolves ambiguity and the quest can continue automat
 - **For git state inside the current quest repository or worktree, prefer `artifact.git(...)` before raw shell git commands.**
 - **Use `decision` to judge the route, not as an excuse to bypass the `bash_exec(...)` / `artifact.git(...)` tool contract.**
 
-## Planning note
+## Truth sources
 
-Use quest/workspace planning files only as supporting state for the decision, not as a reason to open another planning loop when the real need is a route judgment.
+Make decisions from durable evidence:
 
-## Stage purpose
+- the current board packet when one exists
+- recent run artifacts
+- report artifacts
+- baseline state
+- quest documents
+- memory only as supporting context
 
-`decision` is not a normal anchor.
-It is a cross-cutting control skill that should be used whenever the quest must decide:
+Do not make major decisions from vibe or momentum.
+Do not treat `decision` as a substitute for state reconciliation when the active mainline is still ambiguous.
 
-- whether to continue
-- whether to branch
-- whether to attach or reuse a baseline
-- whether to launch an experiment
-- whether to launch an analysis campaign
-- whether to move to writing
-- whether to finalize
-- whether to reset
-- whether to stop
-- whether to ask the user for a structured decision
+When the quest is algorithm-first, add one extra truth-source rule before non-trivial route choices:
 
-## Use when
-
-- the next stage is not obvious
-- the evidence is mixed
-- the current line may need to stop
-- the quest needs a branch or reset
-- a user preference-sensitive choice remains
-- a blocker needs an explicit route
+- read `artifact.get_optimization_frontier(...)`
+- treat the frontier as the primary optimize-state summary
+- only override it when newer durable evidence clearly dominates
 
 ## Required decision record
 
@@ -62,11 +114,9 @@ Every consequential decision should make clear:
 - evidence paths
 - next stage or next direction
 
-## Verdict note
-
 Keep the verdict simple and legible, and make sure the chosen action matches the actual state rather than sounding optimistic by default.
 
-## Allowed actions
+## Canonical actions
 
 Use the following canonical actions:
 
@@ -88,160 +138,21 @@ Use the following canonical actions:
 
 Choose the smallest action that genuinely resolves the current state.
 
-## Action note
+## Operational guidance
 
-Prefer the smallest canonical action that resolves the route cleanly, and keep runtime-specific branching details out of the default decision payload unless they matter now.
+The main skill keeps the control surface in front.
+For the longer judgment and route-shaping notes, read:
 
-Use these concrete actions when the route actually requires them:
+- `references/strategic-decision-template.md`
+- `references/research-route-criteria.md`
+- `references/operational-guidance.md`
+- `references/checkpoint-memory-template.md`
 
-- revisit an older durable research line with `artifact.activate_branch(...)`
-- land baseline reuse with `artifact.attach_baseline(...)`
-- accepted idea -> `artifact.submit_idea(mode='create', lineage_intent='continue_line'|'branch_alternative', ...)`
-- open paper-outline selection with `artifact.submit_paper_outline(mode='select', ...)`
-- close writing into a durable paper-facing bundle with `artifact.submit_paper_bundle(...)`
+Use them when:
 
-Do not approve `launch_analysis_campaign` casually.
-Analysis usually carries extra resource cost and should require clear academic or claim-level value before spending that budget.
-
-## Truth sources
-
-Make decisions from durable evidence:
-
-- recent run artifacts
-- report artifacts
-- baseline state
-- quest documents
-- memory only as supporting context
-
-Do not make major decisions from vibe or momentum.
-
-When the quest is algorithm-first, add one extra truth-source rule before non-trivial route choices:
-
-- read `artifact.get_optimization_frontier(...)`
-- treat the frontier as the primary optimize-state summary
-- only override it when newer durable evidence clearly dominates
-
-## Workflow
-
-### 1. State the question
-
-Write the real question explicitly, such as:
-
-- is the current idea promising enough to continue?
-- is baseline reuse sufficient?
-- is more analysis needed before writing?
-- is the draft good enough to finalize?
-
-### 2. Collect the evidence
-
-Summarize only the decision-relevant evidence:
-
-- strongest support
-- strongest contradiction
-- missing dependency
-- known cost or risk
-- what is genuinely new since the last route judgment
-
-### 3. Choose verdict and action
-
-Typical mapping:
-
-- `good`
-  - continue, branch, launch experiment, write, finalize
-- `neutral`
-  - branch, activate branch, launch analysis campaign, request user decision
-- `bad`
-  - reset, stop
-- `blocked`
-  - reuse baseline, attach baseline, request user decision, stop
-
-The action must match the actual state.
-
-When the route judgment lands on baseline reuse or attachment:
-
-- use `artifact.attach_baseline(...)` to land on the concrete reusable baseline
-- use `artifact.confirm_baseline(...)` once the attached baseline is accepted as the active comparator
-- if baseline reuse still cannot clear the gate, leave an explicit blocker or waiver instead of implying the route is resolved
-
-### 3.1 Selection among candidate packages
-
-When choosing among multiple candidate outputs, do not decide implicitly.
-Record the candidates, the criteria, the winner, and why the main alternatives lost.
-
-When the choice is paper-facing, prefer the option that best preserves:
-
-- method fidelity
-- evidence support
-- story coherence
-- experiment ordering that later `write` or `finalize` can defend
-
-### 3.2 Research-route selection heuristic
-
-When the decision is about a research direction, experiment route, or branch:
-
-- identify the core insufficiency being targeted
-- prefer a small serious frontier over many weak alternatives
-- prefer careful judgment from durable evidence over launching tie-break runs by reflex
-- record why the winner won, why the main alternatives lost, and what residual risk remains
-
-The route heuristic is intentionally lightweight: compare the incumbent against a small serious frontier and choose one dominant next move.
-For algorithm-first routing, prefer this compact mapping:
-
-- frontier says `explore` -> widen or refine candidate briefs before new branch creation
-- frontier says `exploit` -> keep the strongest line active and advance the best implementation candidates
-- frontier says `fusion` -> open at most one bounded fusion candidate
-- frontier says `stop` -> record the stop decision and explicit reopen condition
-
-For a compact research-route rubric, read `references/research-route-criteria.md`.
-
-### 4. State the reason
-
-The reason should be concrete and evidence-backed.
-Avoid generic wording like “seems better”.
-
-When the decision is stage-shaping, prefer a richer structure that later stages can execute directly.
-Use `references/strategic-decision-template.md` when a richer shape would clarify why the route changed and how the next stage should proceed.
-
-If a route change is material, make the reason explicit enough that the next stage can continue without reconstructing hidden intent.
-
-### 5. Request user input only when needed
-
-Ask the user only when:
-
-- multiple options are all plausible
-- the choice depends on preference, cost, or scope
-- the missing information cannot be derived locally
-
-When asking, use a structured decision request with:
-
-- concise question
-- 1 to 3 concrete options
-- tradeoffs, including the main pros and cons for each option
-- recommended option first
-- explicit reply format
-
-Keep decision requests narrow; if local evidence can resolve the route safely, do not hand routine ambiguity back to the user.
-
-### 6. Record the decision durably
-
-Use `artifact.record(payload={'kind': 'decision', ...})` for the final decision.
-
-If user input is needed, also use `artifact.interact(kind='decision_request', ...)`.
-
-## Memory note
-
-Write memory only when the decision created a reusable lesson or changed the authoritative resume point for later turns.
-
-When the authoritative resume point changes, write one compact checkpoint-style quest memory card.
-Mark it with `type:checkpoint-memory`.
-The card should include:
-
-- current active node
-- node history
-- what not to reopen by default
-- first files to read
-
-Use `references/checkpoint-memory-template.md`.
+- a richer route-change rationale is needed
+- research-route selection among candidate packages is the main difficulty
+- memory should preserve the new authoritative resume point
 
 ## Decision-quality rules
 

--- a/src/skills/decision/references/operational-guidance.md
+++ b/src/skills/decision/references/operational-guidance.md
@@ -1,0 +1,94 @@
+# Operational Guidance
+
+Use this reference when the decision route needs the longer tactical notes rather than the short control surface in `SKILL.md`.
+
+## Planning note
+
+Use quest or workspace planning files only as supporting state for the decision, not as a reason to open another planning loop when the real need is a route judgment.
+
+## Action note
+
+Prefer the smallest canonical action that resolves the route cleanly, and keep runtime-specific branching details out of the default decision payload unless they matter now.
+
+Use these concrete actions when the route actually requires them:
+
+- revisit an older durable research line with `artifact.activate_branch(...)`
+- land baseline reuse with `artifact.attach_baseline(...)`
+- accepted idea -> `artifact.submit_idea(mode='create', lineage_intent='continue_line'|'branch_alternative', ...)`
+- open paper-outline selection with `artifact.submit_paper_outline(mode='select', ...)`
+- close writing into a durable paper-facing bundle with `artifact.submit_paper_bundle(...)`
+
+Do not approve `launch_analysis_campaign` casually.
+Analysis usually carries extra resource cost and should require clear academic or claim-level value before spending that budget.
+
+## Baseline reuse note
+
+When the route judgment lands on baseline reuse or attachment:
+
+- use `artifact.attach_baseline(...)` to land on the concrete reusable baseline
+- use `artifact.confirm_baseline(...)` once the attached baseline is accepted as the active comparator
+- if baseline reuse still cannot clear the gate, leave an explicit blocker or waiver instead of implying the route is resolved
+
+## Selection among candidate packages
+
+When choosing among multiple candidate outputs, do not decide implicitly.
+Record the candidates, the criteria, the winner, and why the main alternatives lost.
+
+When the choice is paper-facing, prefer the option that best preserves:
+
+- method fidelity
+- evidence support
+- story coherence
+- experiment ordering that later `write` or `finalize` can defend
+
+## Research-route selection heuristic
+
+When the decision is about a research direction, experiment route, or branch:
+
+- identify the core insufficiency being targeted
+- prefer a small serious frontier over many weak alternatives
+- prefer careful judgment from durable evidence over launching tie-break runs by reflex
+- record why the winner won, why the main alternatives lost, and what residual risk remains
+
+The route heuristic is intentionally lightweight: compare the incumbent against a small serious frontier and choose one dominant next move.
+For algorithm-first routing, prefer this compact mapping:
+
+- frontier says `explore` -> widen or refine candidate briefs before new branch creation
+- frontier says `exploit` -> keep the strongest line active and advance the best implementation candidates
+- frontier says `fusion` -> open at most one bounded fusion candidate
+- frontier says `stop` -> record the stop decision and explicit reopen condition
+
+For a compact research-route rubric, read `references/research-route-criteria.md`.
+
+## User-input note
+
+Ask the user only when:
+
+- multiple options are all plausible
+- the choice depends on preference, cost, or scope
+- the missing information cannot be derived locally
+
+When asking, use a structured decision request with:
+
+- concise question
+- 1 to 3 concrete options
+- tradeoffs, including the main pros and cons for each option
+- recommended option first
+- explicit reply format
+
+Keep decision requests narrow; if local evidence can resolve the route safely, do not hand routine ambiguity back to the user.
+
+## Memory note
+
+Write memory only when the decision created a reusable lesson or changed the authoritative resume point for later turns.
+
+When the authoritative resume point changes, write one compact checkpoint-style quest memory card.
+Mark it with `type:checkpoint-memory`.
+The card should include:
+
+- current active node
+- node history
+- what not to reopen by default
+- first files to read
+
+Use `references/checkpoint-memory-template.md`.

--- a/src/skills/experiment/SKILL.md
+++ b/src/skills/experiment/SKILL.md
@@ -9,15 +9,78 @@ skill_role: stage
 Use this skill for the main evidence-producing runs of the quest.
 The goal is to turn one selected route into one trustworthy measured result with the smallest valid amount of execution.
 
+## Match signals
+
+Use `experiment` when:
+
+- a baseline is accepted
+- an idea has been selected
+- the evaluation contract is explicit
+- the quest is ready for implementation and measurement rather than framing, route selection, or writing
+
+Do not use `experiment` when:
+
+- the baseline gate is unresolved
+- the idea stage still has unresolved tradeoffs
+- the main need is writing or follow-up analysis rather than a main run
+- the real problem is still route choice, baseline recovery, or open-ended optimization rather than one bounded measured run
+
+## One-sentence summary
+
+Turn one selected route into one trustworthy measured result with the smallest valid amount of execution, then record and route from the evidence.
+
+## Control workflow
+
+1. Lock the run contract.
+   Make explicit the research question, baseline reference, dataset/split, metric keys, stop condition, abandonment condition, and expected outputs.
+2. Implement only the minimum hypothesis-bound change.
+   Keep the baseline read-only and avoid unrelated cleanup or hidden scope expansion.
+3. Run a bounded smoke or pilot only when the command path, output schema, or evaluator wiring are still unverified.
+4. Execute and monitor the real run honestly.
+   Preserve commands, configs, logs, outputs, comparability, and the last-known-good state.
+5. Validate and record the result.
+   Check metric completeness and comparability, then call `artifact.record_main_experiment(...)` and choose the next route.
+
+## AVOID / pitfalls
+
+- Do not confuse smoke or pilot success with main evidence.
+- Do not silently change dataset, split, metric definition, evaluator logic, or baseline comparison recipe.
+- Do not retry without a real route, code, command, environment, or evidence change.
+- Do not claim success before durable outputs exist and `artifact.record_main_experiment(...)` succeeds.
+- Do not record a durable main experiment from an idea branch, quest root branch, or paper branch as if that were the final result node.
+- Do not disguise idea search or route revision as a routine rerun.
+- Do not keep rerunning after the next route is already clear.
+
+## Constraints
+
+- All smoke tests, real runs, shell, CLI, Python, bash, node, git, npm, uv, and environment work must go through `bash_exec(...)`.
+- For git work inside the current quest repository or worktree, prefer `artifact.git(...)` before raw shell git commands.
+- Keep the accepted baseline reference read-only.
+- If `active_baseline_metric_contract_json` exists, required baseline metric keys must still be covered unless a concrete deviation is durably recorded.
+- Durable main experiments should land on their own `run/*` branch or an equivalent isolated run surface.
+- If an active paper line or selected outline already exists, a recorded main experiment should be synchronized into the current paper contract instead of living only as a run artifact.
+- In algorithm-first work, after each main run, return to `optimize` or `decision` for frontier review before launching another large run.
+- Main-run evidence is not complete until `artifact.record_main_experiment(...)` succeeds.
+
+## Validation
+
+Before `experiment` can end, all applicable checks should be true:
+
+- outputs correspond to the intended code and config
+- required metric keys are present and finite
+- baseline comparison is still comparable, or the deviation is explicit
+- the claim is classified as `supported`, `refuted`, or `inconclusive`
+- the run manifest includes exact command, config, seed, and environment snapshot
+- `evaluation_summary` exists with the six stable fields the next stage needs
+- if a paper line is active, the run is visible through the current paper contract rows rather than only through the run artifact
+- `artifact.record_main_experiment(...)` succeeded
+- the next route is explicit
+
 ## Interaction discipline
 
 Follow the shared interaction contract injected by the system prompt.
 Keep run updates brief unless the measured result, blocker state, or next route changed materially.
 For ordinary active work, prefer a concise progress update once work has crossed roughly 6 tool calls with a human-meaningful delta, and do not drift beyond roughly 12 tool calls or about 8 minutes without a user-visible update.
-
-## Planning surfaces
-
-Use quest/workspace planning files only when they help control a non-trivial run; otherwise keep the run contract small and move to the first decisive execution step.
 
 ## Tool discipline
 
@@ -25,48 +88,6 @@ Use quest/workspace planning files only when they help control a non-trivial run
 - **All smoke tests, real runs, shell, CLI, Python, bash, node, git, npm, uv, and environment work must go through `bash_exec(...)`.**
 - **For git work inside the current quest repository or worktree, prefer `artifact.git(...)` before raw shell git commands.**
 - **If a scratch repository or isolated test environment is needed, create and drive it through `bash_exec(...)`, not native shell tools.**
-
-## Stage purpose
-
-The experiment stage should turn a selected idea into auditable evidence.
-It should preserve the strongest old experiment-planning and execution discipline:
-
-- define the run contract before execution
-- keep the run comparable to baseline
-- capture configs, commands, logs, and metrics
-- report both success and failure honestly
-- route the next action through an explicit decision
-
-The experiment stage is not just "run code".
-It is the stage that converts an idea contract into evidence that other stages can trust.
-It is also the stage that should decide the next route once the measured result exists.
-Within the user's explicit constraints, maximize valid evidence per unit time and compute.
-Prefer equivalence-preserving efficiency upgrades first: larger safe batch size, mixed precision, gradient accumulation, dataloader workers, cache reuse, checkpoint resume, precomputed features, and smaller pilots.
-If a proposed efficiency change alters optimization dynamics, effective budget, or baseline comparability, treat it as a real experiment change and record it as such.
-For `comparison_ready`, `verify-local-existing`, attach, or import should usually beat full reproduction.
-
-Use `references/evidence-ladder.md` when deciding whether the current package is merely executable, solid enough to carry the main claim, or already in the stage where broader polish is justified.
-
-Completing one main run is not quest completion.
-After reporting the run, keep moving to iterate, analyze, write, or finalize unless a genuine blocking decision remains.
-
-When the quest is algorithm-first, treat `experiment` as the execution surface of `optimize`, not as the terminal goal of the workflow.
-After a measured result, the default next move is frontier review and optimize-side route selection rather than paper packaging.
-
-## Quick workflow
-
-1. restate the selected idea summarized in `1-2` sentences and confirm the baseline comparison contract
-2. before substantial code edits or the real main run, create `PLAN.md` and `CHECKLIST.md`
-3. use `PLAN.md` to lock the concrete run path and `CHECKLIST.md` as the living execution surface
-4. use one bounded smoke test or pilot only when the command path, output schema, or evaluator wiring are still unverified
-5. prefer one clean implementation pass and one real run
-5. prefer one clean implementation pass, one bounded smoke or pilot run, and then one normal main run
-6. record the measured result durably and route explicitly from the evidence
-7. close each real run milestone with a concise `1-2` sentence outcome summary
-
-## Execution note
-
-Keep the run loop simple: define the smallest valid run contract, use at most a bounded smoke or pilot when needed, run the real experiment, record the result, and route explicitly from the measured evidence.
 
 ## Non-negotiable rules
 
@@ -78,92 +99,7 @@ Keep the run loop simple: define the smallest valid run contract, use at most a 
 - Implement the claimed mechanism, not a convenient shortcut that changes the theory.
 - Keep the baseline reference read-only.
 - Avoid asking the user to fix the environment unless there is no credible agent-side path left.
-- Do not record a durable main experiment from an idea branch, quest root branch, or paper branch as if that were the final result node; every durable main experiment should land on its own `run/*` branch.
-- After each `artifact.record_main_experiment(...)`, route from the measured result:
-  - if paper mode is enabled, decide whether to strengthen evidence, analyze, or write
-  - if paper mode is disabled, prefer iterate / revise-idea / branch over default writing
-- In algorithm-first work, after each main run, return to `optimize` or `decision` for frontier review before launching another large run.
-
-## Experiment mental guardrails
-
-- Baseline reproduction is not wasted time; untrusted comparison is wasted time.
-- Failed runs are still data when the delta and diagnosis are recorded clearly.
-- Suspiciously good results deserve the same skepticism as obvious failures.
-- Change less, learn more.
-- If a retry does not add new evidence, it is budget burn rather than progress.
-
-## Use when
-
-- a baseline is accepted
-- an idea has been selected
-- the evaluation contract is explicit
-- the quest is ready for implementation and measurement
-
-## Do not use when
-
-- the baseline gate is unresolved
-- the idea stage still has unresolved tradeoffs
-- the main need is writing or follow-up analysis rather than a main run
-
-## Preconditions and gate
-
-Before a main run starts, confirm:
-
-- selected idea or hypothesis
-- baseline reference
-- dataset and split
-- primary metric
-- stop condition
-- resource budget
-- dedicated `run/*` target branch or isolated worktree for this exact main experiment
-- exact output location
-- required metric keys for acceptance
-- minimal experiment and abandonment condition from the idea stage
-
-If any of these are materially unknown, stop and resolve them through `decision`.
-
-Two execution tiers are acceptable:
-
-- `lightweight run`
-  - minimal code touch
-  - already-trusted command path
-  - no major branch or environment change
-  - one compact control-surface update plus durable result recording is usually enough
-- `durable main run`
-  - substantial code changes, new evaluator wiring, long runtime, or paper-facing claim-carrying evidence
-  - use the fuller `PLAN.md` / `CHECKLIST.md` contract and dedicated `run/*` surface
-
-## Required plan and checklist
-
-Before substantial implementation work or a real main run, create a quest-visible `PLAN.md` and `CHECKLIST.md`.
-
-- Use `references/main-experiment-plan-template.md` as the canonical structure for `PLAN.md`.
-- Use `references/main-experiment-checklist-template.md` as the canonical structure for `CHECKLIST.md`.
-- `PLAN.md` and `CHECKLIST.md` are the canonical planning-and-control surface before and during execution.
-- `PLAN.md` should lead with the selected idea summarized in `1-2` sentences and include the baseline and comparability rules, safe efficiency levers, minimal code-change map, smoke or pilot path, full-run path, fallback options, monitoring and sleep rules, expected outputs, and a revision log.
-- Once the route is concrete, implement according to the current `PLAN.md`.
-- If the code path, comparability contract, runtime strategy, or execution route changes materially, revise `PLAN.md` before spending more code or compute.
-
-## Working-boundary rules
-
-Only modify the active quest workspace for this experiment line.
-
-- treat the accepted baseline workspace as read-only
-- do not derive branch or worktree assumptions from guesswork
-- keep all durable outputs inside the quest
-- if the runtime gives an explicit worktree path, use it exactly
-
-## Resource note
-
-Respect explicit resource limits and record real environment or dependency constraints, but do not stop the run early just to over-document them.
-
-## Resource and environment rules
-
-- Follow the explicit resource assignment if one exists.
-- If GPU assignment is explicit, respect it exactly and record it in the run manifest.
-- Do not silently consume extra GPUs or broaden resource scope.
-- Capture enough environment information that the run can later be reconstructed.
-- If a new dependency appears necessary, record it as a risk and prefer a fallback if possible.
+- After each `artifact.record_main_experiment(...)`, route from the measured result instead of stopping at “run finished”.
 
 ## Truth sources
 
@@ -186,404 +122,45 @@ Do not claim run success without durable outputs.
 A meaningful experiment pass should leave behind:
 
 - a run directory under `artifacts/experiment/<run_id>/` or the quest-equivalent canonical location
-- `artifact_manifest.json`, `run_manifest.json`, `metrics.json`, and `summary.md`
-- `metrics.md` and `runlog.summary.md` for durable main runs
 - durable command, config, and log pointers
 - exported shell log, typically `bash.log`
 - a run artifact with explicit deltas versus baseline
 - a decision about what should happen next
 
-Recommended additional files:
+For the exact run-manifest fields, checklist template, and detailed recording contract, use the references listed below.
 
-- `claim_validation.md`
-- environment snapshot files such as Python version, package freeze, and GPU info when applicable
-- a live execution note or rolling run log when the experiment spans multiple implementation or execution steps
+## Evidence ladder note
 
-`run_manifest.json` should capture at least:
+Use `references/evidence-ladder.md` when deciding whether the current package is merely executable, solid enough to carry the main claim, or already in the stage where broader polish is justified.
 
-- `run_id`
-- quest / branch context
-- baseline reference or commit
-- full commands
-- config paths and key resolved hyperparameters
-- dataset identifier or version
-- seeds
-- environment snapshot paths
-- start time, end time, and final status
+The default ladder is:
 
-If a command needed for environment capture is unavailable, record that gap in the manifest and summary.
+- `minimum`: executable and comparable
+- `solid`: strong enough to carry the main claim
+- `maximum`: broader supporting polish after the main claim is already credible
 
-## Workflow
+Do not spend for `maximum` before the line is at least `solid`.
 
-### 1. Define the run contract
+## Planning note
 
-Before implementation or execution, state:
+Use quest or workspace planning files only when they help control a non-trivial run.
+Otherwise keep the run contract small and move to the first decisive execution step.
 
-- `run_id`
-- experiment tier: `auxiliary/dev` or `main/test`
-- research question
-- null hypothesis
-- alternative hypothesis
-- hypothesis
-- baseline id or variant
-- metric targets
-- expected changed files
-- expected outputs
-- stop condition
-- compute or runtime budget
-- minimal experiment
-- abandonment condition
-- strongest alternative hypothesis
-- exact metric keys that will decide success or failure
+## Operational guidance
 
-Prefer to write this contract first in `PLAN.md` using `references/main-experiment-plan-template.md`, then keep the current execution state visible in `CHECKLIST.md` using `references/main-experiment-checklist-template.md`.
+The main skill keeps the control surface in front.
+For the longer operational notes, read the references:
 
-For substantial runs, also record the following seven experiment fields early and keep them updated during execution:
+- `references/main-experiment-plan-template.md`
+- `references/main-experiment-checklist-template.md`
+- `references/execution-playbook.md`
+- `references/operational-guidance.md`
 
-1. research question
-2. research type
-3. research objective
-4. experimental setup
-5. experimental results
-6. experimental analysis
-7. experimental conclusions
+Use them when:
 
-If the run contract changes materially later, record the change durably.
-
-Treat the run contract as a research question contract, not only an execution checklist.
-Before coding, be able to explain:
-
-- why this run is the best current route rather than the main alternatives
-- what observation would count as a real answer to the research question
-- what result would force a downgrade, retry, or route change
-- what confounder would make the run non-comparable even if it finishes successfully
-
-If multiple candidate experiment packages exist, prefer the one with the best balance of technical feasibility, research importance, and methodological rigor.
-Do not choose a package only because it sounds ambitious.
-
-For paper-facing lines, default to this evidence ladder:
-
-- `auxiliary/dev`
-  - clarify parameters, settings, mechanisms, or diagnostics
-- `main/test`
-  - carry the core comparison the paper will rely on
-- `minimum -> solid -> maximum`
-  - first make the result executable and comparable
-  - then make it strong enough to carry the claim
-  - only then spend effort on broader supporting polish
-
-### 2. Run a preflight check
-
-Before editing or executing:
-
-- confirm the dataset path, version, and split contract
-- confirm the baseline metrics reference
-- if durable state exposes `active_baseline_metric_contract_json`, read that JSON file before planning commands or comparisons
-- treat `active_baseline_metric_contract_json` as the default authoritative baseline comparison contract unless you record a concrete reason to override it
-- confirm the selected idea claim and code-level plan
-- look up prior incidents or repeated failure patterns when available
-- confirm output directories and naming
-- confirm that the intended run still matches the current quest decision
-
-If a repeated failure pattern already exists, apply the mitigation first and record that choice.
-
-Also confirm before comparison work:
-
-- the baseline verification is trustworthy enough
-- the planned comparison still uses the same metric contract
-- the metric keys and primary metric still match `active_baseline_metric_contract_json` when that file is available
-- every main experiment submission still covers all required baseline metric ids from `active_baseline_metric_contract_json`; extra metrics are allowed, but missing required metrics are not
-- the required baseline metrics still use the same evaluation code and metric definitions; if an extra evaluator is genuinely necessary, record it as supplementary output rather than replacing the canonical comparator
-- if the run is `main/test` and superiority is likely to be claimed, define the significance-testing plan before execution rather than after seeing the numbers
-- if `Result/metric.md` was used during the run, treat it as optional scratch memory only and reconcile it against the final submitted metrics before `artifact.record_main_experiment(...)`
-
-Before you begin a substantial run, send a concise threaded `artifact.interact(kind='progress', ...)` update naming:
-
-- the run contract you are about to execute
-- the main evidence it is testing
-- the expected durable outputs
-- the next checkpoint for reporting back
-
-### 2.1 Diagnostic mode trigger
-
-Switch from ordinary execution mode into diagnosis mode when any of the following becomes true:
-
-- two retries in a row add no new evidence or no interpretable delta
-- the baseline gap is much larger than expected and the cause is unclear
-- the metrics are suspiciously strong, suspiciously identical to baseline, or highly unstable
-- logs, checkpoints, or intermediate outputs conflict with the claimed behavior
-
-In diagnosis mode:
-
-- stop brute-force retrying
-- prefer the smallest discriminative test that can separate competing hypotheses
-- resolve obvious environment or data-contract issues before launching another comparison run
-- make the diagnosis goal explicit: explain the behavior, not just "try something else"
-
-### 3. Confirm the execution workspace
-
-The normal experiment workspace is the current active idea worktree returned by `artifact.submit_idea(...)`.
-
-- do not create a fresh manual branch for the main experiment unless recovery or debugging truly requires it
-- implement and run inside the current active idea workspace
-- if the idea package changes materially before execution, submit a new durable idea branch with `artifact.submit_idea(mode='create', lineage_intent='continue_line'|'branch_alternative', ...)` instead of silently mutating the old node
-- after a real main run finishes, record it with `artifact.record_main_experiment(...)` before moving to analysis or writing
-- once that durable main result exists, treat the branch as a fixed round node; a later new optimization round should usually compare foundations and create a new `continue_line` child branch or `branch_alternative` sibling-like branch
-- after `artifact.record_main_experiment(...)`, if QQ milestone media is enabled and the metrics are stable enough to summarize honestly, prefer one concise summary PNG over multiple attachments
-
-### 4. Implement the minimum required change
-
-Implementation rules:
-
-- keep the change hypothesis-bound
-- prefer small, explainable edits
-- avoid unrelated cleanup during a main run
-- record which files matter for later review
-- preserve theory fidelity between the idea claim and the code change
-- add robustness checks when the mechanism risks NaN, inf, or unstable behavior
-- implement according to the current `PLAN.md` instead of repeatedly improvising a new method after each small observation
-- avoid repeated code churn between the smoke test and the real run unless the smoke test exposes a specific problem that the next change is meant to fix
-
-Prefer to complete one experiment cleanly before expanding to the next, unless parallel execution is explicitly justified and isolated.
-For substantial experiment packages, the default is one experiment at a time, with each one reaching a recoverable recorded state before the next begins.
-
-Retry-delta discipline:
-
-- unless the current state is completely non-executable, change only one major variable per retry
-- if broader recovery is unavoidable, record exactly which layer changed: data, preprocessing, model, objective, optimization, evaluation, or environment
-- before each retry, state the expected effect and the fastest falsification signal
-- if the retry produced no interpretable delta, do not treat it as meaningful evidence about the underlying research hypothesis
-- if the retry does not change the hypothesis, code path, command path, or evidence surface, stop rerunning and route through `decision`
-- if the same failure class appears again without a real route or evidence change, stop looping and route through `decision`
-
-### 5. Execute the run
-
-Run with auditable commands and durable outputs.
-
-Execution rules:
-
-- use non-interactive commands
-- prefer `bash_exec` instead of ephemeral shell invocations
-- use the intended dataset and split
-- keep logs durable
-- report progress for long runs
-- avoid silent metric-definition changes
-- do not drift away from `active_baseline_metric_contract_json` silently when that file exists
-- avoid silently changing the baseline comparison recipe
-- run the full agreed evaluation, not only a smoke test
-
-You may do a quick sanity run first, but if the stage goal is a real experiment you must continue to the real evaluation unless the run is blocked and recorded.
-
-Pilot-before-scale rule:
-
-- start with a bounded pilot only when the modification is non-trivial and that pilot resolves a real execution uncertainty
-- use the pilot to catch implementation mistakes early
-- record pilot outcomes explicitly
-- do not mistake pilot success for final evidence
-
-Incremental-recording rule:
-
-- do not wait until the end to reconstruct the run from memory
-- update the durable run note after:
-  - contract definition
-  - important code changes
-  - pilot validation
-  - full execution checkpoints
-  - post-run analysis
-- update `CHECKLIST.md` alongside those durable notes so the current execution frontier is obvious without replaying the whole log
-- include timestamps when they materially help reconstruction
-- preserve failed attempts, anomalies, and partial outcomes rather than overwriting them
-- a durable run memory or note should explicitly record whether the current state is `success`, `partial`, or `failure`
-- when available, include `idea_id`, `branch`, and `run_id`
-
-Last-known-good rule:
-
-- keep track of the most recent state that was executable, comparable, and explainable
-- when a new attempt breaks that state, debug forward from the last-known-good point instead of stacking more speculative edits on top of the broken state
-- if the last-known-good state is unclear, reconstruct it before spending more budget on new hypotheses
-
-### 5.1 Long-running command protocol
-
-For commands that may run longer than a few minutes:
-
-- if command paths, outputs, or basic metrics are still unverified, execute one bounded smoke test or pilot first
-- keep smoke/pilot budget at `0-2` for the current experiment pass
-- treat smoke work as a `0-2` budget rather than as a mandatory separate phase
-- allow a second smoke/pilot only after a real code, command, environment, or evaluator change
-- once the path is verified, launch the real run with `bash_exec(mode='detach', ...)` and normally leave `timeout_seconds` unset for that long run
-- monitor through durable logs rather than only live terminal output
-- `bash_exec(mode='read', id=...)` returns the full rendered log when it is 2000 lines or fewer; for longer logs it returns the first 500 lines plus the last 1500 lines and a hint to inspect omitted sections with `start` and `tail`
-- if the middle of a long saved log matters, inspect that omitted region with `bash_exec(mode='read', id=..., start=..., tail=...)`
-- use `bash_exec(mode='list')` and `bash_exec(mode='read', id=..., tail_limit=..., order='desc')` to monitor or revisit managed commands while focusing on the newest evidence first
-- after the first read, prefer `bash_exec(mode='read', id=..., after_seq=last_seen_seq, tail_limit=..., order='asc')` so later checks only fetch new evidence
-- if you need to recover ids or sanity-check the active session ordering, use `bash_exec(mode='history')`
-- launch important runs with a structured `comment` such as `{stage, goal, action, expected_signal, next_check}`
-- use `silent_seconds`, `progress_age_seconds`, `signal_age_seconds`, and `watchdog_overdue` from `bash_exec(mode='list'|'read', ...)` as your default watchdog signals
-- use an explicit wait-and-check loop such as:
-  - wait about `60s`, then inspect logs
-  - wait about `120s`, then inspect logs
-  - wait about `300s`, then inspect logs
-  - wait about `600s`, then inspect logs
-  - wait about `1800s`, then inspect logs
-  - then keep checking about every `1800s` while the run is still active
-- if needed, use an explicit bounded wait such as `bash_exec(command='sleep 60', mode='await', timeout_seconds=70)` or `bash_exec(mode='await', id=..., timeout_seconds=...)` between checks
-- canonical sleep choice:
-  - if you only need wall-clock waiting between checks, use `bash_exec(command='sleep N', mode='await', timeout_seconds=N+buffer, ...)`
-  - keep a real buffer on that sleep timeout; do not set `timeout_seconds` exactly equal to `N`
-  - if you are waiting on an already running managed session, prefer `bash_exec(mode='await', id=..., timeout_seconds=...)` instead of starting a new sleep command
-- after every completed sleep / await cycle, inspect logs first; only send `artifact.interact(kind='progress', ...)` when the user-visible state, frontier, blocker status, or ETA materially changed
-- after the first meaningful signal and then at real checkpoints such as completion, recovery, blocker, or a materially widened comparable surface, keep those progress updates going rather than waiting silently
-- if the run is clearly invalid, wedged, or superseded, stop it with `bash_exec(mode='kill', id=..., wait=true, timeout_seconds=...)`; if it must die immediately, add `force=true`, record the reason, fix the issue, and relaunch cleanly
-- do not report completion until logs and output files both confirm completion
-- when you control the run code, prefer a throttled `tqdm` progress reporter and concise structured progress markers when feasible
-
-Always preserve the managed `bash_exec` log and export it into the experiment artifact directory when the run artifact is written.
-
-### 5.2 Progress marker protocol
-
-If the run emits progress markers, keep them concise and machine-readable instead of narrating every low-level update in chat.
-When a real checkpoint is reached, include the estimated next reply time and `next_reply_at` when that is honestly knowable.
-
-### 6. Validate the outputs
-
-After the run, verify:
-
-- outputs correspond to the intended code/config
-- metrics are complete and interpretable
-- comparison to baseline is fair
-- any failure mode or confounder is visible
-- required metric keys are present and finite
-- the result can be mapped back to the original claim
-- the summary states a clear go or no-go recommendation
-
-Create a durable claim-validation record that maps:
-
-- claim
-- metric key
-- expected direction
-- observed result
-- verdict:
-  - `supported`
-  - `refuted`
-  - `inconclusive`
-
-Also verify baseline comparability before claiming deltas:
-
-- was the baseline verification stable?
-- was the evaluation path the same?
-- are the compared metric keys identical?
-- if the run is claim-carrying, are the significance results or uncertainty estimates strong enough for main-text use?
-- do known caveats make the delta weaker than it first appears?
-
-### 7. Record the run
-
-Every meaningful main run must be recorded through `artifact.record_main_experiment(...)`.
-
-That call is responsible for writing:
-
-- `experiments/main/<run_id>/RUN.md`
-- `experiments/main/<run_id>/RESULT.json`
-- the durable `run` artifact payload
-- baseline comparisons
-- breakthrough status derived by the system
-
-`artifact.record_main_experiment(...)` should include at least:
-
-- `run_id`
-- title
-- hypothesis
-- setup
-- execution
-- results
-- conclusion
-- baseline reference
-- `metrics_summary`
-- `metric_rows` when available
-- the metric contract actually used
-- verdict
-- evidence paths
-- changed files
-- relevant config paths when applicable
-- `evaluation_summary` with exactly these six fields:
-  - `takeaway`
-  - `claim_update`
-  - `baseline_relation`
-  - `comparability`
-  - `failure_mode`
-  - `next_action`
-
-Use `evaluation_summary` as the short structured judgment layer on top of the longer narrative fields:
-
-- `takeaway`: one sentence the next reader can reuse directly
-- `claim_update`: `strengthens`, `weakens`, `narrows`, or `neutral`
-- `baseline_relation`: `better`, `worse`, `mixed`, or `not_comparable`
-- `comparability`: `high`, `medium`, or `low`
-- `failure_mode`: `none`, `implementation`, `evaluation`, `environment`, or `direction`
-- `next_action`: the immediate route such as `continue`, `revise_idea`, `analysis_campaign`, `write`, or `stop`
-
-After `artifact.record_main_experiment(...)` succeeds, do not assume the same branch should absorb the next round by default.
-Interpret the measured result first, then either:
-
-- launch analysis from this branch, or
-- compare candidate foundations and create the next child research branch
-
-Use `artifact.create_analysis_campaign(...)` only when the extra slices have clear academic or claim-level value relative to their resource cost.
-If the main need is simply to continue optimization from a measured result, prefer a new durable child idea branch instead of an expensive analysis package by reflex.
-If the extra work should happen on an older durable branch rather than the current head, first switch the runtime back there with `artifact.activate_branch(...)`, then launch the analysis campaign from that activated workspace.
-
-When `artifact.record_main_experiment(...)` succeeds, send a richer threaded `artifact.interact(kind='milestone', ...)` update rather than a generic one-line progress ping.
-Lead that milestone with a concise `1-2` sentence outcome summary before expanding into more detail.
-That milestone should state:
-
-- the research question that was tested
-- the primary result and baseline delta
-- whether the run supports, weakens, or leaves the idea inconclusive
-- the main caveat or confidence note that still matters
-- the exact recommended next move
-
-Do not treat a main run as durably complete until `artifact.record_main_experiment(...)` succeeds.
-
-Recommended per-run documentation fields:
-
-1. research question
-2. research type
-3. research objective
-4. experimental setup
-5. experimental results
-6. experimental analysis
-7. experimental conclusions
-
-For durable main runs, these seven fields should be progressively filled as the run advances, not only at final packaging time.
-For lightweight runs, a shorter summary is acceptable if the route remains obvious and the result is still durably recorded.
-
-`RUN.md` should make it easy for later stages to answer:
-
-- what changed?
-- how can this run be reproduced?
-- what are the main results?
-- why did it work or fail?
-- what should happen next?
-
-Recording rules:
-
-- record results incrementally, not only at the end
-- include timestamps when helpful
-- include failed attempts, partial runs, and unexpected outcomes
-- do not leave placeholder sections for later if the information is already known
-- report exactly what happened, not what you hoped would happen
-
-### 8. Decide the next move
-
-The experiment stage should normally end with one of:
-
-- continue the current line
-- branch a new line
-- launch an analysis campaign
-- move to writing
-- reset or stop
-
-Do not let the stage end without an explicit next direction.
-If analysis is selected, record why the expected information gain is strong enough to justify the added compute, time, or annotation budget.
+- the run contract is non-trivial
+- the long-running protocol or monitoring cadence matters
+- the exact manifest, artifact, memory, or charting rules matter
 
 ## Run-quality rules
 
@@ -595,7 +172,7 @@ A credible main run should satisfy:
 - outcome can be explained by the intended intervention or its failure
 - commands, configs, and seeds are reconstructable
 - environment context is reconstructable
-- frontend or later readers can trace code and diff context to command, logs, and metrics
+- later readers can trace code and diff context to command, logs, and metrics
 
 If the result is confounded, say so directly.
 
@@ -613,55 +190,35 @@ Before marking the run complete, verify all of the following:
 
 If these checks fail, record the run as partial or blocked rather than pretending it is complete.
 
-## Memory rules
-
-Stage-start requirement:
-
-- begin every experiment pass with `memory.list_recent(scope='quest', limit=5)`
-- then run at least one experiment-relevant `memory.search(...)` before reopening a previously tested command path or retrying an old run
-
-Stage-end requirement:
-
-- if the run produced a durable lesson, incident pattern, comparability caveat, or route-changing outcome, write at least one `memory.write(...)` before leaving the stage
-
-## Connector-facing chart requirements
-
-When this stage produces connector-facing charts or milestone-facing visuals, keep the palette aligned with the system prompt Morandi plotting template.
-
-- `sage-clay` should be the primary positive / accepted-result color
-- `mist-stone` should be the neutral comparison / baseline color
-- `dust-rose` should be the restrained caution / limitation accent when needed
-- keep light paper-style backgrounds close to `#F3EEE8`
-
-## Memory note
-
-Use memory only to avoid repeating known failures or to preserve reusable experiment lessons; the canonical run record belongs in `artifact`.
-
-## Artifact rules
-
-## Connector-facing chart requirements
-
-- Use calm connector-safe palettes such as `sage-clay`, `mist-stone`, and `dust-rose` when turning experiment evidence into connector-facing charts.
-- A practical anchor for the light `mist-stone` background is `#F3EEE8`.
-- The palette must keep milestone charts readable in QQ or other connector previews before it tries to look vivid.
-- Stay aligned with the system prompt rather than inventing a new local visual language for each chart.
-- Highlight only the decisive delta; do not color every series as if they are equally important.
-
-- use `progress` for long-running execution updates
-- use `artifact.record_main_experiment(...)` for each meaningful completed main experiment
-- use `report` for suspicious-result investigations or analysis-rich summaries when they materially help the next route
-- use `decision` for continue / branch / analysis / write / reset / stop
-- use `approval` when an explicit user approval is captured for an expensive or risky run change
-- use `artifact.checkpoint(...)` when code evolution is meaningful and should be preserved in Git
-- after a meaningful experiment checkpoint or completion, emit `artifact.interact(kind='progress' | 'milestone', ...)` so the user sees the concrete result and next step
-
 ## Failure and blocked handling
 
 A failed main run is still useful if it is explained well.
 
-Record what was attempted, where the failure occurred, whether it was methodological or infrastructural, what retry/branch/reset is justified, and the single best next action.
-Prefer a primary failure type such as `data_contract_mismatch`, `resource_exhausted`, `numeric_instability`, `implementation_bug`, `evaluation_pipeline_failure`, `external_dependency_blocked`, or `direction_underperforming`.
-Also classify the broader failure layer when possible: implementation, evaluation, environment, or direction.
+Record:
+
+- what was attempted
+- where the failure occurred
+- whether the failure was methodological or infrastructural
+- what retry, branch, or reset is justified
+- the single best next action
+
+Prefer a primary failure type such as:
+
+- `data_contract_mismatch`
+- `resource_exhausted`
+- `numeric_instability`
+- `implementation_bug`
+- `evaluation_pipeline_failure`
+- `external_dependency_blocked`
+- `direction_underperforming`
+
+Also classify the broader failure layer when possible:
+
+- implementation
+- evaluation
+- environment
+- direction
+
 Blocked experiment states commonly include missing baseline reference, unknown metric contract, environment failure, run failure before metrics, or metrics that are not comparable.
 When results are suspicious, fix the subset and seeds, isolate preprocessing/model/training/evaluation one by one, compare intermediate outputs on the same inputs, and run the cheapest discriminative check before another full retry.
 
@@ -671,6 +228,6 @@ Exit the experiment stage once one of the following is durably true:
 
 - a main run is completed and recorded
 - the run failed and the blocker is durably recorded
-- the next step is clearly `analysis-campaign`, `write`, another `experiment`, or `reset`
+- the next step is clearly `analysis-campaign`, `write`, another `experiment`, `optimize`, or `reset`
 
 A good experiment pass leaves one interpretable result or one explicit blocker, not another vague promise to rerun later.

--- a/src/skills/experiment/references/execution-playbook.md
+++ b/src/skills/experiment/references/execution-playbook.md
@@ -1,0 +1,373 @@
+# Execution Playbook
+
+Use this reference when the experiment route needs the full execution checklist rather than the short control surface in `SKILL.md`.
+
+## 1. Define the run contract
+
+Before implementation or execution, state:
+
+- `run_id`
+- experiment tier: `auxiliary/dev` or `main/test`
+- research question
+- null hypothesis
+- alternative hypothesis
+- hypothesis
+- baseline id or variant
+- metric targets
+- expected changed files
+- expected outputs
+- stop condition
+- compute or runtime budget
+- minimal experiment
+- abandonment condition
+- strongest alternative hypothesis
+- exact metric keys that will decide success or failure
+
+Prefer to write this contract first in `PLAN.md` using `references/main-experiment-plan-template.md`, then keep the current execution state visible in `CHECKLIST.md` using `references/main-experiment-checklist-template.md`.
+
+For substantial runs, also record the following seven experiment fields early and keep them updated during execution:
+
+1. research question
+2. research type
+3. research objective
+4. experimental setup
+5. experimental results
+6. experimental analysis
+7. experimental conclusions
+
+If the run contract changes materially later, record the change durably.
+
+Treat the run contract as a research-question contract, not only an execution checklist.
+Before coding, be able to explain:
+
+- why this run is the best current route rather than the main alternatives
+- what observation would count as a real answer to the research question
+- what result would force a downgrade, retry, or route change
+- what confounder would make the run non-comparable even if it finishes successfully
+
+If multiple candidate experiment packages exist, prefer the one with the best balance of technical feasibility, research importance, and methodological rigor.
+Do not choose a package only because it sounds ambitious.
+
+For paper-facing lines, default to this evidence ladder:
+
+- `auxiliary/dev`
+  - clarify parameters, settings, mechanisms, or diagnostics
+- `main/test`
+  - carry the core comparison the paper will rely on
+- `minimum -> solid -> maximum`
+  - first make the result executable and comparable
+  - then make it strong enough to carry the claim
+  - only then spend effort on broader supporting polish
+
+## 2. Run a preflight check
+
+Before editing or executing:
+
+- confirm the dataset path, version, and split contract
+- confirm the baseline metrics reference
+- if durable state exposes `active_baseline_metric_contract_json`, read that JSON file before planning commands or comparisons
+- treat `active_baseline_metric_contract_json` as the default authoritative baseline comparison contract unless you record a concrete reason to override it
+- confirm the selected idea claim and code-level plan
+- look up prior incidents or repeated failure patterns when available
+- confirm output directories and naming
+- confirm that the intended run still matches the current quest decision
+
+If a repeated failure pattern already exists, apply the mitigation first and record that choice.
+
+Also confirm before comparison work:
+
+- the baseline verification is trustworthy enough
+- the planned comparison still uses the same metric contract
+- the metric keys and primary metric still match `active_baseline_metric_contract_json` when that file is available
+- every main experiment submission still covers all required baseline metric ids from `active_baseline_metric_contract_json`; extra metrics are allowed, but missing required metrics are not
+- the required baseline metrics still use the same evaluation code and metric definitions; if an extra evaluator is genuinely necessary, record it as supplementary output rather than replacing the canonical comparator
+- if the run is `main/test` and superiority is likely to be claimed, define the significance-testing plan before execution rather than after seeing the numbers
+- if `Result/metric.md` was used during the run, treat it as optional scratch memory only and reconcile it against the final submitted metrics before `artifact.record_main_experiment(...)`
+
+Before you begin a substantial run, send a concise threaded `artifact.interact(kind='progress', ...)` update naming:
+
+- the run contract you are about to execute
+- the main evidence it is testing
+- the expected durable outputs
+- the next checkpoint for reporting back
+
+## 2.1 Diagnostic mode trigger
+
+Switch from ordinary execution mode into diagnosis mode when any of the following becomes true:
+
+- two retries in a row add no new evidence or no interpretable delta
+- the baseline gap is much larger than expected and the cause is unclear
+- the metrics are suspiciously strong, suspiciously identical to baseline, or highly unstable
+- logs, checkpoints, or intermediate outputs conflict with the claimed behavior
+
+In diagnosis mode:
+
+- stop brute-force retrying
+- prefer the smallest discriminative test that can separate competing hypotheses
+- resolve obvious environment or data-contract issues before launching another comparison run
+- make the diagnosis goal explicit: explain the behavior, not just "try something else"
+
+## 3. Confirm the execution workspace
+
+The normal experiment workspace is the current active idea worktree returned by `artifact.submit_idea(...)`.
+
+- do not create a fresh manual branch for the main experiment unless recovery or debugging truly requires it
+- implement and run inside the current active idea workspace
+- if the idea package changes materially before execution, submit a new durable idea branch with `artifact.submit_idea(mode='create', lineage_intent='continue_line'|'branch_alternative', ...)` instead of silently mutating the old node
+- after a real main run finishes, record it with `artifact.record_main_experiment(...)` before moving to analysis or writing
+- once that durable main result exists, treat the branch as a fixed round node; a later new optimization round should usually compare foundations and create a new `continue_line` child branch or `branch_alternative` sibling-like branch
+- after `artifact.record_main_experiment(...)`, if QQ milestone media is enabled and the metrics are stable enough to summarize honestly, prefer one concise summary PNG over multiple attachments
+
+## 4. Implement the minimum required change
+
+Implementation rules:
+
+- keep the change hypothesis-bound
+- prefer small, explainable edits
+- avoid unrelated cleanup during a main run
+- record which files matter for later review
+- preserve theory fidelity between the idea claim and the code change
+- add robustness checks when the mechanism risks NaN, inf, or unstable behavior
+- implement according to the current `PLAN.md` instead of repeatedly improvising a new method after each small observation
+- avoid repeated code churn between the smoke test and the real run unless the smoke test exposes a specific problem that the next change is meant to fix
+
+Prefer to complete one experiment cleanly before expanding to the next, unless parallel execution is explicitly justified and isolated.
+For substantial experiment packages, the default is one experiment at a time, with each one reaching a recoverable recorded state before the next begins.
+
+Retry-delta discipline:
+
+- unless the current state is completely non-executable, change only one major variable per retry
+- if broader recovery is unavoidable, record exactly which layer changed: data, preprocessing, model, objective, optimization, evaluation, or environment
+- before each retry, state the expected effect and the fastest falsification signal
+- if the retry produced no interpretable delta, do not treat it as meaningful evidence about the underlying research hypothesis
+- if the retry does not change the hypothesis, code path, command path, or evidence surface, stop rerunning and route through `decision`
+- if the same failure class appears again without a real route or evidence change, stop looping and route through `decision`
+
+## 5. Execute the run
+
+Run with auditable commands and durable outputs.
+
+Execution rules:
+
+- use non-interactive commands
+- prefer `bash_exec` instead of ephemeral shell invocations
+- use the intended dataset and split
+- keep logs durable
+- report progress for long runs
+- avoid silent metric-definition changes
+- do not drift away from `active_baseline_metric_contract_json` silently when that file exists
+- avoid silently changing the baseline comparison recipe
+- run the full agreed evaluation, not only a smoke test
+
+You may do a quick sanity run first, but if the stage goal is a real experiment you must continue to the real evaluation unless the run is blocked and recorded.
+
+Pilot-before-scale rule:
+
+- start with a bounded pilot only when the modification is non-trivial and that pilot resolves a real execution uncertainty
+- use the pilot to catch implementation mistakes early
+- record pilot outcomes explicitly
+- do not mistake pilot success for final evidence
+
+Incremental-recording rule:
+
+- do not wait until the end to reconstruct the run from memory
+- update the durable run note after:
+  - contract definition
+  - important code changes
+  - pilot validation
+  - full execution checkpoints
+  - post-run analysis
+- update `CHECKLIST.md` alongside those durable notes so the current execution frontier is obvious without replaying the whole log
+- include timestamps when they materially help reconstruction
+- preserve failed attempts, anomalies, and partial outcomes rather than overwriting them
+- a durable run memory or note should explicitly record whether the current state is `success`, `partial`, or `failure`
+- when available, include `idea_id`, `branch`, and `run_id`
+
+Last-known-good rule:
+
+- keep track of the most recent state that was executable, comparable, and explainable
+- when a new attempt breaks that state, debug forward from the last-known-good point instead of stacking more speculative edits on top of the broken state
+- if the last-known-good state is unclear, reconstruct it before spending more budget on new hypotheses
+
+## 5.1 Long-running command protocol
+
+For commands that may run longer than a few minutes:
+
+- if command paths, outputs, or basic metrics are still unverified, execute one bounded smoke test or pilot first
+- keep smoke or pilot budget at `0-2` for the current experiment pass
+- treat smoke work as a `0-2` budget rather than as a mandatory separate phase
+- allow a second smoke or pilot only after a real code, command, environment, or evaluator change
+- once the path is verified, launch the real run with `bash_exec(mode='detach', ...)` and normally leave `timeout_seconds` unset for that long run
+- monitor through durable logs rather than only live terminal output
+- `bash_exec(mode='read', id=...)` returns the full rendered log when it is 2000 lines or fewer; for longer logs it returns the first 500 lines plus the last 1500 lines and a hint to inspect omitted sections with `start` and `tail`
+- if the middle of a long saved log matters, inspect that omitted region with `bash_exec(mode='read', id=..., start=..., tail=...)`
+- use `bash_exec(mode='list')` and `bash_exec(mode='read', id=..., tail_limit=..., order='desc')` to monitor or revisit managed commands while focusing on the newest evidence first
+- after the first read, prefer `bash_exec(mode='read', id=..., after_seq=last_seen_seq, tail_limit=..., order='asc')` so later checks only fetch new evidence
+- if you need to recover ids or sanity-check the active session ordering, use `bash_exec(mode='history')`
+- launch important runs with a structured `comment` such as `{stage, goal, action, expected_signal, next_check}`
+- use `silent_seconds`, `progress_age_seconds`, `signal_age_seconds`, and `watchdog_overdue` from `bash_exec(mode='list'|'read', ...)` as your default watchdog signals
+- use an explicit wait-and-check loop such as:
+  - wait about `60s`, then inspect logs
+  - wait about `120s`, then inspect logs
+  - wait about `300s`, then inspect logs
+  - wait about `600s`, then inspect logs
+  - wait about `1800s`, then inspect logs
+  - then keep checking about every `1800s` while the run is still active
+- if needed, use an explicit bounded wait such as `bash_exec(command='sleep 60', mode='await', timeout_seconds=70)` or `bash_exec(mode='await', id=..., timeout_seconds=...)` between checks
+- canonical sleep choice:
+  - if you only need wall-clock waiting between checks, use `bash_exec(command='sleep N', mode='await', timeout_seconds=N+buffer, ...)`
+  - keep a real buffer on that sleep timeout; do not set `timeout_seconds` exactly equal to `N`
+  - if you are waiting on an already running managed session, prefer `bash_exec(mode='await', id=..., timeout_seconds=...)` instead of starting a new sleep command
+- after every completed sleep or await cycle, inspect logs first; only send `artifact.interact(kind='progress', ...)` when the user-visible state, frontier, blocker status, or ETA materially changed
+- after the first meaningful signal and then at real checkpoints such as completion, recovery, blocker, or a materially widened comparable surface, keep those progress updates going rather than waiting silently
+- if the run is clearly invalid, wedged, or superseded, stop it with `bash_exec(mode='kill', id=..., wait=true, timeout_seconds=...)`; if it must die immediately, add `force=true`, record the reason, fix the issue, and relaunch cleanly
+- do not report completion until logs and output files both confirm completion
+- when you control the run code, prefer a throttled `tqdm` progress reporter and concise structured progress markers when feasible
+
+Always preserve the managed `bash_exec` log and export it into the experiment artifact directory when the run artifact is written.
+
+## 5.2 Progress marker protocol
+
+If the run emits progress markers, keep them concise and machine-readable instead of narrating every low-level update in chat.
+When a real checkpoint is reached, include the estimated next reply time and `next_reply_at` when that is honestly knowable.
+
+## 6. Validate the outputs
+
+After the run, verify:
+
+- outputs correspond to the intended code and config
+- metrics are complete and interpretable
+- comparison to baseline is fair
+- any failure mode or confounder is visible
+- required metric keys are present and finite
+- the result can be mapped back to the original claim
+- the summary states a clear go or no-go recommendation
+
+Create a durable claim-validation record that maps:
+
+- claim
+- metric key
+- expected direction
+- observed result
+- verdict:
+  - `supported`
+  - `refuted`
+  - `inconclusive`
+
+Also verify baseline comparability before claiming deltas:
+
+- was the baseline verification stable?
+- was the evaluation path the same?
+- are the compared metric keys identical?
+- if the run is claim-carrying, are the significance results or uncertainty estimates strong enough for main-text use?
+- do known caveats make the delta weaker than it first appears?
+
+## 7. Record the run
+
+Every meaningful main run must be recorded through `artifact.record_main_experiment(...)`.
+
+That call is responsible for writing:
+
+- `experiments/main/<run_id>/RUN.md`
+- `experiments/main/<run_id>/RESULT.json`
+- the durable `run` artifact payload
+- baseline comparisons
+- breakthrough status derived by the system
+
+`artifact.record_main_experiment(...)` should include at least:
+
+- `run_id`
+- title
+- hypothesis
+- setup
+- execution
+- results
+- conclusion
+- baseline reference
+- `metrics_summary`
+- `metric_rows` when available
+- the metric contract actually used
+- verdict
+- evidence paths
+- changed files
+- relevant config paths when applicable
+- `evaluation_summary` with exactly these six fields:
+  - `takeaway`
+  - `claim_update`
+  - `baseline_relation`
+  - `comparability`
+  - `failure_mode`
+  - `next_action`
+
+Use `evaluation_summary` as the short structured judgment layer on top of the longer narrative fields:
+
+- `takeaway`: one sentence the next reader can reuse directly
+- `claim_update`: `strengthens`, `weakens`, `narrows`, or `neutral`
+- `baseline_relation`: `better`, `worse`, `mixed`, or `not_comparable`
+- `comparability`: `high`, `medium`, or `low`
+- `failure_mode`: `none`, `implementation`, `evaluation`, `environment`, or `direction`
+- `next_action`: the immediate route such as `continue`, `revise_idea`, `analysis_campaign`, `write`, or `stop`
+
+After `artifact.record_main_experiment(...)` succeeds, do not assume the same branch should absorb the next round by default.
+Interpret the measured result first, then either:
+
+- launch analysis from this branch, or
+- compare candidate foundations and create the next child research branch
+
+Use `artifact.create_analysis_campaign(...)` only when the extra slices have clear academic or claim-level value relative to their resource cost.
+If the main need is simply to continue optimization from a measured result, prefer a new durable child idea branch instead of an expensive analysis package by reflex.
+If the extra work should happen on an older durable branch rather than the current head, first switch the runtime back there with `artifact.activate_branch(...)`, then launch the analysis campaign from that activated workspace.
+
+When `artifact.record_main_experiment(...)` succeeds, send a richer threaded `artifact.interact(kind='milestone', ...)` update rather than a generic one-line progress ping.
+Lead that milestone with a concise `1-2` sentence outcome summary before expanding into more detail.
+That milestone should state:
+
+- the research question that was tested
+- the primary result and baseline delta
+- whether the run supports, weakens, or leaves the idea inconclusive
+- the main caveat or confidence note that still matters
+- the exact recommended next move
+
+Do not treat a main run as durably complete until `artifact.record_main_experiment(...)` succeeds.
+
+Recommended per-run documentation fields:
+
+1. research question
+2. research type
+3. research objective
+4. experimental setup
+5. experimental results
+6. experimental analysis
+7. experimental conclusions
+
+For durable main runs, these seven fields should be progressively filled as the run advances, not only at final packaging time.
+For lightweight runs, a shorter summary is acceptable if the route remains obvious and the result is still durably recorded.
+
+`RUN.md` should make it easy for later stages to answer:
+
+- what changed?
+- how can this run be reproduced?
+- what are the main results?
+- why did it work or fail?
+- what should happen next?
+
+Recording rules:
+
+- record results incrementally, not only at the end
+- include timestamps when helpful
+- include failed attempts, partial runs, and unexpected outcomes
+- do not leave placeholder sections for later if the information is already known
+- report exactly what happened, not what you hoped would happen
+
+## 8. Decide the next move
+
+The experiment stage should normally end with one of:
+
+- continue the current line
+- branch a new line
+- launch an analysis campaign
+- move to writing
+- reset or stop
+
+Do not let the stage end without an explicit next direction.
+If analysis is selected, record why the expected information gain is strong enough to justify the added compute, time, or annotation budget.

--- a/src/skills/experiment/references/operational-guidance.md
+++ b/src/skills/experiment/references/operational-guidance.md
@@ -1,0 +1,108 @@
+# Operational Guidance
+
+Use this reference when the experiment route needs the longer planning, environment, artifact, memory, or charting notes rather than the main control surface in `SKILL.md`.
+
+## Planning surfaces
+
+Use quest or workspace planning files only when they help control a non-trivial run; otherwise keep the run contract small and move to the first decisive execution step.
+
+## Required plan and checklist
+
+Before substantial implementation work or a real main run, create a quest-visible `PLAN.md` and `CHECKLIST.md`.
+
+- Use `references/main-experiment-plan-template.md` as the canonical structure for `PLAN.md`.
+- Use `references/main-experiment-checklist-template.md` as the canonical structure for `CHECKLIST.md`.
+- `PLAN.md` and `CHECKLIST.md` are the canonical planning-and-control surface before and during execution.
+- `PLAN.md` should lead with the selected idea summarized in `1-2` sentences and include the baseline and comparability rules, safe efficiency levers, minimal code-change map, smoke or pilot path, full-run path, fallback options, monitoring and sleep rules, expected outputs, and a revision log.
+- Once the route is concrete, implement according to the current `PLAN.md`.
+- If the code path, comparability contract, runtime strategy, or execution route changes materially, revise `PLAN.md` before spending more code or compute.
+
+## Working-boundary rules
+
+Only modify the active quest workspace for this experiment line.
+
+- treat the accepted baseline workspace as read-only
+- do not derive branch or worktree assumptions from guesswork
+- keep all durable outputs inside the quest
+- if the runtime gives an explicit worktree path, use it exactly
+
+## Resource note
+
+Respect explicit resource limits and record real environment or dependency constraints, but do not stop the run early just to over-document them.
+
+## Resource and environment rules
+
+- Follow the explicit resource assignment if one exists.
+- If GPU assignment is explicit, respect it exactly and record it in the run manifest.
+- Do not silently consume extra GPUs or broaden resource scope.
+- Capture enough environment information that the run can later be reconstructed.
+- If a new dependency appears necessary, record it as a risk and prefer a fallback if possible.
+
+## Required durable outputs
+
+A meaningful experiment pass should leave behind:
+
+- a run directory under `artifacts/experiment/<run_id>/` or the quest-equivalent canonical location
+- `artifact_manifest.json`, `run_manifest.json`, `metrics.json`, and `summary.md`
+- `metrics.md` and `runlog.summary.md` for durable main runs
+- durable command, config, and log pointers
+- exported shell log, typically `bash.log`
+- a run artifact with explicit deltas versus baseline
+- a decision about what should happen next
+
+Recommended additional files:
+
+- `claim_validation.md`
+- environment snapshot files such as Python version, package freeze, and GPU info when applicable
+- a live execution note or rolling run log when the experiment spans multiple implementation or execution steps
+
+`run_manifest.json` should capture at least:
+
+- `run_id`
+- quest or branch context
+- baseline reference or commit
+- full commands
+- config paths and key resolved hyperparameters
+- dataset identifier or version
+- seeds
+- environment snapshot paths
+- start time, end time, and final status
+
+If a command needed for environment capture is unavailable, record that gap in the manifest and summary.
+
+## Memory rules
+
+Stage-start requirement:
+
+- begin every experiment pass with `memory.list_recent(scope='quest', limit=5)`
+- then run at least one experiment-relevant `memory.search(...)` before reopening a previously tested command path or retrying an old run
+
+Stage-end requirement:
+
+- if the run produced a durable lesson, incident pattern, comparability caveat, or route-changing outcome, write at least one `memory.write(...)` before leaving the stage
+
+## Memory note
+
+Use memory only to avoid repeating known failures or to preserve reusable experiment lessons; the canonical run record belongs in `artifact`.
+
+## Artifact rules
+
+- use `progress` for long-running execution updates
+- use `artifact.record_main_experiment(...)` for each meaningful completed main experiment
+- use `report` for suspicious-result investigations or analysis-rich summaries when they materially help the next route
+- use `decision` for continue / branch / analysis / write / reset / stop
+- use `approval` when an explicit user approval is captured for an expensive or risky run change
+- use `artifact.checkpoint(...)` when code evolution is meaningful and should be preserved in Git
+- after a meaningful experiment checkpoint or completion, emit `artifact.interact(kind='progress' | 'milestone', ...)` so the user sees the concrete result and next step
+
+## Connector-facing chart requirements
+
+When this stage produces connector-facing charts or milestone-facing visuals, keep the palette aligned with the system prompt Morandi plotting template.
+
+- `sage-clay` should be the primary positive or accepted-result color
+- `mist-stone` should be the neutral comparison or baseline color
+- `dust-rose` should be the restrained caution or limitation accent when needed
+- keep light paper-style backgrounds close to `#F3EEE8`
+- use calm connector-safe palettes such as `sage-clay`, `mist-stone`, and `dust-rose`
+- highlight only the decisive delta; do not color every series as if they are equally important
+- stay aligned with the system prompt rather than inventing a new local visual language for each chart

--- a/src/skills/finalize/SKILL.md
+++ b/src/skills/finalize/SKILL.md
@@ -94,8 +94,10 @@ For paper-like deliverables, do not finalize while any of these remain true:
 - required main-text outline items are still unresolved
 - completed analysis remains unmapped into the paper contract
 - the active paper line still reports open supplementary work that is expected to block the manuscript
+- the current paper contract rows still fail to expose the main experiment or required analysis rows that the manuscript depends on
 
 If the current paper-state blocker is not obvious from the existing files, call `artifact.get_paper_contract_health(detail='full')` before deciding whether finalize is legitimate.
+If the exact section rows, evidence rows, or experiment-matrix rows matter, call `artifact.get_paper_contract(detail='full')` before deciding whether finalize is legitimate.
 If the active quest/runtime state is unclear after restart or long pause, call `artifact.get_quest_state(detail='summary')` first.
 If the exact latest `SUMMARY.md`, `status.md`, or active user requirement wording matters for closure, call `artifact.read_quest_documents(...)`.
 If earlier user/assistant continuity matters for whether the quest should really stop, call `artifact.get_conversation_context(...)` instead of guessing from prompt context alone.

--- a/src/skills/idea/SKILL.md
+++ b/src/skills/idea/SKILL.md
@@ -13,6 +13,98 @@ When `startup_contract.need_research_paper = false` and the quest already has a 
 In that algorithm-first case, `idea` should usually produce a small method-brief frontier and then defer candidate ranking, promotion, and bounded search to `optimize`.
 When doing that handoff, prefer the brief-shaping discipline later used by `optimize`: clarify the bottleneck and constraints, keep only a small differentiated `2-3` option slate, and hand off a recommended brief rather than a pile of loose intuitions.
 
+## Match signals
+
+Use `idea` when:
+
+- the accepted baseline and metric contract already exist, but the next route is still unresolved
+- the current line failed and the quest needs a new falsifiable direction
+- the problem is not "build a new module" but "decide what kind of route should be tried next"
+- the current bottleneck might be a mechanism problem, an objective mismatch, a measurement/evaluator problem, or an infrastructure constraint that changes what should be tested next
+
+Do not use `idea` when:
+
+- the baseline gate is still unresolved
+- the current board state is too stale or conflicting to say what the mainline actually is
+- the next step is already obviously `write`, `review`, or `finalize`
+
+If the current board cannot be compressed cleanly, route through `decision` or `intake-audit` before widening the frontier.
+
+## One-sentence summary
+
+Turn the current objective, board state, and bottleneck into a small differentiated frontier, then select the next falsifiable route.
+
+## Control workflow
+
+1. Write the objective contract.
+   Use `references/objective-contract-template.md`.
+   Make the real target, trusted proxies, false-progress signals, and hard constraints explicit before generating ideas.
+2. Write the current board packet.
+   Use `references/current-board-packet-template.md`.
+   Compress the incumbent, latest decisive result, active blocker, and stale routes-to-ignore into one current state surface.
+3. Identify the important contradiction and plausible novelty source.
+   Use `references/high-value-idea-sourcing.md`.
+   Start from the most important unresolved contradiction, anomaly, bottleneck, or failure region rather than from a preferred mechanism.
+4. Run a broad, history-aware literature search.
+   Use `references/related-work-playbook.md` and `references/research-history-playbook.md`.
+   If DeepXiv is available, use it for broad paper-centric discovery and citation expansion; otherwise use search engines and citation chaining directly.
+5. Choose the idea family mix.
+   At minimum, decide whether the current pass should consider some mix of:
+   - mechanism-family routes
+   - objective-family routes
+   - measurement-family routes
+   - infrastructure-family routes
+6. Run bounded brainstorming.
+   Use `references/controlled-brainstorming-playbook.md` when the route is not already obvious.
+   Generate a small, meaningfully different slate rather than a pile of micro-variants.
+7. Filter aggressively.
+   Use `references/selection-gate.md`.
+   Remove candidates that only improve a surrogate, reopen a stale route without new evidence, violate leakage or submission-time boundaries, or lack a cheap falsification path.
+8. Select and hand off.
+   The selected package must include the route, why now, novelty type, main risk, anti-win condition, core hypothesis, mechanism sketch, strongest falsification experiment, minimal validation, abandonment condition, and the next stage.
+
+## AVOID / pitfalls
+
+- Do not start from swapping method A for method B before naming the important contradiction or bottleneck.
+- Do not brainstorm before the real objective and false-progress signals are explicit.
+- Do not treat lower loss, better average surrogate, or cleaner intermediate metrics as route health if the real target is unchanged.
+- Do not reopen stale routes unless new evidence explicitly weakens the current mainline.
+- Do not generate a large within-family variant swarm before the mechanism family itself is chosen.
+- Do not treat novelty as “totally unprecedented”; it may come from a new problem, view, mechanism, method, setting, evaluation, or boundary condition.
+- Do not promote a direction that fails a value/feasibility screen simply because it sounds exciting.
+- Do not promote a direction without a cheap falsification path and a visible anti-win condition.
+
+## Constraints
+
+- Keep the accepted dataset, metric, and evaluation contract fixed unless scope explicitly changed.
+- Do not propose routes that depend on submit-time unavailable features.
+- Do not propose routes that introduce leakage-prone targets or labels into training.
+- Do not let implementation convenience outrank target alignment.
+- Search should be broad enough to map the main paradigms, history, and strongest overlaps, not just skim a few recent papers.
+- If DeepXiv is available, prefer it for broad paper-centric discovery; otherwise use search engines, citation chaining, and open-web search directly.
+- A serious candidate should be explainable in terms of importance, novelty type, feasibility, verification path, and failure value.
+- In system optimization work, a valid idea may be a mechanism change, an objective/evaluator correction, a measurement fix, or an infrastructure change if that is what best improves the real target.
+
+## Validation
+
+Before the idea pass can end, the durable selected idea package should make explicit:
+
+- the important contradiction, gap, anomaly, or bottleneck it is targeting
+- the dominant novelty type
+- the targeted limitation
+- the real objective and the strongest false-progress signal
+- the selected direction and why it won now
+- the value/feasibility screen or equivalent judgment
+- the core hypothesis
+- the mechanism sketch
+- the strongest falsification experiment
+- the anti-win condition
+- the minimal validation
+- the abandonment condition
+- the next stage
+
+If those fields are still fuzzy, continue ideation or route back through `decision` rather than pretending the route is ready.
+
 ## Interaction discipline
 
 - Follow the shared interaction contract injected by the system prompt.
@@ -50,6 +142,12 @@ The idea node should make explicit:
 - which candidate families are still live
 - what selection gate must be cleared before experiment
 
+Before widening the frontier, the node should also make explicit:
+
+- the current objective contract
+- the current board packet
+- which candidate-family mix is actually being explored in this pass
+
 ## Stage purpose
 
 The idea stage should not generate vague inspiration.
@@ -61,7 +159,7 @@ It should produce executable hypotheses tied to:
 - the strongest relevant prior work
 
 This stage is not just "brainstorming".
-It is the research-direction selection stage.
+It is a controlled brainstorming plus route-selection stage.
 It still needs a bounded creative-divergence phase before convergence.
 Do not collapse onto the first plausible route just because it sounds implementable.
 It should normally create a new candidate direction branch and node; it does not by itself decide the next optimization round.
@@ -128,6 +226,8 @@ Candidate sets should usually cover some mix of:
 - a strong local refinement of the incumbent
 - an orthogonal alternative that addresses the same bottleneck differently
 - a cleaner or more defensible route with lower conceptual complexity
+- an objective/evaluator fix when the current route may be optimizing the wrong thing
+- an infrastructure or throughput fix when measurement cost itself is blocking useful iteration
 
 Do not default to “run a small experiment and see” as the way to break ties.
 Break ties primarily through careful reasoning over:
@@ -240,6 +340,7 @@ Do not skip the `scout` pass just because the quest is already in the `idea` sta
 
 Use `references/idea-thinking-flow.md` when the main need is better reasoning hygiene.
 Use `references/idea-generation-playbook.md` when the main need is to create a new idea slate and select one clear next research object.
+Use `references/high-value-idea-sourcing.md` when the main need is to identify a truly important contradiction or bottleneck before widening.
 
 Default creation flow for a fresh idea pass:
 
@@ -311,10 +412,20 @@ If durable quest memory already contains a recent and explicit survey, reuse it 
 For a normal selected-idea decision, the durable sweep must end with at least `5` and usually `5-10` papers that are close enough to the task-modeling problem, failure mode, mechanism, or codebase translation question to inform the actual design.
 This floor exists to prevent thin novelty claims and under-motivated ideas, not to reward quota chasing.
 
+Do not treat “recent papers” as a substitute for “the field history”.
+At minimum, map:
+
+- seminal or foundational papers
+- turning-point or paradigm-shift papers
+- current mainstream or SOTA papers
+
+Then use citation chaining to reconstruct how the question evolved and where the real breakpoints still are.
+
 When tools allow it, combine:
 
 - `memory.search(...)` and recent memory reads
-- web search for arXiv and adjacent sources
+- DeepXiv for broad paper-centric discovery and citation expansion when available
+- otherwise web search for arXiv and adjacent sources
 - `artifact.arxiv(paper_id=..., full_text=False)` for actually reading shortlisted papers
 - citation expansion or open-web search for follow-up papers, code, and comparisons
 
@@ -366,6 +477,8 @@ If the search is still too thin to support a novelty or value judgment, the idea
 
 The idea stage should usually leave behind:
 
+- an objective contract
+- a current board packet
 - a limitations analysis
 - a literature survey report
 - a survey-delta section that marks:
@@ -416,6 +529,9 @@ Recommended durable files:
 - `artifacts/idea/research_outline.md`
 
 When producing the literature survey report, prefer the structure in `references/literature-survey-template.md`.
+When writing the objective contract, prefer `references/objective-contract-template.md`.
+When writing the current board packet, prefer `references/current-board-packet-template.md`.
+When the route needs a bounded but real creative-divergence pass, prefer `references/controlled-brainstorming-playbook.md`.
 
 When producing a full research-outline style note, prefer the detailed structure in `references/research-outline-template.md`.
 

--- a/src/skills/idea/references/controlled-brainstorming-playbook.md
+++ b/src/skills/idea/references/controlled-brainstorming-playbook.md
@@ -1,0 +1,78 @@
+# Controlled Brainstorming Playbook
+
+Use this reference when the current route is not already obvious and `idea` needs a real divergence pass.
+
+The goal is not open-ended ideation.
+The goal is a bounded, differentiated slate that is broad enough to avoid premature convergence and narrow enough to remain auditable.
+
+## 1. Enter only after framing
+
+Before brainstorming, make sure both of these already exist:
+
+- an objective contract
+- a current board packet
+
+If either is still fuzzy, do not widen yet.
+
+## 2. Choose the family mix first
+
+Decide which route families are allowed in this pass:
+
+- `mechanism_family`
+  - new algorithmic or modeling idea
+- `objective_family`
+  - change the training target, ranking target, or optimization target
+- `measurement_family`
+  - change the evaluator, validation lens, or what is being trusted
+- `infrastructure_family`
+  - change throughput, batching, staging, or other system constraints that affect useful iteration
+
+Do not default to mechanism-family routes only.
+
+## 3. Generate a bounded slate
+
+Default target:
+
+- `6-12` raw ideas
+- collapse to a serious frontier of `2-3`, and at most `5`
+
+Require visible differentiation:
+
+- one local refinement of the incumbent
+- one orthogonal alternative
+- one route that changes the objective or measurement layer when that layer may be wrong
+- one infrastructure or iteration-speed route when throughput itself is blocking progress
+
+## 4. Filter aggressively
+
+Discard or downgrade candidates that:
+
+- only improve a surrogate without changing the real objective
+- violate hard constraints
+- are just within-family micro-variants
+- reopen stale routes without new evidence
+- have no cheap falsification path
+
+## 5. Force `why now`
+
+Every serious candidate must answer:
+
+- what changed?
+- why now?
+- why this family instead of the current mainline?
+
+If the answer is weak, the candidate should usually not survive.
+
+## 6. End with a structured selection
+
+The final serious candidates should each include:
+
+- family type
+- targeted limitation
+- why now
+- strongest prior-work overlap
+- anti-win condition
+- minimal validation
+- abandonment condition
+
+The selected route should beat the others on evidence-per-run, not just novelty theater.

--- a/src/skills/idea/references/current-board-packet-template.md
+++ b/src/skills/idea/references/current-board-packet-template.md
@@ -1,0 +1,61 @@
+# Current Board Packet Template
+
+Use this reference before widening the idea frontier.
+
+The goal is to compress all currently relevant durable state into one board surface so ideation does not continue from stale branches, stale narratives, or stale blockers.
+
+## Minimal fields
+
+- `incumbent`
+  - the current strongest line
+- `current_mainline`
+  - the route that should be treated as active now
+- `latest_decisive_result`
+  - the most recent result that actually changed route quality
+- `strongest_negative_evidence`
+  - the clearest recent reason the current line may be wrong or incomplete
+- `active_blocker`
+  - the current gating problem
+- `stale_routes_to_ignore`
+  - routes that should not be reopened by default
+- `next_decision_scope`
+  - what kind of choice ideation is actually making now
+- `budget_class`
+  - cheap-to-check vs expensive-to-check route class
+
+## Questions to answer
+
+1. What is the current mainline, really?
+2. Which result changed the route most recently?
+3. What is the strongest reason to distrust the current mainline?
+4. Which old routes should not be reopened unless new evidence appears?
+5. Is the next step about mechanism choice, objective correction, evaluator repair, or infrastructure?
+6. Is this a cheap-falsification pass or an expensive-validation pass?
+
+## Example shape
+
+```md
+# Current Board Packet
+
+- incumbent:
+  - current best durable line
+- current_mainline:
+  - the route that new candidates should be compared against
+- latest_decisive_result:
+  - the last result that changed route quality materially
+- strongest_negative_evidence:
+  - the strongest observed reason the current line may still be wrong
+- active_blocker:
+  - the specific thing preventing clean progress now
+- stale_routes_to_ignore:
+  - old routes that should not be reopened by default
+- next_decision_scope:
+  - mechanism / objective / measurement / infrastructure
+- budget_class:
+  - fast-check or slow-check
+```
+
+## Exit rule
+
+If this packet cannot be made coherent, do not widen the frontier yet.
+Route through `decision` or `intake-audit` first.

--- a/src/skills/idea/references/high-value-idea-sourcing.md
+++ b/src/skills/idea/references/high-value-idea-sourcing.md
@@ -1,0 +1,106 @@
+# High-Value Idea Sourcing
+
+Use this reference when the ideation pass is in danger of starting from a clever technique rather than an important contradiction.
+
+The goal is to find a route that is both worth doing and realistically testable, not just to swap one module for another.
+
+## 1. Start from the important contradiction
+
+Before asking "what mechanism should we add?", ask:
+
+- what core problem in this area is still unresolved?
+- why do existing methods still fail to solve it cleanly?
+- which observation, conflict, or failure case does the mainline still not explain?
+
+Prefer starting from one of these contradiction sources:
+
+- unexplained phenomenon
+  - a stylized fact, anomaly, or recurring pattern the current explanation does not fit
+- failure region
+  - a task, subgroup, regime, or deployment condition where the mainline reliably breaks
+- evaluation distortion
+  - benchmark scores look strong but real-world use or stronger diagnostics disagree
+- theoretical rupture
+  - the method works empirically, but the mechanism or theory remains weak or conflicting
+- neglected problem slice
+  - an important cross-domain, subgroup, condition, or setting is still thinly studied
+
+If the pass cannot name one important contradiction or bottleneck, do not start from a model swap.
+
+## 2. Decompose novelty
+
+Do not treat novelty as "never seen before".
+A serious idea may be novel because it offers:
+
+- a new problem definition
+- a new perspective or framing
+- a new mechanism
+- a new method
+- a new dataset or setting
+- a new evaluation lens
+- a new boundary condition
+
+When scoring candidates, explicitly label the dominant novelty source.
+If the novelty source cannot be named, the idea is usually weak or too vague.
+
+## 3. Use multiple idea-source methods
+
+Good candidate routes often come from one or more of these search lenses:
+
+- gap-driven
+  - what important thing is still uncovered or weakly evidenced?
+- anomaly-driven
+  - what keeps happening that the current explanation does not fit?
+- bottleneck-driven
+  - what single bottleneck most limits useful progress?
+- assumption-reversal
+  - which default field assumption might be wrong or too narrow?
+- cross-domain transfer
+  - what neighboring field solves the same structural problem differently?
+- writing-to-think
+  - what becomes obvious only after forcing a one-page problem definition and claim sketch?
+
+Do not rely on only one source lens, especially if it produces several same-family ideas.
+
+## 4. Ask mechanism questions early
+
+Depth usually comes from mechanism, not only effect size.
+Before promotion, force the candidate to answer:
+
+- why should this work?
+- for whom or under what condition should it work?
+- under what condition should it fail?
+- what mechanism is changing, rather than which surface metric is moving?
+
+Every serious candidate should make explicit:
+
+- core hypothesis
+- mechanism sketch
+- strongest falsification experiment
+
+If these remain fuzzy, the idea is not yet strong enough for promotion.
+
+## 5. Prefer ideas with failure value
+
+A strong idea is not only promising when positive.
+It should also still teach something if it fails.
+
+Ask:
+
+- if the route fails, will that eliminate a tempting but weak line?
+- will the failure teach us something about the bottleneck, mechanism, or evaluation?
+- is the failure interpretable, or would it only create noise?
+
+Low-information failure routes should be filtered out early.
+
+## 6. Use this as a pre-brainstorming check
+
+Before widening the frontier, make sure the active pass can answer:
+
+1. What is the important contradiction or bottleneck?
+2. Why is it important to the real objective?
+3. What kind of novelty is plausible here?
+4. What mechanism-level explanation is being proposed?
+5. What is the strongest falsification path?
+
+If these answers are weak, stay in problem definition and history search rather than generating a larger idea slate.

--- a/src/skills/idea/references/objective-contract-template.md
+++ b/src/skills/idea/references/objective-contract-template.md
@@ -1,0 +1,54 @@
+# Objective Contract Template
+
+Use this reference at the start of an `idea` pass whenever the real target might differ from the easiest available surrogate.
+
+The goal is to prevent ideation from drifting into "optimize what is measurable" when the real objective is narrower, more fragile, or more deployment-constrained.
+
+## Minimal fields
+
+- `primary_objective`
+  - the real target the next route should improve
+- `scoreboard_metric`
+  - the single metric or ranking surface the quest is actually judged by
+- `trusted_proxy_metrics`
+  - the proxies that are allowed to influence direction choice
+- `false_progress_signals`
+  - local improvements that must not be mistaken for route health
+- `hard_constraints`
+  - constraints that invalidate a route even if metrics improve
+
+## Questions to answer
+
+1. What metric or region of behavior actually matters most?
+2. Which proxies are trustworthy, and why?
+3. Which proxies are only convenience signals rather than real progress?
+4. What kind of apparent improvement would still count as failure?
+5. Which leakage, deployment, submission-time, or comparability constraints must remain inviolable?
+
+## Example shape
+
+```md
+# Objective Contract
+
+- primary_objective:
+  - Improve the real target metric, not just the easiest averaged surrogate.
+- scoreboard_metric:
+  - The metric or ranking surface that actually decides whether the route is better.
+- trusted_proxy_metrics:
+  - Proxy A because it tracks the head of the decision surface.
+  - Proxy B because it reflects the main deployment tradeoff.
+- false_progress_signals:
+  - Lower average loss without improvement on the real decision region.
+  - Better offline score using a feature that will not exist at deployment time.
+- hard_constraints:
+  - No submit-time unavailable features.
+  - No leakage-prone labels or post-hoc ranking information in training.
+```
+
+## Exit rule
+
+Do not widen the frontier until this contract is explicit enough to distinguish:
+
+- true progress
+- false progress
+- invalid routes

--- a/src/skills/idea/references/related-work-playbook.md
+++ b/src/skills/idea/references/related-work-playbook.md
@@ -2,6 +2,21 @@
 
 Use this reference during the `idea` stage when you need a deeper and more explicit process for literature scouting, novelty checking, and value judgment.
 
+For a broader history-aware search before final narrowing, also read `research-history-playbook.md`.
+
+## 0. Broad search policy
+
+Search should be broad enough to map the field and its history, not only to confirm the first attractive candidate.
+
+If DeepXiv is available under the runtime contract, prefer it for broad paper-centric discovery, citation expansion, and shortlist triage.
+If DeepXiv is unavailable, use search engines directly and keep the same breadth target:
+
+- recent papers
+- foundational papers
+- turning-point papers
+- citation chaining
+- adjacent-domain mechanism search
+
 ## 1. Search objective
 
 The goal is not to collect random citations.
@@ -41,6 +56,21 @@ Then search externally for the missing neighborhood:
 
 The goal is not to search the same cluster from zero every time.
 The goal is to reuse what the quest already knows and only spend new search budget on gaps, recency, or unresolved overlap.
+
+## 2.2 History-aware pass
+
+Before claiming novelty, identify:
+
+- seminal papers
+- paradigm-shift papers
+- current mainstream or SOTA papers
+
+Then use both:
+
+- backward citation chaining
+- forward citation chaining
+
+to reconstruct the problem lineage rather than only the current keyword cluster.
 
 ## 3. Coverage targets
 
@@ -89,6 +119,15 @@ Recommended columns:
 Before stopping, also leave behind a literature survey report.
 Prefer the structure in `literature-survey-template.md`.
 
+For harder cases, also keep a lineage-style table with:
+
+- research problem
+- core assumption or mechanism
+- method and data
+- main conclusion
+- explicit limitation
+- implicit limitation you detect
+
 ## 6. Novelty triage logic
 
 Ask these questions in order:
@@ -127,6 +166,8 @@ Watch for these traps:
 - mistaking recency for relevance
 - importing a concept from another domain without proving the translation makes sense here
 - treating a paper title match as evidence without checking dataset and metric overlap
+- reading only the last few years and mistaking recency for centrality
+- skipping citation chaining and therefore missing the evolution of the question itself
 
 ## 9. Exit condition
 

--- a/src/skills/idea/references/research-history-playbook.md
+++ b/src/skills/idea/references/research-history-playbook.md
@@ -1,0 +1,114 @@
+# Research History Playbook
+
+Use this reference when the `idea` stage needs broad, history-aware literature search rather than a shallow scan of the last few papers.
+
+The goal is to move from a field map to a lineage view and then to the real unresolved breakpoints.
+
+## 1. Build a field map first
+
+Before deep reading, map the landscape:
+
+- main problem
+- major subproblems
+- representative paradigms
+- common datasets and metrics
+- recurring disputes or failure modes
+
+For a broad topic, start with:
+
+- `3` strong reviews, tutorials, or surveys
+- about `10` recent representative papers
+- about `5` seminal or foundational papers
+
+Do not start with deep reading of one narrow recent cluster and mistake that for the field.
+
+## 2. Find the three paper roles
+
+For any serious direction, identify at least:
+
+- seminal or foundational papers
+- paradigm-shift or turning-point papers
+- current SOTA or mainstream papers
+
+Only reading recent papers makes it too easy to confuse "currently fashionable" with "structurally important".
+
+## 3. Use citation chaining aggressively
+
+History reconstruction should use both:
+
+- backward citation chaining
+  - what did the key paper cite?
+- forward citation chaining
+  - who later cited the key paper?
+
+Use citation chaining to answer:
+
+- how was the problem originally defined?
+- which assumptions survived over time?
+- which assumptions changed?
+- which assumptions were never seriously tested?
+
+If DeepXiv is available under the runtime contract, prefer it for broad paper-centric discovery, citation expansion, and shortlist triage.
+If DeepXiv is unavailable, use search engines, citation expansion, arXiv discovery, and open-web search directly.
+
+## 4. Keep a lineage table, not just paper titles
+
+For the strongest `20-40` papers in the active neighborhood, track at least:
+
+- paper
+- research problem
+- core assumption or mechanism
+- method and data
+- main conclusion
+- explicit limitation
+- implicit limitation you detect
+
+This table is often where the real idea appears:
+
+- overworked problems
+- default assumptions with weak evidence
+- conclusions tied to one narrow data regime
+- real gaps versus fake gaps
+
+## 5. Search broadly but with structure
+
+Use a broad search ladder:
+
+1. direct neighborhood
+   - same task, dataset, and metric
+2. failure-mode neighborhood
+   - same bottleneck, breakdown pattern, or contradiction
+3. mechanism neighborhood
+   - same core idea in the same or adjacent tasks
+4. cross-domain neighborhood
+   - structurally similar solutions from nearby fields
+
+Use DeepXiv when available for broad paper-centric discovery.
+If it is not available, use search engines directly and keep the same breadth target.
+
+Broad search does not mean random search.
+It means wide enough to expose the main paradigms, history, and unresolved contradictions before selecting a route.
+
+## 6. Distinguish review intents
+
+Use the right review style for the current need:
+
+- narrative review
+  - good for understanding and viewpoint formation
+- scoping review
+  - good for broad boundary mapping and gap discovery
+- systematic review
+  - good for tighter, reproducible evidence synthesis on a focused question
+
+The `idea` stage usually begins closer to field mapping and scoping, then narrows toward targeted comparison once the frontier becomes smaller.
+
+## 7. Stop when the breakpoints are clear
+
+The history pass is good enough when you can answer:
+
+- what the field now treats as the mainline
+- what its strongest assumptions are
+- where the main contradictions, blind spots, or failure regions remain
+- why the current candidate still matters despite the strongest nearby work
+
+If these are still unclear, do not rush into novelty claims.

--- a/src/skills/idea/references/selection-gate.md
+++ b/src/skills/idea/references/selection-gate.md
@@ -2,7 +2,33 @@
 
 Use this reference when choosing the final idea and preparing the handoff to `experiment`.
 
-## 1. Lightweight quality gate
+## 1. Value and feasibility screen
+
+Before promotion, score each serious candidate on a compact `1-5` scale:
+
+- importance
+- novelty
+- feasibility
+- verifiability
+- paper or report potential
+- failure value
+
+Also check the FINER-style screen explicitly:
+
+- `F`
+  - feasible with current data, compute, codebase, and schedule
+- `I`
+  - interesting enough that the field would care
+- `N`
+  - novel in a meaningful sense relative to the strongest nearby work
+- `E`
+  - ethically acceptable and not obviously high-risk
+- `R`
+  - relevant to an important bottleneck rather than a decorative tweak
+
+If the route scores poorly on both value and feasibility, do not promote it merely because it feels exciting.
+
+## 2. Lightweight quality gate
 
 Score the final serious candidate on a `0/1/2` scale:
 
@@ -34,7 +60,7 @@ Also treat these as hard gates before promotion:
 - the closest-prior-work comparison must explain why the idea is still needed
 - the final selected-idea draft must be ready to carry standard-format citations for the papers actually used
 
-## 2. Honest novelty / value labels
+## 3. Honest novelty / value labels
 
 Use these labels explicitly:
 
@@ -44,7 +70,23 @@ Use these labels explicitly:
 
 Only the first two are eligible for promotion.
 
-## 3. Handoff fields for experiment
+## 4. Mechanism and falsification gate
+
+Before a candidate can be promoted, it should make explicit:
+
+- core hypothesis
+- mechanism sketch
+- strongest falsification experiment
+
+The mechanism sketch can be brief, but it must answer:
+
+- why should this route work at all?
+- what part of the current limitation does it change?
+- for whom, where, or under what condition should it work or fail?
+
+If the mechanism sketch or strongest falsification experiment is still vague, the route is not yet ready.
+
+## 5. Handoff fields for experiment
 
 The selected idea record should include:
 
@@ -69,7 +111,7 @@ Inside the implementation handoff, also include:
 - `abandon_condition`
 - `strongest_alternative_hypothesis`
 
-## 4. Recommended presentation shape
+## 6. Recommended presentation shape
 
 Use a compact Pyramid structure:
 
@@ -78,7 +120,7 @@ Use a compact Pyramid structure:
 - then the minimal validation plan
 - then a short `References` or `Bibliography` section that cites the survey-stage papers actually used
 
-## 5. Promotion gate
+## 7. Promotion gate
 
 Do not promote a candidate if any of these remain unclear:
 

--- a/src/skills/intake-audit/SKILL.md
+++ b/src/skills/intake-audit/SKILL.md
@@ -41,6 +41,9 @@ Its purpose is to answer four questions before deeper work begins:
 3. what can be reused directly?
 4. which skill should take over next?
 
+In practice, `intake-audit` should usually leave behind one authoritative current-board surface.
+That board packet exists so later `decision`, `idea`, `experiment`, and `write` passes do not have to reconstruct the active mainline from several partially stale state sources.
+
 This skill exists because many quests do **not** start from a clean slate.
 Common non-blank starts include:
 
@@ -206,7 +209,24 @@ Then reconcile it with the durable artifact layer:
 
 If the evidence is insufficient for a durable backfill, record that insufficiency explicitly instead of inventing a cleaned-up history.
 
-### 5. Choose the next anchor
+### 5. Compile the current board packet
+
+Before choosing the next anchor, compress the intake result into one durable current-board packet.
+
+At minimum, make explicit:
+
+- `current_mainline`
+- `incumbent`
+- `latest_decisive_result`
+- `active_blocker`
+- `stale_routes_to_ignore`
+- `next_decision_scope`
+- `budget_class`
+
+The point is not to summarize everything.
+The point is to give the next skill one authoritative board surface instead of forcing it to merge branch state, memory, summaries, and artifacts again from scratch.
+
+### 6. Choose the next anchor
 
 After reconciliation, write one durable route decision with `artifact.record(payload={'kind': 'decision', ...})`.
 
@@ -219,7 +239,7 @@ Typical next anchors:
 - review package is active -> `rebuttal`
 - the quest is effectively complete or should pause -> `finalize`
 
-### 6. Report and hand off
+### 7. Report and hand off
 
 At the end of the intake pass, send one threaded `artifact.interact(kind='milestone', ...)` update that says:
 
@@ -231,6 +251,7 @@ At the end of the intake pass, send one threaded `artifact.interact(kind='milest
 ## Recommended durable outputs
 
 - `artifacts/intake/state_audit.md`
+- `artifacts/intake/current_board_packet.md`
 - `artifacts/intake/recommended_next_step.md`
 - one `decision` artifact for the post-audit route
 - one or more repair/backfill artifact calls when justified
@@ -282,6 +303,7 @@ When the audit concerns a specific existing line, include identifiers when known
 - the quest's current state is understandable
 - the trustworthy reusable assets are explicit
 - the untrusted gaps are explicit
+- the current board packet is explicit enough that a later skill can continue from one authoritative board surface
 - the next anchor is explicit
 - the system can continue without pretending the quest started from zero
 

--- a/src/skills/intake-audit/references/state-audit-template.md
+++ b/src/skills/intake-audit/references/state-audit-template.md
@@ -33,6 +33,16 @@
 - missing metric contract:
 - stale draft risk:
 
+## Current Board Packet
+
+- current_mainline:
+- incumbent:
+- latest_decisive_result:
+- active_blocker:
+- stale_routes_to_ignore:
+- next_decision_scope:
+- budget_class:
+
 ## Route Recommendation
 
 - next anchor:

--- a/src/skills/optimize/SKILL.md
+++ b/src/skills/optimize/SKILL.md
@@ -9,8 +9,77 @@ skill_role: stage
 Use this skill for algorithm-first quests where the goal is the strongest justified optimization result rather than paper packaging.
 The goal is to move the frontier by one justified step at a time, not to generate a large pile of low-information candidates.
 
-This skill is the lightweight optimization control layer for DeepScientist.
-It does not replace the normal quest runtime. It tells you how to use the existing DeepScientist artifact, memory, bash_exec, Git, and worktree mechanisms as an optimization system.
+## Match signals
+
+Use `optimize` when:
+
+- the quest is algorithm-first
+- the baseline gate is already confirmed or waived
+- the task has at least one plausible optimization direction
+- multiple candidate directions exist and the system should rank them before promotion
+- a durable line exists and the next step is to manage explore, exploit, fusion, debug, or stop
+
+Do not use `optimize` when:
+
+- the baseline gate is unresolved
+- the main need is a paper draft, rebuttal, review, or finalize task
+- the quest is still in broad literature scouting with no concrete optimization handle
+- the real blocker is still idea-family selection rather than bounded optimization search inside an accepted family
+
+## One-sentence summary
+
+Recover the current frontier, choose one optimize submode, advance one justified move, then record the new frontier or explicit stop condition.
+
+## Control workflow
+
+1. Recover the current frontier and recent durable optimization state.
+   Read the frontier, recent memory, and current quest state before creating or promoting anything.
+2. Choose exactly one primary optimize submode for this pass.
+   Keep the pass legible: one dominant optimize move, not several unrelated route changes.
+3. Keep the candidate slate or active pool small and differentiated.
+   If the direction is still fuzzy, shape and rank branchless candidate briefs; if a durable line already exists, manage a bounded implementation pool inside that line.
+4. Promote or execute only bounded candidates with explicit evidence criteria.
+   Promote only the strongest briefs into durable lines, and record implementation-level attempts separately from durable line creation.
+5. Route from evidence to exactly one dominant next action.
+   End in `explore`, `exploit`, `fusion`, `debug`, or `stop`, and record that route durably.
+
+## AVOID / pitfalls
+
+- Do not treat every patch or micro-attempt as a new durable idea line.
+- Do not create a new Git branch or worktree for every implementation-level candidate.
+- Do not promote every plausible brief.
+- Do not keep widening the frontier once a small serious slate already exists.
+- Do not let one optimize pass mix multiple major route changes.
+- Do not keep selecting the same familiar mechanism family after repeated non-improving results.
+- Do not drift into paper-outline, bundle, or finalize work by default while this stage is active.
+- Do not treat one candidate creation or one smoke pass as stage completion.
+
+## Constraints
+
+- Use these three object levels consistently:
+  - candidate brief
+  - durable optimization line
+  - implementation-level candidate attempt
+- Keep exactly one primary optimize submode active for the current meaningful pass.
+- Keep only one bottom-layer optimize move truly in progress at a time.
+- Before deciding the next route, call `artifact.get_optimization_frontier(...)` when available and use it as the primary optimization-state summary.
+- Candidate briefs should use `artifact.submit_idea(..., submission_mode='candidate')`.
+- Durable lines should use `artifact.submit_idea(..., submission_mode='line')`.
+- Implementation-level candidate attempts inside one durable line should use `artifact.record(... report_type='optimization_candidate' ...)`.
+- Real measured line results should use `artifact.record_main_experiment(...)`.
+- All terminal work in this stage must go through `bash_exec(...)`.
+
+## Validation
+
+Before `optimize` can end, all applicable checks should be true:
+
+- the frontier was refreshed
+- the active optimize submode is explicit
+- the candidate board and optimize checklist reflect the current state
+- promoted lines are justified and bounded
+- every live candidate has status and next action
+- every major success, failure, promotion, or route change is durably recorded
+- the pass ends with one durable next action or stop condition
 
 ## Interaction discipline
 
@@ -19,429 +88,25 @@ It does not replace the normal quest runtime. It tells you how to use the existi
 - Ordinary candidate creation, smoke checks, and route updates should stay concise.
 - Use richer milestone updates only when a candidate is promoted, a strong run finishes, the frontier shifts materially, or a fusion/debug route becomes the new main path.
 - When the user asks for the current optimization state, answer from the frontier and durable artifacts rather than from chat memory.
-- Hard execution rule: every terminal command in this stage must go through `bash_exec`; do not use any other terminal path for smoke checks, quick validations, long runs, Git, Python, package-manager, or file-inspection commands.
+- Every terminal command in this stage must go through `bash_exec`; do not use any other terminal path for smoke checks, quick validations, long runs, Git, Python, package-manager, or file-inspection commands.
 
-## Three-layer todo contract
-
-- keep quest-root `plan.md` as the research map and loop tracker for the whole quest
-- keep workspace `PLAN.md` as the active optimize-node contract
-- keep `OPTIMIZE_CHECKLIST.md` as the optimize-specific execution frontier and mirror the immediate next move into workspace `CHECKLIST.md` when that file exists
-- keep only one bottom-layer optimize move truly in progress at a time
-- if the frontier and checklist stop changing, revise the node contract or route instead of nesting more local tweaks
-
-## Research-map role
-
-- `optimize` is the looped search controller for algorithm-first quests, not a replacement for the quest-level roadmap
-- when a result becomes the new incumbent, plateaus, or stops, update quest-root `plan.md` so the next loop edge is explicit
-
-## Stage purpose
-
-The optimize stage should do four things:
-
-1. turn loose ideas into candidate briefs
-2. rank and promote only the strongest briefs into durable lines
-3. manage candidate attempts within a durable line
-4. choose when to explore, exploit, fuse, debug, or stop
-
-This skill is especially appropriate when `startup_contract.need_research_paper = false`.
-
-Treat `optimize` as one stable stage skill with six internal submodes:
-
-- `brief`
-- `rank`
-- `seed`
-- `loop`
-- `fusion`
-- `debug`
-
-Do not treat these as separate public skills.
-Treat them as internal execution modes inside one optimize workflow.
-
-InternAgent maps most naturally onto the `brief` and `rank` side of this stage.
-MLEvolve maps most naturally onto the `seed`, `loop`, `fusion`, and `debug` side of this stage.
-Do not collapse those two layers into one vague "optimize more" loop.
-
-## Required working files
+## Working surfaces
 
 Before broad optimization search or candidate management becomes substantial, maintain these quest-visible control files:
 
-- `OPTIMIZE_CHECKLIST.md`
-- `CANDIDATE_BOARD.md`
-
-Use:
-
-- the integrated `optimize checklist template` appendix section
-- the integrated `candidate board template` appendix section
-
-`OPTIMIZE_CHECKLIST.md` is the execution control surface.
-It should track:
-
-- current frontier mode
-- current optimize submode
-- candidate brief count
-- promoted line count
-- current smoke queue
-- current full-eval queue
-- stagnation / fusion checks
-- next concrete action
-
-`CANDIDATE_BOARD.md` is the compact candidate ledger.
-It should track:
-
-- candidate id
-- candidate type: brief or implementation attempt
-- parent line or parent candidate
-- strategy: explore / exploit / fusion / debug
-- status
-- expected gain
-- observed result
-- promote / archive recommendation
-
-## Required MCP-driven workflow
-
-Treat this as the concrete optimize workflow. Do not skip these steps just because the quest is algorithm-first.
-
-### 1. Recover the optimization state first
-
-At the start of each meaningful optimize pass, use this order unless a stronger local reason exists:
-
-1. `artifact.get_optimization_frontier(...)`
-2. `memory.list_recent(scope='quest', limit=5)`
-3. `memory.search(...)`
-4. `artifact.get_quest_state(detail='summary')`
-5. `artifact.read_quest_documents(...)` when exact durable wording matters
-
-Do not create new candidates before the frontier, recent optimization lessons, and current runtime refs are checked.
-If the frontier is missing or obviously stale, recover that state before proposing more work.
-
-### 2. Shape candidate briefs before branch promotion
-
-When the next direction is still fuzzy, do not jump straight into code or branch creation.
-First turn the direction into a compact candidate brief.
-
-The brief-shaping sequence is:
-
-1. clarify the bottleneck, constraints, and comparability boundary
-2. identify the incumbent or baseline that this brief must beat or complement
-3. generate a small differentiated slate, usually `2-3` serious approaches
-4. compare them on one shared surface
-5. recommend exactly one lead brief
-6. self-check the recommended brief before submission
-
-Every serious brief should answer:
-
-- bottleneck
-- why_current_line_is_limited
-- mechanism
-- why_now
-- keep_unchanged
-- expected_gain
-- implementation_surface
-- main_risks
-
-The durable call for this step is usually:
-
-- `artifact.submit_idea(mode='create', submission_mode='candidate', ...)`
-
-Use `idea` when the mechanism family itself is still unresolved.
-Use `optimize` when the family is already chosen and the work is now branchless brief shaping, ranking, or within-line search.
-
-### 3. Rank candidate briefs on one explicit surface
-
-Before promoting a line, compare the serious briefs on one shared ranking surface.
-At minimum evaluate:
-
-- expected information gain
-- feasibility in current repo
-- comparability against baseline
-- implementation surface
-- novelty or distinctiveness
-- family diversity
-- change-layer diversity
-- incumbent-improvement potential
-- failure risk
-
-Then state:
-
-- winner justification
-- non-winner defer / reject reasons
-- promotion cap: how many lines should actually be promoted now
-
-Do not promote every plausible brief.
-Default rule: promote only `1-3` candidate briefs, and usually fewer.
-
-The durable call for this step is one of:
-
-- `artifact.submit_idea(mode='create', submission_mode='line', source_candidate_id=..., ...)`
-- `artifact.record(payload={'kind': 'decision', 'action': 'branch'|'continue'|'stop', ...})`
-
-### 4. Hand off promoted lines into experiment cleanly
-
-Once a brief is promoted, the next main work belongs to `experiment`, not to vague optimize chatter.
-Before substantial implementation or compute:
-
-- activate or confirm the intended durable line
-- update `OPTIMIZE_CHECKLIST.md`
-- update `CANDIDATE_BOARD.md`
-- create or revise `PLAN.md`
-- create or revise `CHECKLIST.md`
-- define the smoke queue and full-eval queue explicitly
-
-Then hand off into `experiment` for:
-
-- one clean implementation pass
-- one bounded smoke or pilot run
-- one real measured main run
-
-Do not keep reshaping the method after the run contract is already concrete.
-
-### 5. Record every meaningful result durably
-
-Use these artifact forms consistently:
-
-- candidate brief:
-  - `artifact.submit_idea(..., submission_mode='candidate')`
-- durable optimization line:
-  - `artifact.submit_idea(..., submission_mode='line')`
-- implementation-level candidate attempt inside one line:
-  - `artifact.record(payload={'kind': 'report', 'report_type': 'optimization_candidate', ...})`
-- real measured main result:
-  - `artifact.record_main_experiment(...)`
-- route change after the result:
-  - `artifact.record(payload={'kind': 'decision', 'action': 'iterate'|'branch'|'continue'|'stop', ...})`
-
-Do not treat chat summaries as substitutes for these durable records.
-
-### 6. Manage process lifecycle explicitly
-
-Optimize uses the same long-run process discipline as `experiment`.
-
-- Use `bash_exec` for smoke checks, quick validations, and long runs.
-- Before launching a new run, inspect current managed sessions first.
-- Do not start a duplicate process for the same purpose if a valid live session already exists.
-- Use bounded smoke before long runs unless direct quick validation is already cheap and equally informative.
-- Use `bash_exec(mode='detach', ...)` for long runs and monitor with `list/read/await`.
-- Read logs before retrying a failed or suspicious run; do not relaunch blindly.
-- Kill only on explicit invalidity, supersession, or checked no-progress conditions.
-- After pause, resume, or daemon recovery, recover session state before spawning new runs.
-
-### 7. Route from evidence, not from momentum
-
-After every real measured result:
-
-1. refresh the frontier
-2. compare the result against the incumbent and backlog
-3. choose exactly one dominant next action:
-   - explore
-   - exploit
-   - fusion
-   - debug
-   - stop
-4. record that route durably
-
-Do not treat one candidate creation, one smoke pass, or one detached launch as stage completion.
-
-## Integrated templates and playbooks
-
-Use the following integrated structures directly inside this skill. They replace the old optimize reference files conceptually, even if those files still exist on disk.
-
-### Candidate brief template
-
-Every serious candidate brief should include:
-
-- title
-- bottleneck
-- why_current_line_is_limited
-- mechanism
-- mechanism_family
-- change_layer: `Tier1` / `Tier2` / `Tier3`
-- source_lens
-- keep_unchanged
-- expected_gain
-- implementation_surface
-- risks
-- foundation
-- promote_now
-- next_target
-
-### Brief-shaping playbook
-
-Use this when a candidate direction is still fuzzy and needs to become a ranking-ready brief.
-
-- clarify the concrete bottleneck before widening
-- resolve the evaluation or comparability boundary
-- identify the main hard constraint
-- identify the current incumbent
-- generate only a small differentiated slate
-- compare on one shared surface
-- recommend exactly one lead brief
-- self-check for ambiguity, overlap, and weak justification
-
-### Candidate ranking template
-
-When several briefs compete, produce:
-
-- candidate set
-- ranking scope
-- comparison surface
-- ranked candidates with score summary, why each ranks there, and promote / hold / reject
-- winner justification
-- non-winner notes
-- promotion cap
-
-### Candidate board template
-
-`CANDIDATE_BOARD.md` should expose at least these columns:
-
-- candidate id
-- level: `brief` or `implementation`
-- parent
-- strategy
-- status
-- expected gain
-- observed result
-- promote / archive recommendation
-
-### Optimize checklist template
-
-`OPTIMIZE_CHECKLIST.md` should track at least:
-
-- frontier has been refreshed
-- primary optimize submode chosen
-- current route mode chosen
-- recent optimization memory reviewed
-- brief slate checked for family diversity
-- candidate briefs updated or confirmed
-- candidate ranking updated
-- promotion decision made
-- current implementation pool recorded
-- smoke queue defined
-- full-eval queue defined
-- failures classified
-- stagnation check performed
-- fusion eligibility checked
-- next concrete action written
-
-### Frontier review template
-
-Whenever route choice is unclear, write down:
-
-- current frontier
-- evidence summary
-- route choice
-- active optimize submode
-- immediate next action
-
-### Code-generation route playbook
-
-Choose one route deliberately:
-
-- brief-only when the direction is still unclear
-- stepwise generation for first substantial implementation of a new line
-- diff / patch generation for improve / exploit / debug / most fusion work
-- full rewrite only when the current implementation is structurally broken or mismatched
-
-Do not jump to a rewrite merely because one local patch failed.
-
-### Debug response template
-
-When a candidate fails but still looks strategically valuable, record:
-
-- error
-- retrieved memory
-- root cause
-- minimal fix
-- keep unchanged
-- next check
-- archive threshold
-
-### Fusion playbook
-
-Before opening a fusion candidate, answer:
-
-- what exactly is being fused?
-- why are the source strengths complementary rather than redundant?
-- what remains unchanged for comparability?
-- what bounded evidence would prove the fusion worthwhile?
-- what bounded first validation step should run before any broad rollout?
-
-Do not fuse two weak lines or two same-mechanism lines under different names.
-
-### Optimization memory template
-
-When writing reusable optimization lessons, capture:
-
-- type
-- context
-- observation
-- why it matters
-- retrieval hint
-- reuse hint
-
-### Plateau response playbook
-
-If one line keeps producing non-improving results:
-
-1. state that the line is plateauing
-2. identify the most likely root cause
-3. choose one larger route change:
-   - widen search
-   - promote a stronger alternative
-   - fuse
-   - debug
-   - stop
-4. record one explicit non-repeat rule
-
-Do not hide plateau under a sequence of tiny "one more tweak" loops.
-
-### Prompt patterns worth preserving
-
-For candidate-brief, improve, fusion, and debug prompts, preserve:
-
-- introduction
-- task description
-- memory
-- previous solution or previous line
-- instructions
-- explicit response format
-
-Preserve these reasoning contracts whenever possible:
-
-- WHAT is changing?
-- WHY is the current line limited?
-- HOW should the change address the limitation?
-- KEEP UNCHANGED
-- NEXT ACTION
-
-## Non-negotiable rules
-
-- Do not treat every patch or micro-attempt as a new durable idea line.
-- Do not create a new Git branch/worktree for every implementation-level candidate.
-- Use `artifact.submit_idea(..., submission_mode='candidate')` for candidate briefs that should be ranked before promotion.
-- Use `artifact.submit_idea(..., submission_mode='line')` only for directions that deserve a durable optimization line and branch/worktree.
-- Use `artifact.record(payload={'kind': 'report', 'report_type': 'optimization_candidate', ...})` for implementation-level candidate attempts inside one durable line.
-- Before deciding the next route, call `artifact.get_optimization_frontier(...)` when available and use it as the primary optimization-state summary.
-- Keep all major optimization successes and failures durable through artifacts and memory.
-- Do not drift into paper-outline, bundle, or finalize work by default while this stage is active.
-- Do not convert ranking uncertainty into premature branch creation.
-- Do not treat an implementation-level candidate report as a new durable optimization line.
-- Do not keep widening the frontier once a small serious slate already exists.
-- Do not let one optimize pass mix multiple major route changes.
-  One pass may inspect several possibilities, but it should finish with one dominant next action.
-
-## When to use
-
-- the quest is algorithm-first
-- the baseline gate is already confirmed or waived
-- the task has at least one plausible optimization direction
-- multiple candidate directions exist and the system should rank them before promotion
-- a durable line exists and the next step is to manage explore / exploit / fuse / debug
-
-## Do not use when
-
-- the baseline gate is unresolved
-- the main need is a paper draft, rebuttal, or review task
-- the quest is still in broad literature scouting with no concrete optimization handle
+- quest-root `plan.md` as the research map and loop tracker for the whole quest
+- workspace `PLAN.md` as the active optimize-node contract
+- `OPTIMIZE_CHECKLIST.md` as the optimize-specific execution frontier
+- workspace `CHECKLIST.md` as a mirror of the immediate next move when it exists
+- `CANDIDATE_BOARD.md` as the compact candidate ledger
+
+Use these templates:
+
+- `references/optimize-checklist-template.md`
+- `references/candidate-board-template.md`
+
+`optimize` is the looped search controller for algorithm-first quests, not a replacement for the quest-level roadmap.
+When a result becomes the new incumbent, plateaus, or stops, update quest-root `plan.md` so the next loop edge is explicit.
 
 ## Core object model
 
@@ -449,230 +114,40 @@ Use these three object levels consistently:
 
 1. candidate brief
    `artifact.submit_idea(mode='create', submission_mode='candidate', ...)`
-   This records a possible direction or method brief without opening a branch yet.
-
+   Record a possible direction or method brief without opening a branch yet.
 2. durable optimization line
    `artifact.submit_idea(mode='create', submission_mode='line', ...)`
-   This opens a real branch/worktree and becomes a formal optimization path.
-
+   Open a real branch or worktree and make it a formal optimization path.
 3. implementation-level candidate attempt
    `artifact.record(payload={'kind': 'report', 'report_type': 'optimization_candidate', ...})`
-   This is a within-line attempt such as one patch, one smoke candidate, one debug candidate, or one fusion candidate.
+   Record one within-line attempt such as one patch, one smoke candidate, one debug candidate, or one fusion candidate.
 
-## Recommended workflow
+## Optimize submodes
 
-1. Read the current frontier and recent durable state.
-2. If only loose candidate directions exist, create or refine candidate briefs first.
-3. Rank the candidate briefs and promote only the best `1-3` into durable lines.
-4. Inside a durable line, generate a small candidate pool, then run bounded smoke checks before full evaluations.
-5. Record each implementation-level attempt durably with status, change plan, and result.
-6. After each real result, decide whether to explore, exploit, fuse, debug, or stop.
-7. Write optimization lessons to memory before leaving the stage.
+Treat `optimize` as one stable stage skill with six internal submodes:
 
-At the start of each meaningful optimize pass, update `OPTIMIZE_CHECKLIST.md` before spending significant code or compute.
+- `brief`: turn loose directions into compact candidate briefs
+- `rank`: compare briefs on one shared surface and choose promotion candidates
+- `seed`: create a small implementation-level pool inside one durable line
+- `loop`: advance one durable line with bounded smoke/full-eval/record actions
+- `fusion`: combine complementary strengths from multiple lines
+- `debug`: rescue a strategically valuable candidate blocked by a concrete failure mode
 
-## Mandatory first-call sequence
-
-At the start of a meaningful optimize pass, use this order unless a stronger local reason exists:
-
-1. `artifact.get_optimization_frontier(...)`
-2. `memory.search(...)`
-3. `artifact.get_quest_state(detail='summary')`
-4. `artifact.read_quest_documents(...)` when exact durable wording matters
-
-Do not start generating new candidates before the frontier and recent optimization lessons are checked.
-
-## Stage-start requirement
-
-Stage-start requirement:
-
-- run `memory.list_recent(scope='quest', limit=5)`
-- run at least one `memory.search(...)`
-- read `artifact.get_optimization_frontier(...)`
-- update `OPTIMIZE_CHECKLIST.md`
-
-If the frontier is missing or obviously stale, recover that state before proposing more work.
-
-## Internal submode selection
-
-Choose exactly one primary optimize submode for the current meaningful pass.
+Do not treat these as separate public skills.
+Treat them as internal execution modes inside one optimize workflow.
 
 Default selection order:
 
-1. `fusion`
-   - when the frontier explicitly says `fusion`
-2. `debug`
-   - when a strategically valuable candidate failed for a concrete and likely fixable reason
-3. `rank`
-   - when several candidate briefs already exist and promotion is the main unresolved question
-4. `brief`
-   - when the candidate-brief slate is too thin or too weak
-5. `seed`
-   - when a durable line exists but there is no live implementation-candidate pool
-6. `loop`
-   - when a live candidate pool or leading durable line already exists and the main need is bounded execution progress
+1. `fusion` when the frontier explicitly says `fusion`
+2. `debug` when a strategically valuable candidate failed for a concrete and likely fixable reason
+3. `rank` when several candidate briefs already exist and promotion is the main unresolved question
+4. `brief` when the candidate-brief slate is too thin or too weak
+5. `seed` when a durable line exists but there is no live implementation-candidate pool
+6. `loop` when a live candidate pool or leading durable line already exists and the main need is bounded execution progress
 
-Do not bounce among submodes repeatedly in one pass.
-If the best submode changes after new evidence appears, record that route shift explicitly.
+## Frontier route meanings
 
-## Candidate brief protocol
-
-When a direction is interesting but not yet worthy of a new branch:
-
-- create a candidate brief with `submission_mode='candidate'`
-- keep it branchless
-- record enough structure that later ranking or promotion is possible
-
-Good candidate-brief fields include:
-
-- title
-- problem
-- hypothesis
-- mechanism
-- mechanism_family
-- change_layer
-- source_lens
-- expected_gain
-- risks
-- decision_reason
-- foundation_ref
-- lineage_intent
-
-Do not promote every candidate automatically.
-
-Use the integrated `method brief template` section for the minimum acceptable candidate-brief structure.
-Use the integrated `brief shaping playbook` section when the brief is still too vague, too implementation-first, or too collapsed onto one familiar mechanism.
-
-Candidate briefs should explicitly answer:
-
-- WHAT bottleneck is being targeted?
-- WHY is the current line limited?
-- HOW does this mechanism address the limitation?
-- WHAT must remain unchanged for comparability?
-
-If the brief cannot answer those four questions clearly, it is not ready for promotion or implementation.
-
-Treat a candidate brief as the DeepScientist form of a method brief.
-It should sit between "idea intuition" and "code implementation".
-
-Preserve this brief-shaping discipline:
-
-1. clarify the bottleneck, constraints, and comparability boundary first
-2. generate a small differentiated slate, usually `2-3` serious approaches
-3. recommend one approach with explicit tradeoffs against the alternatives
-4. self-check the winning brief for ambiguity, overlap, and weak justification before submission
-
-Do not jump from "interesting intuition" to branch creation.
-Do not jump from "I know how to code this" to "this deserves promotion."
-
-When running the `brief` submode:
-
-- produce only `2-4` serious candidate briefs by default
-- ask or answer the minimum clarifying questions needed to remove ambiguity around bottleneck, constraint fit, and comparability
-- explicitly keep one incumbent-compatible refinement when possible
-- explicitly keep one orthogonal alternative when possible
-- explicitly keep one broader lens or paradigm shift candidate when possible
-- avoid generating several renamed variants of the same mechanism
-- prefer mechanism-level distinctness over volume
-- present the differentiated slate on one shared comparison surface before choosing a recommended brief
-- keep the questioning bounded and execution-oriented rather than open-ended brainstorming
-
-Use a coverage contract for every serious brief slate:
-
-- one `incumbent-deepening` direction when justified
-- one `orthogonal-mechanism` direction when justified
-- one `paradigm/objective/data-view shift` direction when justified
-
-If all serious briefs belong to the same mechanism family, do one widening pass before ranking.
-Do not treat a same-family slate as sufficient merely because the local scores look good.
-
-For each serious brief, record at least:
-
-- bottleneck
-- why_current_line_is_limited
-- mechanism
-- why_now
-- mechanism_family
-- change_layer: `Tier1` / `Tier2` / `Tier3`
-- source_lens
-- keep_unchanged
-- expected_gain
-- implementation_surface
-- main_risks
-- promote_now: yes or no
-
-InternAgent-style behavior to preserve here:
-
-- generate candidate methods first
-- critique them before promotion
-- express them as method-layer objects rather than code patches
-- defer branch creation until the candidate is actually chosen
-- prefer one-question-at-a-time clarification when one missing assumption would otherwise contaminate the whole brief slate
-
-Do not require a paper-style literature hard gate inside this submode unless the quest explicitly moved back toward paper work.
-
-## Promotion protocol
-
-Only promote a candidate brief into a durable line when at least one of the following is true:
-
-- it clearly dominates the nearby alternatives
-- it is top-ranked and sufficiently distinct
-- the user explicitly asked to pursue it
-- the current frontier indicates the line is the strongest next move
-
-Promotion should use:
-
-`artifact.submit_idea(mode='create', submission_mode='line', source_candidate_id=..., ...)`
-
-When several candidate briefs are plausible, rank them explicitly before promotion.
-Use the integrated `candidate ranking template` section for the minimum acceptable ranking record.
-
-Default promotion rule:
-
-- promote only `1-3` candidate briefs into durable lines
-- if one candidate clearly dominates, promote only that one
-- if the frontier is still structurally uncertain, promote at most two sufficiently distinct lines
-
-When running the `rank` submode:
-
-- compare the current serious briefs on one explicit shared surface
-- score or rank them with written reasons
-- state why the winner is better now
-- state why the main alternatives are deferred rather than erased
-- never treat "all seem promising" as a sufficient reason to promote them all
-
-Use a distinct promotion policy:
-
-- default rule: each mechanism family should contribute at most one promoted line
-- do not let one familiar family fill the whole promoted slate
-- only override that family cap when one candidate clearly dominates the whole field
-
-When ranking, explicitly check:
-
-- family diversity
-- change-layer diversity
-- whether the brief slate is collapsing into one familiar lens
-
-If the top briefs are all same-family, either:
-
-- keep only the strongest one
-- or return to `brief` for a widening pass
-
-The output of `rank` should be promotion-ready.
-The output of `brief` should be candidate-ready.
-
-## Frontier protocol
-
-At meaningful route boundaries, inspect:
-
-- best branch
-- best recent run
-- stagnant branches
-- candidate backlog
-- possible fusion opportunities
-- recommended mode
-
-Prefer these route meanings:
+At meaningful route boundaries, choose exactly one dominant route meaning:
 
 - `explore`: widen search with fresh candidate directions
 - `exploit`: focus on the strongest current line
@@ -680,982 +155,55 @@ Prefer these route meanings:
 - `debug`: rescue a candidate or line blocked by a concrete failure mode
 - `stop`: the current frontier is saturated or the remaining routes are not justified
 
-Use the integrated `frontier review template` section when the next route is unclear.
-
-Interpret frontier state with these default heuristics:
-
-- `explore`
-  - use when no line is clearly dominant
-  - use when current lines are too similar
-  - use when the search has not yet established a strong incumbent
-
-- `exploit`
-  - use when one line clearly leads on evidence and comparability
-  - use when smoke results already narrowed the candidate pool
-
-- `fusion`
-  - use when at least two lines have meaningful strengths
-  - use when one line is strong but another line contributes a complementary mechanism
-  - use when the current incumbent is stagnating but the broader frontier is still promising
-
-- `debug`
-  - use when a candidate failed for a concrete and likely fixable reason
-  - use when the candidate is still strategically valuable after the failure
-
-- `stop`
-  - use when the frontier is saturated
-  - use when remaining routes are low-value, redundant, or too weak relative to cost
-
-When the frontier says `explore`, the default optimize submode is `brief`.
-When the frontier says `exploit`, the default optimize submode is `seed` or `loop`.
-When the frontier says `fusion`, the default optimize submode is `fusion`.
-When a candidate failure dominates the next move, the default optimize submode is `debug` even if the frontier does not yet say so explicitly.
-
-## Seed protocol
-
-Use `seed` after a durable line exists and before a broad execution loop begins.
-
-The goal is not to launch a full run immediately.
-The goal is to generate a small within-line candidate pool that can be smoke-tested and triaged.
-
-When running `seed`:
-
-- generate only `2-3` implementation-level candidates by default
-- make each candidate meaningfully different in mechanism, implementation path, or risk profile
-- prefer plan-first candidates over immediate large edits
-- record each candidate as `report_type='optimization_candidate'`
-- define which candidates enter smoke first
-- for a newly promoted line, keep at least one `simple-first` candidate in the initial seed batch
-- do not start a fresh line with ensemble stacking, broad HPO, or a heavy multi-stage pipeline unless durable evidence already proves the simple route is insufficient
-
-For each seed candidate, record at least:
-
-- candidate_id
-- parent line
-- strategy
-- mechanism_family
-- change_layer
-- change_plan
-- expected_gain
-- keep_unchanged
-- first validation step
-- archive condition
-
-MLEvolve-style behavior to preserve here:
-
-- one durable line may produce multiple candidate attempts
-- candidate generation is bounded
-- smoke comes before full evaluation unless the task is explicitly `fast-check` and direct quick validation is cheaper and equally informative
-
-Use a validation-cost-aware seed policy:
-
-- `fast-check`: the first objective smoke signal is likely under about `20` minutes
-- `slow-check`: the first objective smoke signal is likely over about `20` minutes or expensive enough that broad probing is wasteful
-
-For `fast-check` seed work:
-
-- widen a bit more aggressively inside the line
-- a seed batch of `3-5` candidates can be justified when they are genuinely differentiated
-- prefer multiple orthogonal quick tests over one over-discussed candidate
-- a separate smoke stage is optional; direct submission into quick parallel validation is acceptable when the first check is already cheap
-- only skip smoke when the parallel quick validations are expected to produce distinguishable conclusions rather than repeated near-duplicate outcomes
-
-For `slow-check` seed work:
-
-- keep the initial seed batch tighter, usually `1-2` candidates and rarely `3`
-- insist on a stronger reason for every candidate entering smoke
-- prefer one dominant hypothesis plus one hedge candidate over a broad exploratory pool
-- do not spend long runs to discover that the brief itself was weak
-
-Do not keep a live implementation pool dominated by the same mechanism family.
-Default active-pool rule:
-
-- at most `1-2` live candidates from the same family
-- if one family already fills the live pool, new same-family candidates do not enter smoke by default
-
-## Loop protocol
-
-Use `loop` when a durable line and implementation-candidate pool already exist and the main need is bounded forward motion.
-
-Before changing code in `loop`, inspect the same-line local attempt memory for the current line.
-Treat recent sibling attempts on the same line as the first memory surface, ahead of broader quest memory.
-
-When running `loop`, choose one primary action:
-
-- `smoke`
-- `promote_to_full_eval`
-- `archive`
-- `record_main_result`
-- `switch_to_fusion`
-- `switch_to_debug`
-- `stop`
-
-Every loop pass should end with:
-
-- one updated candidate status
-- one updated next action
-- one frontier review trigger
-
-Do not leave the line with several half-started directions and no dominant next move.
-
-Default exploit rule: one atomic improvement per pass.
-Do not bundle several unrelated changes into one exploit candidate unless:
-
-- the changes are one tightly coupled design package
-- or the pass is explicitly a fusion route
-
-MLEvolve-style behavior to preserve here:
-
-- bounded parallelism
-- small live candidate pool
-- explicit move from draft -> smoke -> full eval -> archive or result
-- measured frontier review after real evidence
-
-Use a validation-cost-aware loop policy:
-
-- for `fast-check` tasks, it is acceptable to run more quick, different tests before converging
-- for `fast-check` tasks, direct quick validation may replace a separate smoke stage if that saves time without losing decision quality
-- for `slow-check` tasks, use fewer but sharper passes, and require objective gain before widening or evolving further
-- if the validation loop is slow, do not keep paying for frontier uncertainty that could have been reduced in `brief`
-- if the validation loop is fast, prefer resolving uncertainty with evidence instead of over-arguing in chat
-
-Use a branch/family diversity cap during exploitation:
-
-- do not keep selecting only the locally familiar family because it is easiest to elaborate
-- when several strong candidates are close, prefer the one that preserves frontier diversity
-- if one branch or family already dominates recent attempts, require stronger evidence before selecting another near-duplicate attempt
-
-## Memory protocol
-
-Before broad new search, run at least one `memory.search(...)` using:
-
-- the current task name
-- the active idea id
-- a method keyword
-- the most recent failure mode or successful mechanism
-
-When the search appears too narrow, also retrieve one of:
-
-- a similar failure pattern
-- an orthogonal success pattern
-- a deliberately dissimilar but high-value prior attempt
-
-For `seed`, `loop`, and `debug`, also inspect the same-line local attempt memory from the current leading line before widening to broader quest memory.
-
-Write at least one quest memory card when you learn something reusable, such as:
-
-- a successful optimization pattern
-- a repeated failure pattern
-- a fusion lesson
-- a reason a candidate should not be retried
-
-Use the integrated `optimization memory template` section for the minimum acceptable memory-card shape.
-
-Do not write generic "we tried some optimization" memory cards.
-Each card should be retrieval-friendly and decision-relevant.
-
-## Artifact protocol
-
-Use:
-
-- `artifact.submit_idea(..., submission_mode='candidate')` for candidate briefs
-- `artifact.submit_idea(..., submission_mode='line')` for durable promoted lines
-- `artifact.record(payload={'kind': 'report', 'report_type': 'optimization_candidate', ...})` for within-line attempts
-- `artifact.record(payload={'kind': 'decision', 'action': 'iterate'|'branch'|'continue'|'stop', ...})` for route changes
-- `artifact.record_main_experiment(...)` for real measured line results
-
-When the optimize pass is about ranking or promotion, also record one durable decision explaining:
-
-- which briefs were compared
-- which one won
-- why promotion was justified now
-- why the others were held, fused, or rejected
-
-When recording implementation-level candidates, prefer these status values:
-
-- `proposed`
-- `smoke_running`
-- `smoke_passed`
-- `smoke_failed`
-- `promoted`
-- `full_eval_running`
-- `succeeded`
-- `failed`
-- `archived`
-
-Use `report_type='optimization_candidate'` consistently for implementation-level attempts so they can later be summarized into the frontier.
-
-## Execution protocol
-
-- Use `bash_exec` for smoke checks and full runs.
-- Prefer bounded smoke before full evaluation unless `fast-check` direct validation is cheaper and equally informative.
-- Do not keep rerunning the same unchanged candidate.
-- If a candidate fails with a clear root cause, either debug it deliberately or archive it.
-- If the same line stalls repeatedly, switch to exploit or fusion rather than pretending more of the same is new evidence.
-
-Use this execution order by default:
-
-1. candidate brief selection
-2. implementation-level candidate generation
-3. smoke test or direct quick validation
-4. promotion to fuller evaluation when justified
-5. durable result recording
-6. frontier review
-
-Prefer only a small active pool at once:
-
-- usually `2-4` candidate briefs before promotion
-- usually `2-3` live implementation candidates in smoke
-- usually `1-2` full evaluations running at once unless the environment clearly supports more
-
-Validation-cost-aware override:
-
-- if first-pass validation is under about `20` minutes, it is reasonable to increase smoke breadth modestly and compare more alternatives early
-- if first-pass validation is under about `20` minutes, you may skip a separate smoke stage and submit several quick validations in parallel
-- only do that when the validations are likely to yield different conclusions such as clear win / tie / fail / instability, rather than redundant repeats
-- if first-pass validation is slower than that, keep the active pool narrow and gate evolution on clear objective signal
-- for slow validation, do not promote a candidate into heavier resource investment until smoke or pilot evidence shows a real performance improvement, stability improvement, or comparability-preserving advantage
-
-## Code-generation route selection
-
-Do not use the same code-generation route for every optimization step.
-
-Prefer:
-
-1. brief-first, no code yet
-   - when the direction is still unclear
-   - stay at candidate-brief level
-
-2. stepwise generation
-   - for the first substantial implementation of a new durable line
-   - especially when the line touches multiple subsystems such as data processing, model design, and training/evaluation
-
-3. diff / patch generation
-   - when a strong current implementation already exists
-   - for improve, exploit, debug, and most fusion work
-
-4. full rewrite
-   - only when the current implementation is too broken or too structurally mismatched for diff patching to remain safe
-
-Use the integrated `codegen route playbook` section before committing to a larger rewrite.
-
-## Debug protocol
-
-Use `debug` when a candidate failed but still looks strategically valuable.
-
-`debug` is bugfix-only.
-Do not use a debug pass to sneak in a new performance-improvement idea.
-If the proposed change goes beyond the minimal fix and becomes a new mechanism, stop and route back to `brief` or `loop` instead.
-
-When a candidate fails:
-
-- classify whether the failure is structural, local, or environmental
-- retrieve similar failure patterns from memory before changing code
-- prefer targeted fixes over broad rewrites
-- define the exact post-fix bounded check before editing
-
-Good debug prompts should make these explicit:
-
-- the concrete error
-- the likely root cause
-- the minimal fix
-- what must remain unchanged
-
-Use the integrated `debug response template` section for the minimum acceptable debug response shape.
-
-Archive rather than debug when:
-
-- the failure is mostly strategic rather than local
-- the candidate no longer looks better than the nearby alternatives
-- the fix would effectively turn it into a different candidate anyway
-
-## Fusion protocol
-
-Use `fusion` only when the frontier justifies cross-line combination.
-
-Before opening a fusion candidate:
-
-- identify the real strength of each source line
-- identify the real weakness of each source line
-- explain why the strengths are complementary rather than redundant
-- define what remains unchanged for comparability
-- define the bounded evidence that would prove the fusion was worthwhile
-
-Use the integrated `fusion playbook` section before launching cross-line fusion.
-
-Do not fuse:
-
-- two lines with the same mechanism under different names
-- two weak lines that lack a clear strength
-- merely because multiple branches exist
-
-If the fusion hypothesis is still underspecified, return to `brief` instead of pretending fusion is ready.
-
-## Prompt patterns worth preserving
-
-For candidate-brief, improve, fusion, and debug prompts, preserve these recurring structures:
-
-- Introduction
-- Task description
-- Memory
-- Previous solution or previous line
-- Instructions
-- assistant_prefix when a stable response lead-in reduces drift
-- explicit response format
-
-And preserve these recurring reasoning contracts:
-
-- root cause first
-- WHAT / WHY / HOW
-- KEEP UNCHANGED
-- explicit next action
-
-Use the integrated `prompt patterns` section as the canonical optimization prompt crib sheet.
-
-## Plateau and fusion protocol
-
-Treat repeated local edits without evidence gain as a search failure mode.
-
-If one line shows repeated non-improving results:
-
-- stop issuing near-duplicate attempts
-- record the stagnation explicitly
-- either widen the search or fuse with another line
-
-Use the integrated `fusion playbook` section before launching cross-line fusion.
-Use the integrated `plateau response playbook` section when deciding how to respond to repeated non-improving results.
-
-Good fusion candidates usually satisfy both:
-
-- each source line has at least one real strength
-- the strengths are complementary rather than redundant
-
-Do not fuse merely because two lines both exist.
-
-When a line plateaus:
-
-- stop issuing near-duplicate low-information attempts
-- say explicitly that the line is plateauing
-- force one larger route change:
-  - widen the brief slate
-  - promote a stronger alternative
-  - fuse
-  - debug one blocked but valuable candidate
-  - stop
-
-Do not hide plateau under a sequence of tiny "one more tweak" loops.
-
-Family-shift trigger:
-
-- if recent attempts stay inside one mechanism family and there is no meaningful improvement
-- or if `success_patience >= 2`
-- or if `total_patience >= 5`
-- the next pass must not be another same-family Tier1 tweak
-- instead choose one of:
-  - orthogonal family
-  - Tier2 or Tier3 shift
-  - fusion
-  - stop
-
-This is the default anti-collapse rule for optimize.
-
-## Task-category primer
-
-Before widening a stale frontier, classify the task briefly into one or more dominant structures:
-
-- tabular
-- vision / spatial
-- sequence / language
-- graph / topology
-- systems / optimization
-- mixed
-
-Then ask whether the current brief slate overfits one familiar method family for that task.
-If it does, require at least one serious candidate from a different plausible family or lens before promotion.
-
-## Stall-recovery protocol
-
-If the optimize stage appears to stall, diagnose the stall explicitly instead of idling.
-
-Common stall classes:
-
-- no frontier information
-- no candidate clearly worth promotion
-- candidate pool is too similar
-- repeated failures on one line
-- no active runs and no next action recorded
-
-Preferred recovery order:
-
-1. refresh the frontier
-2. inspect the current candidate board
-3. inspect recent optimization memory
-4. record one explicit route decision
-5. continue with exactly one concrete next action
-
-Do not leave the stage parked without a recorded reason and a concrete reopen condition.
-
-## Stage-end requirement
-
-Stage-end requirement:
-
-- write at least one `memory.write(...)` when the pass produced a reusable success pattern, repeated failure pattern, fusion lesson, or explicit non-retry rule
-- update `OPTIMIZE_CHECKLIST.md`
-- update `CANDIDATE_BOARD.md` when the candidate pool changed
-- leave one durable next action or stop condition
-
-If nothing reusable was learned, record why this pass was still necessary instead of writing a fake memory card.
-
-## Completion rule
-
-This stage is complete only when one of these is durably true:
+Default heuristics:
+
+- choose `explore` when no line is clearly dominant or the current lines are too similar
+- choose `exploit` when one line clearly leads on evidence and comparability
+- choose `fusion` when at least two lines have meaningful complementary strengths
+- choose `debug` when a strategically valuable candidate failed for a concrete and likely fixable reason
+- choose `stop` when the frontier is saturated or the remaining routes are low-value relative to cost
+
+## Non-negotiable rules
+
+- Keep all major optimization successes and failures durable through artifacts and memory.
+- Do not convert ranking uncertainty into premature branch creation.
+- Do not treat an implementation-level candidate report as a new durable optimization line.
+- Before broad new search, inspect recent optimization memory and the same-line local attempt memory when relevant.
+- If the same line stalls repeatedly, switch route instead of pretending more of the same is new evidence.
+- Plateau is a route signal, not a reason to keep issuing tiny tweaks.
+
+## Operational guidance
+
+The main skill keeps the control surface in front.
+For the longer playbooks, templates, and protocol details, read the references:
+
+- `references/operational-guidance.md`
+- `references/brief-shaping-playbook.md`
+- `references/candidate-ranking-template.md`
+- `references/frontier-review-template.md`
+- `references/method-brief-template.md`
+- `references/codegen-route-playbook.md`
+- `references/debug-response-template.md`
+- `references/fusion-playbook.md`
+- `references/optimization-memory-template.md`
+- `references/optimize-checklist-template.md`
+- `references/plateau-response-playbook.md`
+- `references/prompt-patterns.md`
+
+Use them when:
+
+- the candidate brief is still fuzzy
+- explicit ranking or promotion notes are needed
+- the frontier route is unclear
+- implementation-route choice, debug, fusion, or plateau handling needs the full playbook
+- memory writing, checklist maintenance, or prompt shaping materially affect the route
+
+## Exit criteria
+
+Exit `optimize` only when one of these is durably true:
 
 - a stronger line was promoted and the next anchor is clear
 - the current line produced a real measured result and the next route is recorded
 - the optimization frontier says stop and that stop decision is durably recorded
 
 Do not treat one candidate creation or one smoke pass as stage completion.
-
-## Integrated reference appendix
-
-This appendix inlines the former `optimize/references/*.md` material so the skill remains self-contained.
-
-### brief-shaping-playbook.md
-
-# Brief Shaping Playbook
-
-Use this reference when a candidate direction is still fuzzy and needs to become a structured, ranking-ready brief.
-
-This playbook borrows the useful part of product-style brainstorming without importing a full software-spec workflow.
-The goal is not a long design document.
-The goal is a compact candidate brief that is clear enough to compare, rank, and either submit as `submission_mode='candidate'` or reject.
-
-## 1. Clarify before widening
-
-Before generating more variants, resolve the minimum ambiguity around:
-
-- the concrete bottleneck
-- the evaluation or comparability boundary
-- the main hard constraint: data, metric, compute, latency, memory, interface, or training budget
-- the current incumbent or baseline that this brief must beat or complement
-
-If one unknown would materially change every candidate, clarify it first instead of generating a noisy slate.
-Prefer one question at a time when clarification is genuinely needed.
-If the answer is already available from durable state, use that instead of asking.
-
-## 2. Generate a small differentiated slate
-
-Default target: `2-3` serious approaches.
-
-The slate should usually include:
-
-- one incumbent-deepening refinement
-- one orthogonal mechanism
-- one broader shift candidate when justified
-
-Do not produce several renamed variants of the same mechanism family.
-If two variants differ only by parameter choice or patch detail, keep only the sharper one.
-
-For each candidate, write:
-
-- bottleneck
-- why_current_line_is_limited
-- mechanism
-- why_now
-- keep_unchanged
-- expected_gain
-- main_risks
-
-## 3. Compare on one shared surface
-
-Before recommending a winner, compare the serious candidates on the same dimensions:
-
-- expected upside
-- comparability safety
-- implementation surface
-- mechanism distinctness
-- failure risk
-- reason this route is better now than the nearby alternatives
-
-Do not let each candidate justify itself with a different scoring story.
-Use one comparison surface so ranking is auditable.
-
-## 4. Recommend exactly one lead brief
-
-After comparison, recommend one lead brief and explain:
-
-- why it is the best next move now
-- why the main alternatives are deferred instead of promoted
-- what evidence would quickly disconfirm the lead brief
-
-Do not say "all are promising" and promote everything.
-If the slate is still too close to call, return to widening once or narrow the slate further.
-
-## 5. Self-check before submission
-
-Before calling `artifact.submit_idea(..., submission_mode='candidate', ...)`, check:
-
-- Is the bottleneck concrete rather than generic?
-- Does `why_current_line_is_limited` explain a real gap instead of restating the mechanism?
-- Does `why_now` explain what changed in evidence, failure pattern, or frontier state?
-- Is the comparability boundary explicit?
-- Is the recommendation based on tradeoffs rather than implementation convenience?
-- Would the brief still make sense if handed to another agent with no chat context?
-
-If any answer is no, refine the brief before submission.
-
-## 6. Output shape
-
-A good final brief package is short and structured:
-
-1. brief title
-2. one-paragraph bottleneck and constraint summary
-3. a `2-3` candidate comparison table or bullet slate
-4. recommended brief with tradeoff summary
-5. self-check outcome
-6. fields ready for the integrated `method-brief-template.md` section
-
-Keep it compact.
-This is a shaping pass for optimization candidates, not a paper draft or engineering spec.
-
-### candidate-board-template.md
-
-# CANDIDATE_BOARD.md
-
-| Candidate ID | Level | Parent | Strategy | Status | Expected Gain | Observed Result | Promote / Archive |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| cand-001 | brief | current-head | explore | proposed | Better tail accuracy | n/a | pending |
-| cand-002 | impl | cand-001 | exploit | smoke_passed | Faster convergence | smoke ok | consider promote |
-
-Notes:
-
-- `Level` should be `brief` or `implementation`
-- `Parent` may be a branch, idea id, run id, or candidate id
-- `Strategy` should usually be one of `explore`, `exploit`, `fusion`, `debug`
-- `Promote / Archive` should be a clear recommendation, not an empty placeholder
-
-### candidate-ranking-template.md
-
-# Candidate Ranking Template
-
-## Candidate Set
-
-- Candidate IDs:
-- Ranking scope:
-- Comparison surface:
-
-## Criteria
-
-- expected information gain
-- feasibility in current repo
-- comparability against baseline
-- implementation surface
-- likely novelty or distinctiveness
-- risk of redundant overlap
-- incumbent-improvement potential
-- distinctness from other candidates
-- mechanism-family diversity
-- change-layer diversity
-
-## Ranked Candidates
-
-1. `candidate_id`
-   Score summary:
-   Why it ranks here:
-   Promote / hold / reject:
-
-2. `candidate_id`
-   Score summary:
-   Why it ranks here:
-   Promote / hold / reject:
-
-3. `candidate_id`
-   Score summary:
-   Why it ranks here:
-   Promote / hold / reject:
-
-## Winner Justification
-
-Why the selected candidate should become a durable line now.
-
-## Non-Winner Notes
-
-Why the other candidates were deferred, fused, or rejected.
-
-## Promotion Cap
-
-- how many candidates should be promoted now:
-- why more promotion would dilute the frontier:
-- same-family cap override justification:
-
-### codegen-route-playbook.md
-
-# Codegen Route Playbook
-
-Choose the code-generation route deliberately.
-
-## Use brief-only
-
-Use no-code candidate briefs when:
-
-- the direction is still underspecified
-- multiple distinct directions still need ranking
-- a new line should not be promoted yet
-
-## Use stepwise generation
-
-Prefer stepwise generation when:
-
-- a new durable line is being implemented for the first time
-- the change spans data processing, model design, and training/evaluation
-- a modular decomposition will reduce large integrated errors
-- a plan -> refine -> implement sequence is safer than one monolithic edit
-
-## Use diff / patch generation
-
-Prefer diff / patch generation when:
-
-- a strong current implementation already exists
-- the current change is local enough to preserve most of the line
-- the task is improve, exploit, debug, or most fusion work
-- the desired change can be described as a bounded delta from the current solution
-
-## Use full rewrite
-
-Use a full rewrite only when:
-
-- the existing implementation is structurally broken
-- the desired architecture no longer matches the current codebase shape
-- diff patching would be more fragile than replacement
-
-Do not jump to a rewrite merely because one local patch failed.
-
-## Response shape
-
-For non-trivial codegen work, prefer this shape:
-
-1. short plan
-2. bounded implementation surface
-3. keep-unchanged contract
-4. validation step
-
-Do not go from a vague idea directly into a large patch with no intermediate plan.
-
-### debug-response-template.md
-
-# Debug Response Template
-
-## Error
-
-What concrete error or failure occurred?
-
-## Retrieved Memory
-
-What similar failure pattern or repair lesson should be reused before changing code?
-
-## Root Cause
-
-What is the most likely underlying cause?
-
-## Minimal Fix
-
-What is the smallest plausible fix?
-
-## Keep Unchanged
-
-What parts of the line must remain unchanged for comparability and stability?
-
-## Next Check
-
-What bounded smoke or validation check should confirm the fix?
-
-## Archive Threshold
-
-What outcome would prove this candidate should be archived instead of debugged again?
-
-### frontier-review-template.md
-
-# Frontier Review Template
-
-## Current Frontier
-
-- mode:
-- best branch:
-- best run:
-- stagnant branches:
-- candidate backlog:
-- fusion candidates:
-
-## Evidence Summary
-
-- strongest support:
-- strongest contradiction:
-- biggest unresolved risk:
-
-## Route Choice
-
-- explore / exploit / fusion / debug / stop:
-- why this is the best next move:
-
-## Active Optimize Submode
-
-- brief / rank / seed / loop / fusion / debug:
-- why this submode is dominant now:
-
-## Immediate Next Action
-
-- exact next step:
-- what result will trigger another frontier review:
-- what result would force a different mode:
-
-### fusion-playbook.md
-
-# Fusion Playbook
-
-Use fusion only when:
-
-- at least two lines have real strengths
-- the strengths are complementary
-- one line alone is no longer improving fast enough
-
-Before fusion, write down:
-
-- source line A:
-  strongest mechanism:
-  strongest evidence:
-  main weakness:
-  what must survive the fusion:
-
-- source line B:
-  strongest mechanism:
-  strongest evidence:
-  main weakness:
-  what must survive the fusion:
-
-Then answer:
-
-- what exactly is being fused?
-- why does this combination address a real bottleneck?
-- why are the source strengths complementary rather than redundant?
-- what remains unchanged for comparability?
-- what evidence would prove the fusion was worth it?
-- what bounded first validation step should run before any broad rollout?
-
-Do not fuse:
-
-- two lines with the same mechanism under different names
-- two weak lines with no clear strengths
-- merely because multiple branches exist
-
-### method-brief-template.md
-
-# Method Brief Template
-
-## Title
-
-One short line naming the candidate direction.
-
-## Bottleneck
-
-What concrete bottleneck or limitation does this target?
-
-## Why Current Line Is Limited
-
-Why is the current best line or baseline not already solving this?
-
-## Mechanism
-
-What specific intervention or design change is proposed?
-
-## Mechanism Family
-
-Name the family explicitly, for example `adapter`, `loss`, `architecture`, `augmentation`, `ensemble`, `retrieval`, `objective-shift`.
-
-## Change Layer
-
-One of:
-
-- `Tier1`: local optimization / training detail
-- `Tier2`: representation or component change
-- `Tier3`: paradigm or system-level shift
-
-## Source Lens
-
-Where did this candidate come from?
-
-- baseline_refinement
-- orthogonal_mechanism
-- failure_repair
-- cross_domain_transfer
-- objective_shift
-- search_widening
-
-## Keep Unchanged
-
-What must remain stable for comparability?
-
-## Expected Gain
-
-What evidence should improve if this works?
-
-## Implementation Surface
-
-- main files or modules likely involved:
-- likely change scope: local / moderate / broad
-
-## Risks
-
-- Main failure mode
-- Comparability risk
-- Implementation risk
-
-## Foundation
-
-- Source branch / run / baseline:
-- Why this foundation is the right starting point:
-
-## Promote Now
-
-- yes / no
-- why:
-
-## Next Target
-
-Usually `optimize` or `experiment`.
-
-### optimization-memory-template.md
-
-# Optimization Memory Template
-
-## Type
-
-- success pattern / failure pattern / fusion lesson
-
-## Context
-
-- task:
-- branch or idea:
-- candidate id:
-- strategy:
-
-## Observation
-
-What actually happened?
-
-## Why It Matters
-
-Why should a later optimization pass retrieve this?
-
-## Retrieval Hint
-
-- query keywords:
-- closest line or mechanism family:
-- when this should be recalled first:
-
-## Reuse Hint
-
-When should this lesson be reused, and when should it be avoided?
-
-### optimize-checklist-template.md
-
-# OPTIMIZE_CHECKLIST.md
-
-- [ ] Read `artifact.get_optimization_frontier(...)` or equivalent durable frontier summary
-- [ ] Select the primary optimize submode: `brief`, `rank`, `seed`, `loop`, `fusion`, or `debug`
-- [ ] Confirm whether the current pass is `explore`, `exploit`, `fusion`, `debug`, or `stop`
-- [ ] Review recent optimization memory before generating new candidates
-- [ ] Check whether the current brief slate covers more than one mechanism family
-- [ ] Candidate briefs updated or confirmed
-- [ ] Candidate ranking updated
-- [ ] Promote only the strongest brief(s) into durable line(s) if justified
-- [ ] Current implementation candidate pool recorded
-- [ ] Smoke queue defined
-- [ ] Full-eval queue defined
-- [ ] Recent failures classified and either debugged or archived
-- [ ] Stagnation check performed
-- [ ] Family-shift trigger checked
-- [ ] Fusion eligibility checked
-- [ ] Next concrete action written
-
-### plateau-response-playbook.md
-
-# Plateau Response Playbook
-
-Use this when one line keeps producing non-improving results.
-
-## Plateau indicators
-
-- repeated non-improving results on the same line
-- repeated "small tweak" proposals with no structural change
-- candidate queue filled with near-duplicate mechanisms
-
-## Required response
-
-1. state that the line is plateauing
-2. identify the most likely root cause of the plateau
-3. choose one of:
-   - widen search
-   - promote a stronger alternative
-   - fuse with another line
-   - debug a strategically valuable blocked candidate
-   - stop the line
-4. record one explicit non-repeat rule so the next pass does not retry the same low-information move
-
-## Do not do
-
-- keep proposing near-identical local tweaks
-- rerun the same unchanged candidate
-- fuse without a clear complementary mechanism
-- hide a plateau under a sequence of tiny "one more tweak" edits
-
-### prompt-patterns.md
-
-# Optimization Prompt Patterns
-
-These prompt structures are worth preserving across optimize subroutines.
-
-## Common skeleton
-
-- Introduction
-- Task description
-- Memory
-- Previous solution or previous line
-- Instructions
-- assistant_prefix when a stable response lead-in reduces drift
-- Explicit response format
-
-## Common reasoning contract
-
-- WHAT is changing?
-- WHY is the current line limited?
-- HOW should the change address the limitation?
-- KEEP UNCHANGED: what must remain stable for comparability?
-- NEXT ACTION: what concrete step follows this prompt?
-
-## Plateau pattern
-
-When the line is stagnating:
-
-- explicitly state that the current approach has plateaued
-- forbid trivial hyperparameter-only tweaks when a deeper change is needed
-- require a larger representational or architectural shift
-
-## Fusion pattern
-
-When combining lines:
-
-- identify the real strength of each source line
-- explain why those strengths are complementary
-- avoid combining everything
-- preserve the comparison surface
-
-## Debug pattern
-
-For debugging:
-
-- restate the concrete error
-- state the likely root cause
-- require the minimal targeted fix
-- preserve the original solution intent unless the bug proves the design invalid
-
-A good optimize pass changes the frontier or stops a stale line; it does not keep generating activity without moving the incumbent.

--- a/src/skills/optimize/references/brief-shaping-playbook.md
+++ b/src/skills/optimize/references/brief-shaping-playbook.md
@@ -1,0 +1,95 @@
+# Brief Shaping Playbook
+
+Use this reference when a candidate direction is still fuzzy and needs to become a structured, ranking-ready brief.
+
+This playbook borrows the useful part of product-style brainstorming without importing a full software-spec workflow.
+The goal is not a long design document.
+The goal is a compact candidate brief that is clear enough to compare, rank, and either submit as `submission_mode='candidate'` or reject.
+
+## 1. Clarify before widening
+
+Before generating more variants, resolve the minimum ambiguity around:
+
+- the concrete bottleneck
+- the evaluation or comparability boundary
+- the main hard constraint: data, metric, compute, latency, memory, interface, or training budget
+- the current incumbent or baseline that this brief must beat or complement
+
+If one unknown would materially change every candidate, clarify it first instead of generating a noisy slate.
+Prefer one question at a time when clarification is genuinely needed.
+If the answer is already available from durable state, use that instead of asking.
+
+## 2. Generate a small differentiated slate
+
+Default target: `2-3` serious approaches.
+
+The slate should usually include:
+
+- one incumbent-deepening refinement
+- one orthogonal mechanism
+- one broader shift candidate when justified
+
+Do not produce several renamed variants of the same mechanism family.
+If two variants differ only by parameter choice or patch detail, keep only the sharper one.
+
+For each candidate, write:
+
+- bottleneck
+- why_current_line_is_limited
+- mechanism
+- why_now
+- keep_unchanged
+- expected_gain
+- main_risks
+
+## 3. Compare on one shared surface
+
+Before recommending a winner, compare the serious candidates on the same dimensions:
+
+- expected upside
+- comparability safety
+- implementation surface
+- mechanism distinctness
+- failure risk
+- reason this route is better now than the nearby alternatives
+
+Do not let each candidate justify itself with a different scoring story.
+Use one comparison surface so ranking is auditable.
+
+## 4. Recommend exactly one lead brief
+
+After comparison, recommend one lead brief and explain:
+
+- why it is the best next move now
+- why the main alternatives are deferred instead of promoted
+- what evidence would quickly disconfirm the lead brief
+
+Do not say “all are promising” and promote everything.
+If the slate is still too close to call, return to widening once or narrow the slate further.
+
+## 5. Self-check before submission
+
+Before calling `artifact.submit_idea(..., submission_mode='candidate', ...)`, check:
+
+- Is the bottleneck concrete rather than generic?
+- Does `why_current_line_is_limited` explain a real gap instead of restating the mechanism?
+- Does `why_now` explain what changed in evidence, failure pattern, or frontier state?
+- Is the comparability boundary explicit?
+- Is the recommendation based on tradeoffs rather than implementation convenience?
+- Would the brief still make sense if handed to another agent with no chat context?
+
+If any answer is no, refine the brief before submission.
+
+## 6. Output shape
+
+A good final brief package is short and structured:
+
+1. brief title
+2. one-paragraph bottleneck and constraint summary
+3. a `2-3` candidate comparison table or bullet slate
+4. recommended brief with tradeoff summary
+5. self-check outcome
+6. fields ready for the method brief template
+
+Keep it compact.
+This is a shaping pass for optimization candidates, not a paper draft or engineering spec.

--- a/src/skills/optimize/references/candidate-board-template.md
+++ b/src/skills/optimize/references/candidate-board-template.md
@@ -1,0 +1,13 @@
+# CANDIDATE_BOARD.md
+
+| Candidate ID | Level | Parent | Strategy | Status | Expected Gain | Observed Result | Promote / Archive |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| cand-001 | brief | current-head | explore | proposed | Better tail accuracy | n/a | pending |
+| cand-002 | impl | cand-001 | exploit | smoke_passed | Faster convergence | smoke ok | consider promote |
+
+Notes:
+
+- `Level` should be `brief` or `implementation`
+- `Parent` may be a branch, idea id, run id, or candidate id
+- `Strategy` should usually be one of `explore`, `exploit`, `fusion`, `debug`
+- `Promote / Archive` should be a clear recommendation, not an empty placeholder

--- a/src/skills/optimize/references/candidate-ranking-template.md
+++ b/src/skills/optimize/references/candidate-ranking-template.md
@@ -1,0 +1,51 @@
+# Candidate Ranking Template
+
+## Candidate Set
+
+- Candidate IDs:
+- Ranking scope:
+- Comparison surface:
+
+## Criteria
+
+- expected information gain
+- feasibility in current repo
+- comparability against baseline
+- implementation surface
+- likely novelty or distinctiveness
+- risk of redundant overlap
+- incumbent-improvement potential
+- distinctness from other candidates
+- mechanism-family diversity
+- change-layer diversity
+
+## Ranked Candidates
+
+1. `candidate_id`
+   Score summary:
+   Why it ranks here:
+   Promote / hold / reject:
+
+2. `candidate_id`
+   Score summary:
+   Why it ranks here:
+   Promote / hold / reject:
+
+3. `candidate_id`
+   Score summary:
+   Why it ranks here:
+   Promote / hold / reject:
+
+## Winner Justification
+
+Why the selected candidate should become a durable line now.
+
+## Non-Winner Notes
+
+Why the other candidates were deferred, fused, or rejected.
+
+## Promotion Cap
+
+- how many candidates should be promoted now:
+- why more promotion would dilute the frontier:
+- same-family cap override justification:

--- a/src/skills/optimize/references/codegen-route-playbook.md
+++ b/src/skills/optimize/references/codegen-route-playbook.md
@@ -1,0 +1,50 @@
+# Codegen Route Playbook
+
+Choose the code-generation route deliberately.
+
+## Use brief-only
+
+Use no-code candidate briefs when:
+
+- the direction is still underspecified
+- multiple distinct directions still need ranking
+- a new line should not be promoted yet
+
+## Use stepwise generation
+
+Prefer stepwise generation when:
+
+- a new durable line is being implemented for the first time
+- the change spans data processing, model design, and training/evaluation
+- a modular decomposition will reduce large integrated errors
+- a plan -> refine -> implement sequence is safer than one monolithic edit
+
+## Use diff / patch generation
+
+Prefer diff / patch generation when:
+
+- a strong current implementation already exists
+- the current change is local enough to preserve most of the line
+- the task is improve, exploit, debug, or most fusion work
+- the desired change can be described as a bounded delta from the current solution
+
+## Use full rewrite
+
+Use a full rewrite only when:
+
+- the existing implementation is structurally broken
+- the desired architecture no longer matches the current codebase shape
+- diff patching would be more fragile than replacement
+
+Do not jump to a rewrite merely because one local patch failed.
+
+## Response shape
+
+For non-trivial codegen work, prefer this shape:
+
+1. short plan
+2. bounded implementation surface
+3. keep-unchanged contract
+4. validation step
+
+Do not go from a vague idea directly into a large patch with no intermediate plan.

--- a/src/skills/optimize/references/debug-response-template.md
+++ b/src/skills/optimize/references/debug-response-template.md
@@ -1,0 +1,29 @@
+# Debug Response Template
+
+## Error
+
+What concrete error or failure occurred?
+
+## Retrieved Memory
+
+What similar failure pattern or repair lesson should be reused before changing code?
+
+## Root Cause
+
+What is the most likely underlying cause?
+
+## Minimal Fix
+
+What is the smallest plausible fix?
+
+## Keep Unchanged
+
+What parts of the line must remain unchanged for comparability and stability?
+
+## Next Check
+
+What bounded smoke or validation check should confirm the fix?
+
+## Archive Threshold
+
+What outcome would prove this candidate should be archived instead of debugged again?

--- a/src/skills/optimize/references/frontier-review-template.md
+++ b/src/skills/optimize/references/frontier-review-template.md
@@ -1,0 +1,32 @@
+# Frontier Review Template
+
+## Current Frontier
+
+- mode:
+- best branch:
+- best run:
+- stagnant branches:
+- candidate backlog:
+- fusion candidates:
+
+## Evidence Summary
+
+- strongest support:
+- strongest contradiction:
+- biggest unresolved risk:
+
+## Route Choice
+
+- explore / exploit / fusion / debug / stop:
+- why this is the best next move:
+
+## Active Optimize Submode
+
+- brief / rank / seed / loop / fusion / debug:
+- why this submode is dominant now:
+
+## Immediate Next Action
+
+- exact next step:
+- what result will trigger another frontier review:
+- what result would force a different mode:

--- a/src/skills/optimize/references/fusion-playbook.md
+++ b/src/skills/optimize/references/fusion-playbook.md
@@ -1,0 +1,36 @@
+# Fusion Playbook
+
+Use fusion only when:
+
+- at least two lines have real strengths
+- the strengths are complementary
+- one line alone is no longer improving fast enough
+
+Before fusion, write down:
+
+- source line A:
+  strongest mechanism:
+  strongest evidence:
+  main weakness:
+  what must survive the fusion:
+
+- source line B:
+  strongest mechanism:
+  strongest evidence:
+  main weakness:
+  what must survive the fusion:
+
+Then answer:
+
+- what exactly is being fused?
+- why does this combination address a real bottleneck?
+- why are the source strengths complementary rather than redundant?
+- what remains unchanged for comparability?
+- what evidence would prove the fusion was worth it?
+- what bounded first validation step should run before any broad rollout?
+
+Do not fuse:
+
+- two lines with the same mechanism under different names
+- two weak lines with no clear strengths
+- merely because multiple branches exist

--- a/src/skills/optimize/references/method-brief-template.md
+++ b/src/skills/optimize/references/method-brief-template.md
@@ -1,0 +1,73 @@
+# Method Brief Template
+
+## Title
+
+One short line naming the candidate direction.
+
+## Bottleneck
+
+What concrete bottleneck or limitation does this target?
+
+## Why Current Line Is Limited
+
+Why is the current best line or baseline not already solving this?
+
+## Mechanism
+
+What specific intervention or design change is proposed?
+
+## Mechanism Family
+
+Name the family explicitly, for example `adapter`, `loss`, `architecture`, `augmentation`, `ensemble`, `retrieval`, `objective-shift`.
+
+## Change Layer
+
+One of:
+
+- `Tier1`: local optimization / training detail
+- `Tier2`: representation or component change
+- `Tier3`: paradigm or system-level shift
+
+## Source Lens
+
+Where did this candidate come from?
+
+- baseline_refinement
+- orthogonal_mechanism
+- failure_repair
+- cross_domain_transfer
+- objective_shift
+- search_widening
+
+## Keep Unchanged
+
+What must remain stable for comparability?
+
+## Expected Gain
+
+What evidence should improve if this works?
+
+## Implementation Surface
+
+- main files or modules likely involved:
+- likely change scope: local / moderate / broad
+
+## Risks
+
+- Main failure mode
+- Comparability risk
+- Implementation risk
+
+## Foundation
+
+- Source branch / run / baseline:
+- Why this foundation is the right starting point:
+
+## Promote Now
+
+- yes / no
+- why:
+
+## Next Target
+
+Usually `optimize` or `experiment`.

--- a/src/skills/optimize/references/operational-guidance.md
+++ b/src/skills/optimize/references/operational-guidance.md
@@ -1,0 +1,621 @@
+# Operational Guidance
+
+Use this reference when the optimize route needs the longer execution notes rather than the short control surface in `SKILL.md`.
+
+## Contents
+
+- working surfaces
+- research-map role
+- frontier recovery
+- internal submode selection
+- candidate brief protocol
+- promotion protocol
+- frontier protocol
+- seed protocol
+- loop protocol
+- memory protocol
+- artifact protocol
+- execution protocol
+- code-generation route selection
+- debug protocol
+- fusion protocol
+- plateau and fusion protocol
+- task-category primer
+- stall-recovery protocol
+- stage-start and stage-end requirements
+- completion rule
+
+## Working surfaces
+
+Keep these quest-visible control files when optimization becomes substantial:
+
+- quest-root `plan.md` as the research map and loop tracker for the whole quest
+- workspace `PLAN.md` as the active optimize-node contract
+- `OPTIMIZE_CHECKLIST.md` as the optimize-specific execution frontier
+- workspace `CHECKLIST.md` as a mirror of the immediate next move when that file exists
+- `CANDIDATE_BOARD.md` as the compact candidate ledger
+
+Keep only one bottom-layer optimize move truly in progress at a time.
+If the frontier and checklist stop changing, revise the node contract or route instead of nesting more local tweaks.
+
+## Research-map role
+
+- `optimize` is the looped search controller for algorithm-first quests, not a replacement for the quest-level roadmap
+- when a result becomes the new incumbent, plateaus, or stops, update quest-root `plan.md` so the next loop edge is explicit
+
+## Frontier recovery
+
+At the start of each meaningful optimize pass, use this order unless a stronger local reason exists:
+
+1. `artifact.get_optimization_frontier(...)`
+2. `memory.list_recent(scope='quest', limit=5)`
+3. `memory.search(...)`
+4. `artifact.get_quest_state(detail='summary')`
+5. `artifact.read_quest_documents(...)` when exact durable wording matters
+
+Do not create new candidates before the frontier, recent optimization lessons, and current runtime refs are checked.
+If the frontier is missing or obviously stale, recover that state before proposing more work.
+
+## Internal submode selection
+
+Choose exactly one primary optimize submode for the current meaningful pass.
+
+Default selection order:
+
+1. `fusion`
+   - when the frontier explicitly says `fusion`
+2. `debug`
+   - when a strategically valuable candidate failed for a concrete and likely fixable reason
+3. `rank`
+   - when several candidate briefs already exist and promotion is the main unresolved question
+4. `brief`
+   - when the candidate-brief slate is too thin or too weak
+5. `seed`
+   - when a durable line exists but there is no live implementation-candidate pool
+6. `loop`
+   - when a live candidate pool or leading durable line already exists and the main need is bounded execution progress
+
+Do not bounce among submodes repeatedly in one pass.
+If the best submode changes after new evidence appears, record that route shift explicitly.
+
+## Candidate brief protocol
+
+When a direction is interesting but not yet worthy of a new branch:
+
+- create a candidate brief with `submission_mode='candidate'`
+- keep it branchless
+- record enough structure that later ranking or promotion is possible
+
+Good candidate-brief fields include:
+
+- title
+- problem
+- hypothesis
+- mechanism
+- mechanism_family
+- change_layer
+- source_lens
+- expected_gain
+- risks
+- decision_reason
+- foundation_ref
+- lineage_intent
+
+Do not promote every candidate automatically.
+
+Candidate briefs should explicitly answer:
+
+- WHAT bottleneck is being targeted?
+- WHY is the current line limited?
+- HOW does this mechanism address the limitation?
+- WHAT must remain unchanged for comparability?
+
+If the brief cannot answer those four questions clearly, it is not ready for promotion or implementation.
+
+Treat a candidate brief as the DeepScientist form of a method brief.
+It should sit between “idea intuition” and “code implementation”.
+
+Preserve this brief-shaping discipline:
+
+1. clarify the bottleneck, constraints, and comparability boundary first
+2. generate a small differentiated slate, usually `2-3` serious approaches
+3. recommend one approach with explicit tradeoffs against the alternatives
+4. self-check the winning brief for ambiguity, overlap, and weak justification before submission
+
+Do not jump from “interesting intuition” to branch creation.
+Do not jump from “I know how to code this” to “this deserves promotion.”
+
+When running the `brief` submode:
+
+- produce only `2-4` serious candidate briefs by default
+- ask or answer the minimum clarifying questions needed to remove ambiguity around bottleneck, constraint fit, and comparability
+- explicitly keep one incumbent-compatible refinement when possible
+- explicitly keep one orthogonal alternative when possible
+- explicitly keep one broader lens or paradigm-shift candidate when possible
+- avoid generating several renamed variants of the same mechanism
+- prefer mechanism-level distinctness over volume
+- present the differentiated slate on one shared comparison surface before choosing a recommended brief
+- keep the questioning bounded and execution-oriented rather than open-ended brainstorming
+
+Use a coverage contract for every serious brief slate:
+
+- one `incumbent-deepening` direction when justified
+- one `orthogonal-mechanism` direction when justified
+- one `paradigm/objective/data-view shift` direction when justified
+
+If all serious briefs belong to the same mechanism family, do one widening pass before ranking.
+Do not treat a same-family slate as sufficient merely because the local scores look good.
+
+For each serious brief, record at least:
+
+- bottleneck
+- why_current_line_is_limited
+- mechanism
+- why_now
+- mechanism_family
+- change_layer: `Tier1` / `Tier2` / `Tier3`
+- source_lens
+- keep_unchanged
+- expected_gain
+- implementation_surface
+- main_risks
+- promote_now: yes or no
+
+## Promotion protocol
+
+Only promote a candidate brief into a durable line when at least one of the following is true:
+
+- it clearly dominates the nearby alternatives
+- it is top-ranked and sufficiently distinct
+- the user explicitly asked to pursue it
+- the current frontier indicates the line is the strongest next move
+
+Promotion should use:
+
+`artifact.submit_idea(mode='create', submission_mode='line', source_candidate_id=..., ...)`
+
+When several candidate briefs are plausible, rank them explicitly before promotion.
+
+Default promotion rule:
+
+- promote only `1-3` candidate briefs into durable lines
+- if one candidate clearly dominates, promote only that one
+- if the frontier is still structurally uncertain, promote at most two sufficiently distinct lines
+
+When running the `rank` submode:
+
+- compare the current serious briefs on one explicit shared surface
+- score or rank them with written reasons
+- state why the winner is better now
+- state why the main alternatives are deferred rather than erased
+- never treat “all seem promising” as a sufficient reason to promote them all
+
+Use a distinct promotion policy:
+
+- default rule: each mechanism family should contribute at most one promoted line
+- do not let one familiar family fill the whole promoted slate
+- only override that family cap when one candidate clearly dominates the whole field
+
+When ranking, explicitly check:
+
+- family diversity
+- change-layer diversity
+- whether the brief slate is collapsing into one familiar lens
+
+If the top briefs are all same-family, either:
+
+- keep only the strongest one
+- or return to `brief` for a widening pass
+
+The output of `rank` should be promotion-ready.
+The output of `brief` should be candidate-ready.
+
+## Frontier protocol
+
+At meaningful route boundaries, inspect:
+
+- best branch
+- best recent run
+- stagnant branches
+- candidate backlog
+- possible fusion opportunities
+- recommended mode
+
+Prefer these route meanings:
+
+- `explore`: widen search with fresh candidate directions
+- `exploit`: focus on the strongest current line
+- `fusion`: merge insights from multiple successful or complementary lines
+- `debug`: rescue a candidate or line blocked by a concrete failure mode
+- `stop`: the current frontier is saturated or the remaining routes are not justified
+
+Interpret frontier state with these default heuristics:
+
+- `explore`
+  - use when no line is clearly dominant
+  - use when current lines are too similar
+  - use when the search has not yet established a strong incumbent
+
+- `exploit`
+  - use when one line clearly leads on evidence and comparability
+  - use when smoke results already narrowed the candidate pool
+
+- `fusion`
+  - use when at least two lines have meaningful strengths
+  - use when one line is strong but another line contributes a complementary mechanism
+  - use when the current incumbent is stagnating but the broader frontier is still promising
+
+- `debug`
+  - use when a candidate failed for a concrete and likely fixable reason
+  - use when the candidate is still strategically valuable after the failure
+
+- `stop`
+  - use when the frontier is saturated
+  - use when remaining routes are low-value, redundant, or too weak relative to cost
+
+When the frontier says `explore`, the default optimize submode is `brief`.
+When the frontier says `exploit`, the default optimize submode is `seed` or `loop`.
+When the frontier says `fusion`, the default optimize submode is `fusion`.
+When a candidate failure dominates the next move, the default optimize submode is `debug` even if the frontier does not yet say so explicitly.
+
+## Seed protocol
+
+Use `seed` after a durable line exists and before a broad execution loop begins.
+
+The goal is not to launch a full run immediately.
+The goal is to generate a small within-line candidate pool that can be smoke-tested and triaged.
+
+When running `seed`:
+
+- generate only `2-3` implementation-level candidates by default
+- make each candidate meaningfully different in mechanism, implementation path, or risk profile
+- prefer plan-first candidates over immediate large edits
+- record each candidate as `report_type='optimization_candidate'`
+- define which candidates enter smoke first
+- for a newly promoted line, keep at least one `simple-first` candidate in the initial seed batch
+- do not start a fresh line with ensemble stacking, broad HPO, or a heavy multi-stage pipeline unless durable evidence already proves the simple route is insufficient
+
+For each seed candidate, record at least:
+
+- candidate_id
+- parent line
+- strategy
+- mechanism_family
+- change_layer
+- change_plan
+- expected_gain
+- keep_unchanged
+- first validation step
+- archive condition
+
+Use a validation-cost-aware seed policy:
+
+- `fast-check`: the first objective smoke signal is likely under about `20` minutes
+- `slow-check`: the first objective smoke signal is likely over about `20` minutes or expensive enough that broad probing is wasteful
+
+For `fast-check` seed work:
+
+- widen a bit more aggressively inside the line
+- a seed batch of `3-5` candidates can be justified when they are genuinely differentiated
+- prefer multiple orthogonal quick tests over one over-discussed candidate
+- a separate smoke stage is optional; direct submission into quick parallel validation is acceptable when the first check is already cheap
+- only skip smoke when the parallel quick validations are expected to produce distinguishable conclusions rather than repeated near-duplicate outcomes
+
+For `slow-check` seed work:
+
+- keep the initial seed batch tighter, usually `1-2` candidates and rarely `3`
+- insist on a stronger reason for every candidate entering smoke
+- prefer one dominant hypothesis plus one hedge candidate over a broad exploratory pool
+- do not spend long runs to discover that the brief itself was weak
+
+Do not keep a live implementation pool dominated by the same mechanism family.
+Default active-pool rule:
+
+- at most `1-2` live candidates from the same family
+- if one family already fills the live pool, new same-family candidates do not enter smoke by default
+
+## Loop protocol
+
+Use `loop` when a durable line and implementation-candidate pool already exist and the main need is bounded forward motion.
+
+Before changing code in `loop`, inspect the same-line local attempt memory for the current line.
+Treat recent sibling attempts on the same line as the first memory surface, ahead of broader quest memory.
+
+When running `loop`, choose one primary action:
+
+- `smoke`
+- `promote_to_full_eval`
+- `archive`
+- `record_main_result`
+- `switch_to_fusion`
+- `switch_to_debug`
+- `stop`
+
+Every loop pass should end with:
+
+- one updated candidate status
+- one updated next action
+- one frontier review trigger
+
+Do not leave the line with several half-started directions and no dominant next move.
+
+Default exploit rule: one atomic improvement per pass.
+Do not bundle several unrelated changes into one exploit candidate unless:
+
+- the changes are one tightly coupled design package
+- or the pass is explicitly a fusion route
+
+Use a validation-cost-aware loop policy:
+
+- for `fast-check` tasks, it is acceptable to run more quick, different tests before converging
+- for `fast-check` tasks, direct quick validation may replace a separate smoke stage if that saves time without losing decision quality
+- for `slow-check` tasks, use fewer but sharper passes, and require objective gain before widening or evolving further
+- if the validation loop is slow, do not keep paying for frontier uncertainty that could have been reduced in `brief`
+- if the validation loop is fast, prefer resolving uncertainty with evidence instead of over-arguing in chat
+
+Use a branch or family diversity cap during exploitation:
+
+- do not keep selecting only the locally familiar family because it is easiest to elaborate
+- when several strong candidates are close, prefer the one that preserves frontier diversity
+- if one branch or family already dominates recent attempts, require stronger evidence before selecting another near-duplicate attempt
+
+## Memory protocol
+
+Before broad new search, run at least one `memory.search(...)` using:
+
+- the current task name
+- the active idea id
+- a method keyword
+- the most recent failure mode or successful mechanism
+
+When the search appears too narrow, also retrieve one of:
+
+- a similar failure pattern
+- an orthogonal success pattern
+- a deliberately dissimilar but high-value prior attempt
+
+For `seed`, `loop`, and `debug`, also inspect the same-line local attempt memory from the current leading line before widening to broader quest memory.
+
+Write at least one quest memory card when you learn something reusable, such as:
+
+- a successful optimization pattern
+- a repeated failure pattern
+- a fusion lesson
+- a reason a candidate should not be retried
+
+Do not write generic “we tried some optimization” memory cards.
+Each card should be retrieval-friendly and decision-relevant.
+
+## Artifact protocol
+
+Use:
+
+- `artifact.submit_idea(..., submission_mode='candidate')` for candidate briefs
+- `artifact.submit_idea(..., submission_mode='line')` for durable promoted lines
+- `artifact.record(payload={'kind': 'report', 'report_type': 'optimization_candidate', ...})` for within-line attempts
+- `artifact.record(payload={'kind': 'decision', 'action': 'iterate'|'branch'|'continue'|'stop', ...})` for route changes
+- `artifact.record_main_experiment(...)` for real measured line results
+
+When the optimize pass is about ranking or promotion, also record one durable decision explaining:
+
+- which briefs were compared
+- which one won
+- why promotion was justified now
+- why the others were held, fused, or rejected
+
+When recording implementation-level candidates, prefer these status values:
+
+- `proposed`
+- `smoke_running`
+- `smoke_passed`
+- `smoke_failed`
+- `promoted`
+- `full_eval_running`
+- `succeeded`
+- `failed`
+- `archived`
+
+Use `report_type='optimization_candidate'` consistently for implementation-level attempts so they can later be summarized into the frontier.
+
+## Execution protocol
+
+- Use `bash_exec` for smoke checks and full runs.
+- Prefer bounded smoke before full evaluation unless `fast-check` direct validation is cheaper and equally informative.
+- Do not keep rerunning the same unchanged candidate.
+- If a candidate fails with a clear root cause, either debug it deliberately or archive it.
+- If the same line stalls repeatedly, switch to exploit or fusion rather than pretending more of the same is new evidence.
+
+Use this execution order by default:
+
+1. candidate brief selection
+2. implementation-level candidate generation
+3. smoke test or direct quick validation
+4. promotion to fuller evaluation when justified
+5. durable result recording
+6. frontier review
+
+Prefer only a small active pool at once:
+
+- usually `2-4` candidate briefs before promotion
+- usually `2-3` live implementation candidates in smoke
+- usually `1-2` full evaluations running at once unless the environment clearly supports more
+
+Validation-cost-aware override:
+
+- if first-pass validation is under about `20` minutes, it is reasonable to increase smoke breadth modestly and compare more alternatives early
+- if first-pass validation is under about `20` minutes, you may skip a separate smoke stage and submit several quick validations in parallel
+- only do that when the validations are likely to yield different conclusions such as clear win / tie / fail / instability, rather than redundant repeats
+- if first-pass validation is slower than that, keep the active pool narrow and gate evolution on clear objective signal
+- for slow validation, do not promote a candidate into heavier resource investment until smoke or pilot evidence shows a real performance improvement, stability improvement, or comparability-preserving advantage
+
+## Code-generation route selection
+
+Do not use the same code-generation route for every optimization step.
+
+Prefer:
+
+1. brief-first, no code yet
+   - when the direction is still unclear
+   - stay at candidate-brief level
+
+2. stepwise generation
+   - for the first substantial implementation of a new durable line
+   - especially when the line touches multiple subsystems such as data processing, model design, and training/evaluation
+
+3. diff / patch generation
+   - when a strong current implementation already exists
+   - for improve, exploit, debug, and most fusion work
+
+4. full rewrite
+   - only when the current implementation is too broken or too structurally mismatched for diff patching to remain safe
+
+Do not jump to a rewrite merely because one local patch failed.
+
+## Debug protocol
+
+Use `debug` when a candidate failed but still looks strategically valuable.
+
+`debug` is bugfix-only.
+Do not use a debug pass to sneak in a new performance-improvement idea.
+If the proposed change goes beyond the minimal fix and becomes a new mechanism, stop and route back to `brief` or `loop` instead.
+
+When a candidate fails:
+
+- classify whether the failure is structural, local, or environmental
+- retrieve similar failure patterns from memory before changing code
+- prefer targeted fixes over broad rewrites
+- define the exact post-fix bounded check before editing
+
+Archive rather than debug when:
+
+- the failure is mostly strategic rather than local
+- the candidate no longer looks better than the nearby alternatives
+- the fix would effectively turn it into a different candidate anyway
+
+## Fusion protocol
+
+Use `fusion` only when the frontier justifies cross-line combination.
+
+Before opening a fusion candidate:
+
+- identify the real strength of each source line
+- identify the real weakness of each source line
+- explain why the strengths are complementary rather than redundant
+- define what remains unchanged for comparability
+- define the bounded evidence that would prove the fusion was worthwhile
+
+Do not fuse:
+
+- two lines with the same mechanism under different names
+- two weak lines that lack a clear strength
+- merely because multiple branches exist
+
+If the fusion hypothesis is still underspecified, return to `brief` instead of pretending fusion is ready.
+
+## Plateau and fusion protocol
+
+Treat repeated local edits without evidence gain as a search failure mode.
+
+If one line shows repeated non-improving results:
+
+- stop issuing near-duplicate attempts
+- record the stagnation explicitly
+- either widen the search or fuse with another line
+
+Good fusion candidates usually satisfy both:
+
+- each source line has at least one real strength
+- the strengths are complementary rather than redundant
+
+When a line plateaus:
+
+- stop issuing near-duplicate low-information attempts
+- say explicitly that the line is plateauing
+- force one larger route change:
+  - widen the brief slate
+  - promote a stronger alternative
+  - fuse
+  - debug one blocked but valuable candidate
+  - stop
+
+Do not hide plateau under a sequence of tiny “one more tweak” loops.
+
+Family-shift trigger:
+
+- if recent attempts stay inside one mechanism family and there is no meaningful improvement
+- or if `success_patience >= 2`
+- or if `total_patience >= 5`
+- the next pass must not be another same-family Tier1 tweak
+- instead choose one of:
+  - orthogonal family
+  - Tier2 or Tier3 shift
+  - fusion
+  - stop
+
+This is the default anti-collapse rule for optimize.
+
+## Task-category primer
+
+Before widening a stale frontier, classify the task briefly into one or more dominant structures:
+
+- tabular
+- vision / spatial
+- sequence / language
+- graph / topology
+- systems / optimization
+- mixed
+
+Then ask whether the current brief slate overfits one familiar method family for that task.
+If it does, require at least one serious candidate from a different plausible family or lens before promotion.
+
+## Stall-recovery protocol
+
+If the optimize stage appears to stall, diagnose the stall explicitly instead of idling.
+
+Common stall classes:
+
+- no frontier information
+- no candidate clearly worth promotion
+- candidate pool is too similar
+- repeated failures on one line
+- no active runs and no next action recorded
+
+Preferred recovery order:
+
+1. refresh the frontier
+2. inspect the current candidate board
+3. inspect recent optimization memory
+4. record one explicit route decision
+5. continue with exactly one concrete next action
+
+Do not leave the stage parked without a recorded reason and a concrete reopen condition.
+
+## Stage-start and stage-end requirements
+
+At the start of a meaningful optimize pass:
+
+- run `memory.list_recent(scope='quest', limit=5)`
+- run at least one `memory.search(...)`
+- read `artifact.get_optimization_frontier(...)`
+- update `OPTIMIZE_CHECKLIST.md`
+
+If the frontier is missing or obviously stale, recover that state before proposing more work.
+
+At the end of a meaningful optimize pass:
+
+- write at least one `memory.write(...)` when the pass produced a reusable success pattern, repeated failure pattern, fusion lesson, or explicit non-retry rule
+- update `OPTIMIZE_CHECKLIST.md`
+- update `CANDIDATE_BOARD.md` when the candidate pool changed
+- leave one durable next action or stop condition
+
+If nothing reusable was learned, record why this pass was still necessary instead of writing a fake memory card.
+
+## Completion rule
+
+This stage is complete only when one of these is durably true:
+
+- a stronger line was promoted and the next anchor is clear
+- the current line produced a real measured result and the next route is recorded
+- the optimization frontier says stop and that stop decision is durably recorded
+
+Do not treat one candidate creation or one smoke pass as stage completion.

--- a/src/skills/optimize/references/optimization-memory-template.md
+++ b/src/skills/optimize/references/optimization-memory-template.md
@@ -1,0 +1,30 @@
+# Optimization Memory Template
+
+## Type
+
+- success pattern / failure pattern / fusion lesson
+
+## Context
+
+- task:
+- branch or idea:
+- candidate id:
+- strategy:
+
+## Observation
+
+What actually happened?
+
+## Why It Matters
+
+Why should a later optimization pass retrieve this?
+
+## Retrieval Hint
+
+- query keywords:
+- closest line or mechanism family:
+- when this should be recalled first:
+
+## Reuse Hint
+
+When should this lesson be reused, and when should it be avoided?

--- a/src/skills/optimize/references/optimize-checklist-template.md
+++ b/src/skills/optimize/references/optimize-checklist-template.md
@@ -1,0 +1,18 @@
+# OPTIMIZE_CHECKLIST.md
+
+- [ ] Read `artifact.get_optimization_frontier(...)` or equivalent durable frontier summary
+- [ ] Select the primary optimize submode: `brief`, `rank`, `seed`, `loop`, `fusion`, or `debug`
+- [ ] Confirm whether the current pass is `explore`, `exploit`, `fusion`, `debug`, or `stop`
+- [ ] Review recent optimization memory before generating new candidates
+- [ ] Check whether the current brief slate covers more than one mechanism family
+- [ ] Candidate briefs updated or confirmed
+- [ ] Candidate ranking updated
+- [ ] Promote only the strongest brief(s) into durable line(s) if justified
+- [ ] Current implementation candidate pool recorded
+- [ ] Smoke queue defined
+- [ ] Full-eval queue defined
+- [ ] Recent failures classified and either debugged or archived
+- [ ] Stagnation check performed
+- [ ] Family-shift trigger checked
+- [ ] Fusion eligibility checked
+- [ ] Next concrete action written

--- a/src/skills/optimize/references/plateau-response-playbook.md
+++ b/src/skills/optimize/references/plateau-response-playbook.md
@@ -1,0 +1,28 @@
+# Plateau Response Playbook
+
+Use this when one line keeps producing non-improving results.
+
+## Plateau indicators
+
+- repeated non-improving results on the same line
+- repeated “small tweak” proposals with no structural change
+- candidate queue filled with near-duplicate mechanisms
+
+## Required response
+
+1. state that the line is plateauing
+2. identify the most likely root cause of the plateau
+3. choose one of:
+   - widen search
+   - promote a stronger alternative
+   - fuse with another line
+   - debug a strategically valuable blocked candidate
+   - stop the line
+4. record one explicit non-repeat rule so the next pass does not retry the same low-information move
+
+## Do not do
+
+- keep proposing near-identical local tweaks
+- rerun the same unchanged candidate
+- fuse without a clear complementary mechanism
+- hide a plateau under a sequence of tiny “one more tweak” edits

--- a/src/skills/optimize/references/prompt-patterns.md
+++ b/src/skills/optimize/references/prompt-patterns.md
@@ -1,0 +1,49 @@
+# Optimization Prompt Patterns
+
+These prompt structures are worth preserving across optimize subroutines.
+
+## Common skeleton
+
+- Introduction
+- Task description
+- Memory
+- Previous solution or previous line
+- Instructions
+- assistant_prefix when a stable response lead-in reduces drift
+- Explicit response format
+
+## Common reasoning contract
+
+- WHAT is changing?
+- WHY is the current line limited?
+- HOW should the change address the limitation?
+- KEEP UNCHANGED: what must remain stable for comparability?
+- NEXT ACTION: what concrete step follows this prompt?
+
+## Plateau pattern
+
+When the line is stagnating:
+
+- explicitly state that the current approach has plateaued
+- forbid trivial hyperparameter-only tweaks when a deeper change is needed
+- require a larger representational or architectural shift
+
+## Fusion pattern
+
+When combining lines:
+
+- identify the real strength of each source line
+- explain why those strengths are complementary
+- avoid combining everything
+- preserve the comparison surface
+
+## Debug pattern
+
+For debugging:
+
+- restate the concrete error
+- state the likely root cause
+- require the minimal targeted fix
+- preserve the original solution intent unless the bug proves the design invalid
+
+A good optimize pass changes the frontier or stops a stale line; it does not keep generating activity without moving the incumbent.

--- a/src/skills/references/tool-usage-by-stage.md
+++ b/src/skills/references/tool-usage-by-stage.md
@@ -1,0 +1,438 @@
+# Tool Usage By Stage
+
+Use this shared reference when a stage skill needs precise guidance for when to use `artifact`, `bash_exec`, and `memory`.
+
+The goal is not a generic tool summary.
+The goal is accurate stage control for long-running autonomous quests where durable management, validation, and continuation matter.
+
+## Core roles
+
+- `artifact`
+  - canonical state surface
+  - canonical verification surface
+  - canonical route and handoff surface
+- `bash_exec`
+  - execution surface
+  - first-hand evidence surface
+  - local inspection and monitoring surface
+- `memory`
+  - reusable lesson surface
+  - anti-repeat surface
+  - authoritative resume-hint surface
+
+## Global rules
+
+### Default stage-start order
+
+For most stage passes:
+
+1. recover durable state with `artifact`
+2. retrieve reusable lessons with `memory`
+3. execute or inspect with `bash_exec`
+
+### Default stage-end order
+
+For most stage passes:
+
+1. finish the concrete execution or inspection with `bash_exec`
+2. convert the result into durable truth with `artifact`
+3. write `memory` only if the lesson should change future default behavior
+
+### When `artifact` is mandatory
+
+Use `artifact` before exit whenever:
+
+- a stage result became durable truth
+- the active route changed
+- the next stage became clear
+- a blocker became authoritative
+- a user-visible milestone needs to survive resume or handoff
+
+### When `memory` is mandatory
+
+Use `memory` when:
+
+- the next default action should change because of this pass
+- repeated failure is likely unless the lesson is preserved
+- a reusable success pattern appeared
+- the authoritative resume point changed materially
+
+Do not use `memory` as the primary record of baselines, experiments, analyses, or paper state.
+
+## Baseline
+
+### Use `artifact` when
+
+- recovering the active baseline gate state
+- checking whether `requested_baseline_ref` or `confirmed_baseline_ref` already exists
+- attaching, confirming, waiving, publishing, or blocking a baseline
+- recording the accepted comparator and metric contract
+
+### Use `memory` when
+
+- resuming a previously blocked or ambiguous baseline route
+- reopening an old command path or environment fix
+- repeated failures or environment incidents risk repeating
+- a paper-to-code mismatch or accepted caveat should affect later stages
+
+### Use `bash_exec` when
+
+- verifying a local existing comparator
+- running reproduction or repair
+- checking the evaluator, service, dataset path, or environment
+- collecting first-hand evidence from files, logs, or outputs
+
+### Do not
+
+- do not keep running `bash_exec` retries after the same failure class repeats with no real change
+- do not stop at attach/import/publish alone; use `artifact.confirm_baseline(...)` or `artifact.waive_baseline(...)`
+
+## Scout
+
+### Use `artifact` when
+
+- reconstructing the current frame from durable state
+- reading quest docs before broad search
+- recording the evaluation contract, baseline direction, or next anchor
+- recording an explicit blocked scout state
+
+### Use `memory` when
+
+- resuming after a pause
+- broad literature or repo search is about to start
+- you suspect the survey or shortlist was already partially built
+- repeated search would likely revisit the same cluster
+
+### Use `bash_exec` when
+
+- inspecting local repo docs, benchmark scripts, evaluator code, or dataset paths
+- local code or file inspection materially changes the frame
+
+### Use external search or DeepXiv when
+
+- the task frame, metric contract, or baseline direction is still unclear
+- the current neighborhood is too thin or too recent-only
+- novelty, field map, or historical lineage is still ambiguous
+
+If DeepXiv is available, prefer it for broad paper-centric discovery, citation expansion, and shortlist triage.
+If DeepXiv is unavailable, use search engines directly plus backward and forward citation chaining.
+
+### Do not
+
+- do not continue searching once the next anchor is already clear
+- do not treat recent papers as a substitute for field history
+
+## Idea
+
+### Use `artifact` when
+
+- recovering current board state and research branches
+- writing the objective contract and current board packet
+- recording selected, deferred, and rejected candidates
+- submitting a selected idea as a durable route
+
+### Use `memory` when
+
+- resuming an old ideation thread
+- checking whether a route is stale and should not be reopened
+- broad literature search is about to begin
+- a contradiction, failure pattern, or rejected-route reason should influence later ideation
+
+### Use `bash_exec` when
+
+- local code or evaluator inspection changes feasibility or implementation-surface judgment
+- local branch or file state matters for choosing a foundation
+
+### Use DeepXiv or search when
+
+- broad, history-aware literature search is needed
+- you need seminal papers, turning-point papers, SOTA papers, or citation chaining
+- the strongest prior work or field lineage is still unclear
+
+If DeepXiv is available, prefer it for broad paper-centric discovery.
+If not, use search engines plus citation chaining directly.
+
+### Multiple strong and feasible ideas
+
+If several candidates are truly strong:
+
+- if they are same-family micro-variants:
+  - do not keep them as separate serious routes
+  - merge them into one family-level candidate
+- if they are meaningfully different families:
+  - keep `1` selected route
+  - keep `1-2` deferred but serious alternatives durably
+- if the next regime is algorithm-first and validation is cheap:
+  - keep a small serious frontier, usually `2-3`
+  - hand that frontier into `optimize` as candidate briefs
+- if validation is expensive:
+  - keep one lead plus at most one hedge route
+
+Do not promote every strong-looking idea.
+Do preserve the serious non-winners if they are structurally different and still valuable.
+
+### Do not
+
+- do not start from “swap A for B” before naming the important contradiction or bottleneck
+- do not let only excitement decide promotion
+
+## Optimize
+
+### Use `artifact` when
+
+- recovering the optimization frontier
+- creating candidate briefs
+- promoting durable lines
+- recording implementation-level optimization candidates
+- recording route changes or main measured results
+
+### Use `memory` when
+
+- broad new search is about to start
+- the same durable line has recent sibling attempts
+- repeated failure, plateau, fusion, or non-retry rules should influence the next move
+
+### Use `bash_exec` when
+
+- running smoke checks
+- running quick validations
+- running full evaluations
+- debugging or validating fusion candidates
+
+### Candidate and frontier rules
+
+- keep candidate briefs small and differentiated
+- default serious brief count: `2-3`
+- default line promotion count: usually `1`, sometimes `2`, rarely `3`
+- do not let one familiar mechanism family fill the whole promoted slate
+- keep implementation-level live pools small, usually `2-3`
+
+### Do not
+
+- do not create a durable line for every plausible brief
+- do not treat an implementation candidate as a new durable line
+
+## Experiment
+
+### Use `artifact` when
+
+- recovering runtime refs, baseline refs, and quest state before the run
+- recording the main experiment with `artifact.record_main_experiment(...)`
+- recording the route decision after the measured result
+
+### Use `memory` when
+
+- reopening an old command path
+- retrying after a known failure pattern
+- environment fixes or comparability caveats may repeat
+
+### Use `bash_exec` when
+
+- running smoke or pilot checks
+- running the real experiment
+- monitoring long-running jobs
+- validating outputs and logs
+
+### Practical trigger rules
+
+- if the command path or evaluator wiring is still unclear, start with a bounded smoke or pilot
+- if the path is already concrete, go straight to the real run
+- if the result is suspicious or confounded, do not blindly rerun; route through diagnosis, decision, or analysis
+
+### Do not
+
+- do not treat a run as complete before `artifact.record_main_experiment(...)` succeeds
+- do not let logs alone become the accepted system state
+
+## Analysis Campaign
+
+### Use `artifact` when
+
+- durable lineage matters
+- multiple slices exist
+- paper/rebuttal/review traceability matters
+- campaign launch, slice recording, synthesis, or closeout becomes durable truth
+
+### Use `memory` when
+
+- resuming an old campaign
+- repeated slice failures or comparability caveats may recur
+- a cross-slice lesson should change later defaults
+
+### Use `bash_exec` when
+
+- running slices
+- monitoring slices
+- validating outputs
+- diagnosing slice failures
+
+### Route rules
+
+- if one bounded question is enough and lineage does not matter, a lighter report route can be enough
+- if multiple slices, traceability, or replay matter, use an artifact-backed campaign
+- if multiple slices are valuable, run claim-critical ones first and queue the rest
+
+### Do not
+
+- do not leave slice truth only in chat
+- do not start every plausible slice before the first decisive ones return evidence
+
+## Decision
+
+### Use `artifact` when
+
+- making any consequential route judgment
+- recording verdict, action, reason, evidence paths, and next direction
+
+### Use `memory` when
+
+- the authoritative resume point changed
+- a do-not-reopen rule or reusable route rationale should persist
+
+### Use `bash_exec` when
+
+- local evidence is still missing and a quick concrete check would materially change the route judgment
+
+### Candidate-choice rule
+
+If several options are plausible:
+
+- still choose one winner when local evidence is enough
+- record the main rejected alternative and why it lost
+- only ask the user when the choice is genuinely preference, scope, or cost sensitive and cannot be derived locally
+
+## Finalize
+
+### Use `artifact` when
+
+- checking global quest status
+- checking paper contract health
+- reading the scoreboard
+- completing the quest after explicit approval
+
+### Use `memory` when
+
+- a reusable closure lesson or final authoritative checkpoint should persist
+
+### Use `bash_exec` when
+
+- building, exporting, compiling, or locally verifying final deliverables
+
+### Do not
+
+- do not finalize through a still-blocked paper or evidence contract
+- do not call `artifact.complete_quest(...)` before explicit approval
+
+## Intake Audit
+
+### Use `artifact` when
+
+- recovering mixed state
+- reading quest docs, artifacts, and current runtime state
+- recording the current board packet, trust ranking, or next anchor recommendation
+
+### Use `memory` when
+
+- an old checkpoint, stale route, or resume point may still contaminate current judgment
+
+### Use `bash_exec` when
+
+- local file tree, git state, or output inspection is needed to resolve ambiguity
+
+### Do not
+
+- do not let a mixed-state quest proceed on conversational guesses about the active mainline
+
+## Review
+
+### Use `artifact` when
+
+- reading paper contract health
+- reading quest docs and evidence state
+- recording review findings, revision routes, and experiment requests
+
+### Use `memory` when
+
+- recurring review weaknesses or novelty caveats should persist
+
+### Use `bash_exec` when
+
+- building, compiling, or checking manuscript artifacts locally
+
+### Routing rule
+
+- if the problem is missing evidence, route to `analysis-campaign`
+- if the problem is wording, positioning, or claim scope, route to `write`
+- if the problem is novelty ambiguity, route to `scout`
+
+## Rebuttal
+
+### Use `artifact` when
+
+- reading reviewer packet state
+- recording response matrix, action plan, manuscript delta route, and evidence route
+
+### Use `memory` when
+
+- a recurring rebuttal pattern or claim downgrade should influence later responses
+
+### Use `bash_exec` when
+
+- building, compiling, or verifying local manuscript artifacts
+
+### Do not
+
+- do not hide an evidence gap under rhetorical rewriting
+
+## Paper Plot
+
+### Use `artifact` when
+
+- the figure requirement, output path, and downstream paper role need to be explicit
+
+### Use `bash_exec` when
+
+- rendering figures
+- rerendering after data or spec change
+- validating output existence and export
+
+### Use `memory` when
+
+- a plotting failure or rendering lesson is likely to recur
+
+### Do not
+
+- do not use `figure-polish` when the figure is still missing; first create the structured first-pass figure here
+
+## Figure Polish
+
+### Use `artifact` when
+
+- the figure already exists and the remaining blocker is presentation quality, not missing evidence
+
+### Use `bash_exec` when
+
+- rerendering polished versions
+- checking exports
+
+### Use `memory` when
+
+- a reusable polish or style lesson will affect later figures
+
+## Mentor
+
+### Use `artifact` when
+
+- reading the current board, route, blocker, or paper state before giving calibration advice
+
+### Use `memory` when
+
+- a reusable calibration lesson, founder preference, or do-not-repeat route mistake should persist
+
+### Use `bash_exec` when
+
+- local evidence inspection is needed before making a real calibration judgment
+
+### Do not
+
+- do not let mentor advice float free from the current durable state

--- a/src/skills/scout/SKILL.md
+++ b/src/skills/scout/SKILL.md
@@ -9,6 +9,69 @@ skill_role: stage
 Use this skill when the quest does not yet have a stable research frame.
 The goal is to make the task frame concrete enough that a heavier stage can start with confidence.
 
+## Match signals
+
+Use `scout` when:
+
+- the user goal is still ambiguous
+- the dataset or split contract is unclear
+- the primary metric is unclear
+- no trustworthy baseline has been identified
+- the paper or repo neighborhood is still thin
+- the quest was resumed after a long pause and framing needs reconstruction
+- the next stage is blocked by ambiguity rather than by implementation
+
+Do not use `scout` when:
+
+- the user already fixed the paper, baseline, dataset, metric contract, and scope
+- the quest already has a validated baseline and is ready for ideation or execution
+- the real blocker is execution or verification rather than framing
+
+## One-sentence summary
+
+Resolve only the minimum framing unknowns that change the next anchor, then stop once baseline or idea becomes durable and obvious.
+
+## Control workflow
+
+1. Reconstruct the current frame from durable state.
+   Make the current task, metric contract, baseline status, and blockers explicit before searching.
+2. Identify the minimum unknowns.
+   Keep only the unknowns that materially block `baseline`, `idea`, or both.
+3. Search only the unresolved neighborhood.
+   Reuse memory and local evidence first, then search the smallest paper, repo, and benchmark surface that can change the next anchor.
+4. Make the evaluation contract and baseline direction explicit.
+   End with a small decision-facing baseline shortlist rather than a broad literature dump.
+5. Record the next anchor or blocker and stop on clarity.
+   The right output is a durable frame, not search exhaustion.
+
+## AVOID / pitfalls
+
+- Do not let `scout` become endless exploration.
+- Do not keep searching once the next anchor is already clear.
+- Do not guess the metric, split, or baseline identity when local evidence is still ambiguous.
+- Do not ask the user ordinary technical questions before checking local evidence first.
+- Do not repeat the same wide search from scratch when existing survey notes, memory, or durable quest files already narrow the space.
+- Do not write long paper summaries that do not change the next stage.
+- Do not inflate novelty when the apparent gap is already closed by straightforward scaling, standard engineering, or a strong recent paper.
+
+## Constraints
+
+- Before broad external search, check quest or global memory first with `memory.list_recent(...)` and `memory.search(...)`.
+- When search tools are available, actively use them.
+- If DeepXiv is declared available by the system prompt, prefer the DeepXiv route for paper-centric discovery and shortlist triage before broader open-web search.
+- When a specific arXiv paper must be read or summarized, use `artifact.arxiv(paper_id=..., full_text=False)` instead of defaulting to a raw PDF.
+- Keep discovery in search tooling by default; use `artifact.arxiv(...)` only for actual paper reading, and set `full_text=True` only when needed.
+- `scout` should normally hand off to `baseline` or `idea` as soon as the next move is decision-ready.
+
+## Validation
+
+Before `scout` can end, all applicable checks should be true:
+
+- the task frame is explicit enough
+- the evaluation contract is explicit enough
+- at least one baseline direction is justified enough
+- the next anchor is obvious enough to record durably, or the blocker is explicit enough to stop guessing
+
 ## Interaction discipline
 
 Follow the shared interaction contract injected by the system prompt.
@@ -21,84 +84,6 @@ For ordinary active work, prefer a concise progress update once work has crossed
 - **Any shell, CLI, Python, bash, node, git, npm, uv, or repo-inspection execution must go through `bash_exec(...)`.**
 - **For git inspection inside the current quest repository or worktree, prefer `artifact.git(...)` before raw shell git commands.**
 - **If scouting only needs durable quest context, prefer `artifact.read_quest_documents(...)`, `artifact.get_quest_state(...)`, and `memory.*` instead of shelling out.**
-
-## Planning note
-
-Use quest/workspace planning files only when scouting becomes a real multi-step framing pass instead of a short clarification step.
-
-## Stage purpose
-
-The scout stage exists to answer the smallest set of framing questions required to make the rest of the quest efficient:
-
-- what exact task is being solved?
-- which dataset, split, and metric contract matter?
-- which papers, repos, and baselines define the local neighborhood?
-- which unknowns still block baseline or ideation?
-
-This stage is not generic browsing.
-It is a bounded framing and discovery stage that should quickly make the next anchor obvious.
-
-The scout stage should usually establish four layers:
-
-- task-definition layer
-- evaluation-contract layer
-- literature and repo neighborhood layer
-- baseline-direction layer
-
-If one of these layers is still missing, say so explicitly.
-
-## Non-negotiable rules
-
-- Do not let `scout` become endless exploration.
-- Do not keep searching once the next anchor is already clear.
-- Do not guess the metric, split, or baseline identity when local evidence is still ambiguous.
-- Do not ask the user ordinary technical questions before checking local evidence first.
-- Do not force a baseline route without comparing attach, import, and reproduce options.
-- Do not rely on memory alone when primary sources or durable quest files exist.
-- Before broad external search, check quest/global memory first with `memory.list_recent(...)` and `memory.search(...)`.
-- When search tools are available, actively use them.
-  If DeepXiv is declared available by the system prompt, prefer the DeepXiv route for paper-centric discovery and shortlist paper triage before broader open-web search.
-  If DeepXiv is declared unavailable, stay on the legacy route: web search, memory reuse, benchmark docs, official repos, and broader provenance checks.
-- When a specific arXiv paper must be read or summarized, use `artifact.arxiv(paper_id=..., full_text=False)` instead of defaulting to a raw PDF.
-  Keep discovery in search tooling by default; use `artifact.arxiv(...)` only for actual paper reading, and set `full_text=True` only when needed.
-- Avoid repeating the same wide search from scratch.
-  Reuse prior survey notes and search only for genuinely missing, newer, or unresolved references.
-- Do not write long paper summaries that do not change the next stage.
-- Search for disconfirming evidence, not only supportive evidence.
-- If the apparent gap is already closed by straightforward scaling, standard engineering, or a strong recent paper, say so directly instead of inflating novelty.
-
-## Use when
-
-- the user goal is still ambiguous
-- the dataset or split contract is unclear
-- the primary metric is unclear
-- no trustworthy baseline has been identified
-- the paper or repo neighborhood is still thin
-- the quest was resumed after a long pause and framing needs reconstruction
-- the next stage is blocked by ambiguity rather than by implementation
-
-## Do not use when
-
-- the user already fixed the paper, baseline, dataset, metric contract, and scope
-- the quest already has a validated baseline and is ready for ideation or execution
-- the real blocker is execution or verification rather than framing
-
-## Preconditions and gate
-
-Before spending time scouting, first verify whether the current quest already contains enough framing in:
-
-- `brief.md`
-- `plan.md`
-- `status.md`
-- `SUMMARY.md`
-- baseline artifacts
-- recent paper or knowledge memory cards
-
-If the answer is already clear, exit quickly and move to the correct next anchor.
-
-## Companion-skill note
-
-`scout` should hand off as soon as the next `baseline` or `idea` move is obvious enough to record durably.
 
 ## Truth sources
 
@@ -113,189 +98,49 @@ Prefer the following sources in order:
 
 Do not let the scout stage rest on vague recollection alone.
 
-## Durable-output note
+## Non-negotiable rules
 
-When scout matters, leave behind just enough durable framing state to make the next anchor obvious rather than building a large documentation package by default.
-If external search materially changed the frame, leave a literature scouting report rather than letting the survey live only in chat.
-Prefer the structure in `references/literature-scout-template.md`.
+- Do not force a baseline route without comparing attach, import, and reproduce options.
+- Do not rely on memory alone when primary sources or durable quest files exist.
+- Search for disconfirming evidence, not only supportive evidence.
+- If one of the core framing layers is still missing, say so explicitly instead of pretending the frame is complete.
 
-## Thinking note
+The scout stage should usually establish four layers:
 
-Keep scout conclusion-first and bounded: identify the minimum unknowns, resolve only the ones that change the next stage, then stop.
+- task-definition layer
+- evaluation-contract layer
+- literature and repo neighborhood layer
+- baseline-direction layer
 
-## Workflow
+## Preconditions and gate
 
-### 1. Reconstruct the current frame
-
-Summarize:
-
-- current task
-- current dataset and split understanding
-- current metric contract
-- current baseline status
-- current blockers
-
-If this can already be stated precisely, scouting may be complete immediately.
-
-### 2. Identify the minimum unknowns
-
-List only the unknowns that materially affect later stages, such as:
-
-- unclear evaluation metric
-- multiple conflicting dataset splits
-- missing baseline candidate
-- unclear repo or paper provenance
-- missing source paper for a claimed baseline
-
-Avoid collecting "nice to know" facts that do not change the next stage.
-
-Also classify each unknown:
-
-- blocks `baseline`
-- blocks `idea`
-- blocks both
-- useful but non-blocking
-
-### 2.1 Reuse durable state before broad new search
-
-Before a fresh wide search, quickly reuse existing quest state and memory so scouting only fills real gaps instead of restarting from zero.
-
-Stage-start requirement:
-
-- begin every scout pass with `memory.list_recent(scope='quest', limit=5)`
-- then run at least one scout-relevant `memory.search(...)` before broad new search
-- if several lines already exist, narrow retrieval to the current task, benchmark, dataset, metric, split, and likely baselines
-
-If the frame is already explicit after memory reuse, stop and record the next anchor.
-
-### 3. Search the paper and repo neighborhood
-
-Build a compact but sufficient neighborhood of references and implementations.
-
-Use external search actively when local evidence is not enough.
-
-For papers that survive triage and need real reading, switch from discovery to reading:
-
-- use web search to find the paper
-- then use `artifact.arxiv(paper_id=..., full_text=False)` to read or summarize it
-- only switch to `full_text=True` or the raw PDF when the shorter view does not cover the needed detail
-
-Search only the unresolved neighborhood that still changes framing, evaluation, or baseline choice.
-Use a compact search ladder:
-
-1. direct neighborhood:
-   - same task, dataset, and metric
-2. mechanism neighborhood:
-   - same main lever, objective, or architectural trick
-3. bottleneck neighborhood:
-   - same failure mode, evaluation caveat, or boundary condition
-
-For a more explicit search and triage method, read `references/paper-triage-playbook.md`.
-
-### 4. Clarify the evaluation contract
-
-Produce an explicit statement of:
-
-- task
-- dataset
-- split or evaluation partition
-- primary metric
-- secondary metrics if necessary
-- what counts as a useful improvement
-- what comparisons will be considered fair
-
-The evaluation contract should be strong enough that later `baseline`, `idea`, and `experiment` work do not need to keep re-deriving it.
-
-If the evaluation contract is still ambiguous after local analysis, ask the user for a structured decision instead of guessing.
-
-### 5. Produce a baseline shortlist
-
-End scouting with a clear baseline direction.
-
-For each serious candidate, score at least:
-
-- trustworthiness of provenance
-- metric and split compatibility
-- implementation availability
-- reproduction or import cost
-- value as a downstream comparison reference
-
-Each candidate should lead to one recommended route:
-
-- attach an existing baseline
-- import a reusable baseline package
-- reproduce a baseline from source
-- reject this candidate
-
-For each serious candidate, also state:
-
-- whether it is a direct baseline, a strong competitor, or only an adjacent reference
-- whether the repo path or paper evidence is strong enough to trust the route
-- the cheapest credible next action: attach, import, reproduce, or reject
-
-Keep the shortlist small and decision-facing rather than turning it into a broad survey of every plausible baseline.
-
-### 6. Recommend the next anchor
-
-Do not stop with a list of possibilities.
-Choose the most justified next anchor:
-
-- `baseline`
-- `idea`
-- remain in `scout`
-
-`idea` is only justified when the baseline is already durable and trustworthy enough.
-If no usable baseline exists, prefer `baseline`.
-
-### 7. Update quest continuity
-
-If the frame changed, update:
+Before spending time scouting, first verify whether the current quest already contains enough framing in:
 
 - `brief.md`
 - `plan.md`
 - `status.md`
+- `SUMMARY.md`
+- baseline artifacts
+- recent paper or knowledge memory cards
 
-Then record a durable report or decision showing the recommended next anchor.
+If the answer is already clear, exit quickly and move to the correct next anchor.
 
-### 8. Stop on clarity, not exhaustion
+## Operational guidance
 
-The stage is done when the framing is decision-ready, not when every curiosity is satisfied.
+The main skill keeps the control surface in front.
+For the longer search and handoff notes, read:
 
-Stop once all of the following are true:
+- `references/paper-triage-playbook.md`
+- `references/literature-scout-template.md`
+- `references/eval-contract-template.md`
+- `references/baseline-shortlist-template.md`
+- `references/operational-guidance.md`
 
-- the task frame is explicit enough
-- the evaluation contract is explicit enough
-- the baseline direction is justified enough
-- the next anchor is durable and obvious
+Use them when:
 
-## Search stop rules
-
-Stop literature and repo search when:
-
-- the strongest obvious local neighbors are mapped
-- the evaluation contract no longer depends on unknown sources
-- at least one baseline route is clearly better than the alternatives
-- additional papers are no longer changing the next action
-
-Continue searching only if:
-
-- metric or split ambiguity remains
-- the current shortlist is too weak or conflicting
-- provenance of the likely baseline is still uncertain
-
-Do not continue searching just to collect more papers after the next anchor is already clear.
-
-## Memory note
-
-Use memory to avoid repeating old scouting work and to preserve reusable framing conclusions, but do not let memory-writing become the stage's main output.
-
-Stage-end requirement:
-
-- if scouting produced a durable framing conclusion, literature scouting report, baseline-shortlist lesson, or metric-contract caveat, write at least one `memory.write(...)` before leaving the stage
-
-## Artifact note
-
-Record only the framing outputs that the next stage will actually consume, such as the evaluation contract, baseline direction, or next-anchor recommendation.
+- the paper and repo search needs a fuller playbook
+- the evaluation contract or baseline shortlist should be written durably
+- memory or artifact handling materially affects the route
 
 ## Blocked-state handling
 

--- a/src/skills/scout/references/operational-guidance.md
+++ b/src/skills/scout/references/operational-guidance.md
@@ -1,0 +1,191 @@
+# Operational Guidance
+
+Use this reference when the scout route needs the longer tactical notes rather than the short control surface in `SKILL.md`.
+
+## Planning note
+
+Use quest or workspace planning files only when scouting becomes a real multi-step framing pass instead of a short clarification step.
+
+## Durable-output note
+
+When scout matters, leave behind just enough durable framing state to make the next anchor obvious rather than building a large documentation package by default.
+If external search materially changed the frame, leave a literature scouting report rather than letting the survey live only in chat.
+Prefer the structure in `references/literature-scout-template.md`.
+
+## Thinking note
+
+Keep scout conclusion-first and bounded: identify the minimum unknowns, resolve only the ones that change the next stage, then stop.
+
+## Detailed workflow
+
+### 1. Reconstruct the current frame
+
+Summarize:
+
+- current task
+- current dataset and split understanding
+- current metric contract
+- current baseline status
+- current blockers
+
+If this can already be stated precisely, scouting may be complete immediately.
+
+### 2. Identify the minimum unknowns
+
+List only the unknowns that materially affect later stages, such as:
+
+- unclear evaluation metric
+- multiple conflicting dataset splits
+- missing baseline candidate
+- unclear repo or paper provenance
+- missing source paper for a claimed baseline
+
+Avoid collecting "nice to know" facts that do not change the next stage.
+
+Also classify each unknown:
+
+- blocks `baseline`
+- blocks `idea`
+- blocks both
+- useful but non-blocking
+
+### 2.1 Reuse durable state before broad new search
+
+Before a fresh wide search, quickly reuse existing quest state and memory so scouting only fills real gaps instead of restarting from zero.
+
+Stage-start requirement:
+
+- begin every scout pass with `memory.list_recent(scope='quest', limit=5)`
+- then run at least one scout-relevant `memory.search(...)` before broad new search
+- if several lines already exist, narrow retrieval to the current task, benchmark, dataset, metric, split, and likely baselines
+
+If the frame is already explicit after memory reuse, stop and record the next anchor.
+
+### 3. Search the paper and repo neighborhood
+
+Build a compact but sufficient neighborhood of references and implementations.
+
+Use external search actively when local evidence is not enough.
+
+For papers that survive triage and need real reading, switch from discovery to reading:
+
+- use web search to find the paper
+- then use `artifact.arxiv(paper_id=..., full_text=False)` to read or summarize it
+- only switch to `full_text=True` or the raw PDF when the shorter view does not cover the needed detail
+
+Search only the unresolved neighborhood that still changes framing, evaluation, or baseline choice.
+Use a compact search ladder:
+
+1. direct neighborhood:
+   - same task, dataset, and metric
+2. mechanism neighborhood:
+   - same main lever, objective, or architectural trick
+3. bottleneck neighborhood:
+   - same failure mode, evaluation caveat, or boundary condition
+
+For a more explicit search and triage method, read `references/paper-triage-playbook.md`.
+
+### 4. Clarify the evaluation contract
+
+Produce an explicit statement of:
+
+- task
+- dataset
+- split or evaluation partition
+- primary metric
+- secondary metrics if necessary
+- what counts as a useful improvement
+- what comparisons will be considered fair
+
+The evaluation contract should be strong enough that later `baseline`, `idea`, and `experiment` work do not need to keep re-deriving it.
+
+If the evaluation contract is still ambiguous after local analysis, ask the user for a structured decision instead of guessing.
+
+### 5. Produce a baseline shortlist
+
+End scouting with a clear baseline direction.
+
+For each serious candidate, score at least:
+
+- trustworthiness of provenance
+- metric and split compatibility
+- implementation availability
+- reproduction or import cost
+- value as a downstream comparison reference
+
+Each candidate should lead to one recommended route:
+
+- attach an existing baseline
+- import a reusable baseline package
+- reproduce a baseline from source
+- reject this candidate
+
+For each serious candidate, also state:
+
+- whether it is a direct baseline, a strong competitor, or only an adjacent reference
+- whether the repo path or paper evidence is strong enough to trust the route
+- the cheapest credible next action: attach, import, reproduce, or reject
+
+Keep the shortlist small and decision-facing rather than turning it into a broad survey of every plausible baseline.
+
+### 6. Recommend the next anchor
+
+Do not stop with a list of possibilities.
+Choose the most justified next anchor:
+
+- `baseline`
+- `idea`
+- remain in `scout`
+
+`idea` is only justified when the baseline is already durable and trustworthy enough.
+If no usable baseline exists, prefer `baseline`.
+
+### 7. Update quest continuity
+
+If the frame changed, update:
+
+- `brief.md`
+- `plan.md`
+- `status.md`
+
+Then record a durable report or decision showing the recommended next anchor.
+
+### 8. Stop on clarity, not exhaustion
+
+The stage is done when the framing is decision-ready, not when every curiosity is satisfied.
+
+Stop once all of the following are true:
+
+- the task frame is explicit enough
+- the evaluation contract is explicit enough
+- the baseline direction is justified enough
+- the next anchor is durable and obvious
+
+## Search stop rules
+
+Stop literature and repo search when:
+
+- the strongest obvious local neighbors are mapped
+- the evaluation contract no longer depends on unknown sources
+- at least one baseline route is clearly better than the alternatives
+- additional papers are no longer changing the next action
+
+Continue searching only if:
+
+- metric or split ambiguity remains
+- the current shortlist is too weak or conflicting
+- provenance of the likely baseline is still uncertain
+
+Do not continue searching just to collect more papers after the next anchor is already clear.
+
+## Memory note
+
+Use memory to avoid repeating old scouting work and to preserve reusable framing conclusions, but do not let memory-writing become the stage's main output.
+
+Stage-end requirement:
+
+- if scouting produced a durable framing conclusion, literature scouting report, baseline-shortlist lesson, or metric-contract caveat, write at least one `memory.write(...)` before leaving the stage
+
+## Artifact note
+
+Record only the framing outputs that the next stage will actually consume, such as the evaluation contract, baseline direction, or next-anchor recommendation.

--- a/src/skills/write/SKILL.md
+++ b/src/skills/write/SKILL.md
@@ -18,7 +18,7 @@ skill_role: stage
 1. Refresh control state first.
    Run `memory.list_recent(scope='quest', limit=5)` plus one writing-relevant `memory.search(...)`. If restart context is unclear, use `artifact.get_quest_state(detail='summary')`, `artifact.read_quest_documents(...)`, or `artifact.get_conversation_context(...)`.
 2. Lock the paper contract before heavy prose.
-   Keep `paper/selected_outline.json`, `paper/evidence_ledger.json`, and `paper/paper_experiment_matrix.md` or `.json` aligned. Use `artifact.get_paper_contract_health(detail='full')` when outline state, experiment rows, or evidence ownership may be stale. Use `artifact.submit_paper_outline(mode='candidate'|'select'|'revise', ...)` instead of leaving outline choice only in prose.
+   Keep `paper/selected_outline.json`, `paper/evidence_ledger.json`, and `paper/paper_experiment_matrix.md` or `.json` aligned. Use `artifact.get_paper_contract(detail='full')` as the default paper-reading surface when section rows, experiment rows, or analysis rows matter. Use `artifact.get_paper_contract_health(detail='full')` when outline state, experiment rows, or evidence ownership may be stale. Use `artifact.submit_paper_outline(mode='candidate'|'select'|'revise', ...)` instead of leaving outline choice only in prose.
 3. Refresh literature and citation truth.
    Run `breadth -> shortlist -> depth`. Use DeepXiv or OpenAlex for discovery when available, then retrieve BibTeX from DOI or arXiv, not from memory. Keep `paper/references.bib` machine-usable and audit it before bundle submission.
 4. Plan displays before prose.
@@ -31,6 +31,8 @@ skill_role: stage
 ## Tool Use
 - `artifact.get_paper_contract_health(detail='full')`:
   use when a weak section may actually be caused by stale outline state, unresolved experiment rows, or unclear evidence ownership.
+- `artifact.get_paper_contract(detail='full')`:
+  use by default before drafting any section, table, or analysis prose that depends on concrete main-experiment rows, analysis rows, or section-level `result_table` content.
 - `artifact.get_quest_state(detail='summary')`, `artifact.read_quest_documents(...)`, `artifact.get_conversation_context(...)`:
   use when restart context is unclear, when exact durable wording matters, or when you need file truth instead of chat recollection.
 - `artifact.submit_paper_outline(mode='candidate'|'select'|'revise', ...)`:
@@ -51,15 +53,18 @@ skill_role: stage
 ## AVOID / Pitfalls
 - Do not start with background explanation or overview prose; start with contract health, section job, and evidence state.
 - Do not keep drafting while outline, evidence ledger, or experiment matrix are stale.
+- Do not treat `paper_contract_health` as a substitute for reading the actual section `result_table`, evidence rows, or experiment-matrix rows.
 - Do not draft around missing evidence, unstable baselines, or unresolved non-optional experiment rows.
 - Do not hand-write BibTeX, citations, metrics, or method details from memory.
 - Do not improvise a new plotting stack inside `write` when `paper-plot` should own the first-pass figure.
 - Do not merge experiments and analysis into one undifferentiated result dump when they need distinct reviewer-facing jobs.
+- Do not use rows that are not clearly bound to the current `selected_outline_ref` / active paper line.
 - Do not keep appending new material to the top control block until it turns back into prose-heavy documentation; keep the top short and use the longer guidance below only when the task actually matches it.
 
 ## Constraints
 - Keep these files aligned when they exist:
   `paper/selected_outline.json`, `paper/evidence_ledger.json`, `paper/paper_experiment_matrix.md` or `.json`, `paper/references.bib`, `paper/claim_evidence_map.json`, `paper/paper_bundle_manifest.json`.
+- If a section depends on experiment or analysis evidence, draft from the current paper contract rows, not from remembered summaries.
 - Any shell, CLI, Python, bash, node, git, npm, uv, LaTeX, or file-inspection execution in this stage must go through `bash_exec(...)`.
 - Use `artifact.create_analysis_campaign(...)` only for real paper-facing evidence gaps, not for prose cleanup or citation chores.
 - Use `artifact.submit_paper_bundle(...)` only after draft, bibliography, and bundle metadata are durable enough to hand off.
@@ -70,6 +75,7 @@ skill_role: stage
 ## Validation
 - The current section or draft has a clear job and does not exceed the available evidence.
 - Every important claim can point to a durable artifact path, a verified citation, or an explicit gap.
+- Any section-level experiment table or analysis table is grounded in the current `result_table`, evidence-ledger rows, or experiment-matrix rows rather than health-only summaries.
 - `paper/references.bib` is real, current, and not hand-written from memory.
 - Required figures/tables either exist durably or are recorded as blockers.
 - Appendix bridges and artifact availability are described consistently across the manuscript.

--- a/tests/test_stage_skills.py
+++ b/tests/test_stage_skills.py
@@ -158,6 +158,47 @@ def test_idea_skill_requires_memory_first_literature_survey() -> None:
     assert "`references` or `bibliography` in a standard citation format" in gate_text
 
 
+def test_idea_skill_documents_objective_contract_board_packet_and_controlled_brainstorming() -> None:
+    root = repo_root() / "src" / "skills" / "idea"
+    text = (root / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "## Match signals" in text
+    assert "## One-sentence summary" in text
+    assert "## Control workflow" in text
+    assert "objective contract" in text
+    assert "current board packet" in text
+    assert "mechanism-family routes" in text
+    assert "objective-family routes" in text
+    assert "measurement-family routes" in text
+    assert "infrastructure-family routes" in text
+    assert "anti-win condition" in text
+
+    objective_template = (root / "references" / "objective-contract-template.md").read_text(encoding="utf-8")
+    board_template = (root / "references" / "current-board-packet-template.md").read_text(encoding="utf-8")
+    brainstorming_playbook = (root / "references" / "controlled-brainstorming-playbook.md").read_text(encoding="utf-8")
+
+    assert "false_progress_signals" in objective_template
+    assert "stale_routes_to_ignore" in board_template
+    assert "mechanism_family" in brainstorming_playbook
+    assert "objective_family" in brainstorming_playbook
+
+
+def test_intake_audit_and_decision_skills_share_current_board_packet_handoff() -> None:
+    intake_text = (repo_root() / "src" / "skills" / "intake-audit" / "SKILL.md").read_text(encoding="utf-8")
+    decision_text = (repo_root() / "src" / "skills" / "decision" / "SKILL.md").read_text(encoding="utf-8")
+    intake_template = (
+        repo_root() / "src" / "skills" / "intake-audit" / "references" / "state-audit-template.md"
+    ).read_text(encoding="utf-8")
+
+    assert "current-board surface" in intake_text
+    assert "`current_mainline`" in intake_text
+    assert "`stale_routes_to_ignore`" in intake_text
+    assert "current board packet" in decision_text
+    assert "route through `intake-audit` first" in decision_text
+    assert "## Current Board Packet" in intake_template
+    assert "next_decision_scope" in intake_template
+
+
 def test_scout_skill_requires_memory_first_literature_report() -> None:
     scout_skill = repo_root() / "src" / "skills" / "scout" / "SKILL.md"
     text = scout_skill.read_text(encoding="utf-8")
@@ -233,7 +274,7 @@ def test_skill_resync_repairs_frontmatter_and_removes_stale_files(temp_home: Pat
 
 def test_paper_reading_stage_skills_use_artifact_arxiv_and_legacy_skill_is_removed() -> None:
     root = repo_root() / "src" / "skills"
-    for skill_id in ("baseline", "scout", "idea", "write", "finalize"):
+    for skill_id in ("baseline", "scout", "idea", "finalize"):
         text = (root / skill_id / "SKILL.md").read_text(encoding="utf-8")
         assert "artifact.arxiv(" in text
         assert "alpharxiv-paper-loopup" not in text
@@ -247,35 +288,27 @@ def test_baseline_skill_documents_confirm_or_waive_gate() -> None:
     assert "artifact.waive_baseline(...)" in text
     assert "do not open the downstream gate" in text
     assert "requested_baseline_ref" in text
-    assert "verify the comparator and metric contract" in text
+    assert "comparator identity and core metric contract" in text
 
 
 def test_baseline_skill_documents_environment_autonomy_with_uv_as_tactic() -> None:
     text = (repo_root() / "src" / "skills" / "baseline" / "SKILL.md").read_text(encoding="utf-8")
-    assert "## Environment tactics" in text
-    assert "For Python baselines, prefer a reproducible isolated environment" in text
-    assert "`uv` is a useful default tactic" in text
-    assert "uv sync" in text
-    assert "uv venv" in text
-    assert "uv pip install" in text
-    assert "uv run ..." in text
-    assert "Switch to repo-native conda, docker, poetry" in text
-    assert "Do not force a global `uv` route when it would make the reproduced baseline less faithful" in text
+    assert "references/operational-guidance.md" in text
+    reference = (repo_root() / "src" / "skills" / "baseline" / "references" / "operational-guidance.md").read_text(encoding="utf-8")
+    assert "uv" in reference
 
 
 def test_baseline_skill_has_compact_durable_output_contract() -> None:
     text = (repo_root() / "src" / "skills" / "baseline" / "SKILL.md").read_text(encoding="utf-8")
-    assert "## Durable route records" in text
-    assert "Durable records are required in substance, not in fixed filenames" in text
-    assert "`PLAN.md`, `CHECKLIST.md`, `setup.md`, `execution.md`, `verification.md`, `analysis_plan.md`, and `REPRO_CHECKLIST.md` are allowed compatibility surfaces" in text
-    assert "`attachment.yaml` or equivalent provenance is required for attached or imported baselines" in text
-    assert "`<baseline_root>/json/metric_contract.json` as the canonical accepted comparison contract" in text
+    assert "Core metric contract" in text
+    assert "`attachment.yaml` or equivalent provenance" in text
+    assert "<baseline_root>/json/metric_contract.json" in text
 
 
 def test_decision_skill_requires_reuse_baseline_to_land_on_attach_and_confirm() -> None:
     text = (repo_root() / "src" / "skills" / "decision" / "SKILL.md").read_text(encoding="utf-8")
-    assert "artifact.attach_baseline(...)" in text
-    assert "artifact.confirm_baseline(...)" in text
+    assert "attach_baseline" in text
+    assert "reuse_baseline" in text
     assert "explicit blocker or waiver" in text
 
 
@@ -283,9 +316,9 @@ def test_experiment_and_decision_skills_document_activate_branch_and_analysis_co
     experiment_text = (repo_root() / "src" / "skills" / "experiment" / "SKILL.md").read_text(encoding="utf-8")
     decision_text = (repo_root() / "src" / "skills" / "decision" / "SKILL.md").read_text(encoding="utf-8")
 
-    assert "artifact.activate_branch(...)" in experiment_text
-    assert "clear academic or claim-level value" in experiment_text
-    assert "artifact.activate_branch(...)" in decision_text
+    assert "run/*" in experiment_text
+    assert "isolated run surface" in experiment_text
+    assert "activate_branch" in decision_text
     assert "extra resource cost" in decision_text
 
 
@@ -323,40 +356,36 @@ def test_shared_interaction_contract_covers_blocking_and_mailbox_rules() -> None
 
 def test_stage_and_companion_skills_reference_shared_interaction_contract() -> None:
     root = repo_root() / "src" / "skills"
-    for skill_id in INTERACTION_CONTRACT_SKILLS:
+    for skill_id in (INTERACTION_CONTRACT_SKILLS - {"write"}):
         text = (root / skill_id / "SKILL.md").read_text(encoding="utf-8")
         assert "Follow the shared interaction contract injected by the system prompt." in text
 
 
 def test_all_stage_skills_require_stage_start_memory_retrieval_and_stage_end_memory_write() -> None:
     root = repo_root() / "src" / "skills"
-    for skill_id in ("scout", "idea", "experiment", "analysis-campaign", "write", "finalize"):
+    for skill_id in ("scout", "idea", "write", "finalize"):
         text = (root / skill_id / "SKILL.md").read_text(encoding="utf-8")
-        assert "Stage-start requirement:" in text
-        assert "memory.list_recent(scope='quest', limit=5)" in text
+        assert "memory.list_recent" in text
         assert "memory.search(...)" in text
-        assert "Stage-end requirement:" in text
+    for skill_id in ("write", "finalize"):
+        text = (root / skill_id / "SKILL.md").read_text(encoding="utf-8")
         assert "memory.write(...)" in text
 
     baseline_text = (root / "baseline" / "SKILL.md").read_text(encoding="utf-8")
-    assert "do not require a fresh memory pass for every fast-path validation" in baseline_text
-    assert "use `memory.list_recent(...)` or `memory.search(...)` when resuming" in baseline_text
-    assert "fast-path exception:" in baseline_text
+    assert "repair earlier and now needs repair" in baseline_text or "baseline trust state is unclear" in baseline_text
 
 
 def test_experiment_skill_requires_outcome_status_in_memory_writes() -> None:
     text = (repo_root() / "src" / "skills" / "experiment" / "SKILL.md").read_text(encoding="utf-8")
-    assert "`success`, `partial`, or `failure`" in text
-    assert "`idea_id`, `branch`, and `run_id`" in text
+    assert "supported" in text
+    assert "refuted" in text
+    assert "inconclusive" in text
 
 
 def test_long_running_skills_require_next_reply_time_reporting() -> None:
     root = repo_root() / "src" / "skills"
-    experiment_text = (root / "experiment" / "SKILL.md").read_text(encoding="utf-8")
     campaign_text = (root / "analysis-campaign" / "SKILL.md").read_text(encoding="utf-8")
 
-    assert "estimated next reply time" in experiment_text
-    assert "next_reply_at" in experiment_text
     assert "estimated next reply time" in campaign_text
 
 
@@ -366,44 +395,26 @@ def test_stage_skills_document_palette_requirements_for_connector_and_paper_outp
     campaign_text = (root / "analysis-campaign" / "SKILL.md").read_text(encoding="utf-8")
     write_text = (root / "write" / "SKILL.md").read_text(encoding="utf-8")
 
-    assert "sage-clay" in experiment_text
-    assert "mist-stone" in experiment_text
-    assert "dust-rose" in experiment_text
-    assert "Connector-facing chart requirements" in experiment_text
-
-    assert "sage-clay" in campaign_text
-    assert "mist-stone" in campaign_text
-    assert "Connector-facing campaign chart requirements" in campaign_text
-
-    assert "mist-stone" in write_text
-    assert "sage-clay" in write_text
-    assert "Paper-figure requirements" in write_text
-    assert "#F3EEE8" in experiment_text
-    assert "#7F8F84" in campaign_text
-    assert "#B88C8C" in write_text
     assert "system prompt" in experiment_text
     assert "system prompt" in campaign_text
-    assert "system prompt Morandi plotting template" in write_text
+    assert "`paper-plot`" in write_text
+    assert "`figure-polish`" in write_text
 
 
-def test_write_skill_documents_reviewer_first_reader_first_contract_and_references() -> None:
+def test_write_skill_documents_reader_first_figure_first_contract_and_references() -> None:
     root = repo_root() / "src" / "skills" / "write"
     text = (root / "SKILL.md").read_text(encoding="utf-8")
 
-    assert "reviewer-first pass" in text
-    assert "reader-centered" in text
-    assert "paper experiment matrix" in text
-    assert "paper/reviewer_first_pass.md" in text
-    assert "paper/section_contracts.md" in text
-    assert "paper/figure_storyboard.md" in text
-    assert "paper/related_work_map.md" in text
+    assert "Refresh the paper contract first" in text
+    assert "Plan displays before prose" in text
+    assert "use `paper-plot` first" in text
+    assert "`figure-polish`" in text
     assert "paper/paper_experiment_matrix.md" in text
-    assert "paper/proofing/language_issues.md" in text
     assert "`paper-plot`" in text
-    assert (root / "references" / "paper-experiment-matrix-template.md").exists()
-    assert (root / "references" / "reviewer-first-writing.md").exists()
-    assert (root / "references" / "section-contracts.md").exists()
-    assert (root / "references" / "sentence-level-proofing.md").exists()
+    assert (root / "references" / "experiments_analysis_patterns.md").exists()
+    assert (root / "references" / "oral_package_patterns.md").exists()
+    assert (root / "references" / "oral_writing_principles.md").exists()
+    assert (root / "references" / "section_rewrite_checklist.md").exists()
 
 
 def test_experiment_and_analysis_references_cover_evidence_ladder_and_campaign_design() -> None:
@@ -413,9 +424,9 @@ def test_experiment_and_analysis_references_cover_evidence_ladder_and_campaign_d
     baseline_text = (root / "baseline" / "SKILL.md").read_text(encoding="utf-8")
 
     assert "references/evidence-ladder.md" in experiment_text
-    assert "auxiliary/dev" in experiment_text
-    assert "main/test" in experiment_text
-    assert "minimum -> solid -> maximum" in experiment_text
+    assert "minimum" in experiment_text
+    assert "solid" in experiment_text
+    assert "maximum" in experiment_text
     assert (root / "experiment" / "references" / "evidence-ladder.md").exists()
 
     assert "references/campaign-design.md" in campaign_text
@@ -471,15 +482,16 @@ def test_stage_skills_document_new_branch_lineage_semantics() -> None:
     assert "new canvas node" in idea_text
     assert "maintenance-only compatibility" in idea_text
 
-    assert "new durable idea branch" in experiment_text
-    assert "fixed round node" in experiment_text
-    assert "accepted idea -> `artifact.submit_idea(mode='create', lineage_intent='continue_line'|'branch_alternative', ...)`" in decision_text
+    assert "run/*" in experiment_text
+    assert "isolated run surface" in experiment_text
+    assert "branch" in decision_text
+    assert "prepare_branch" in decision_text
 
 
 def test_analysis_campaign_skill_requires_one_slice_campaign_for_single_extra_experiment() -> None:
     text = (repo_root() / "src" / "skills" / "analysis-campaign" / "SKILL.md").read_text(encoding="utf-8")
     assert "one-slice campaign" in text
-    assert "durable lineage matters" in text
+    assert "durable lineage" in text
     assert "Use a lighter durable report when one bounded answer is enough" in text
 
 


### PR DESCRIPTION
## Summary
- restructure major stage skills toward short control-surface-first layouts
- move longer operational notes and templates into `references/`
- add missing `src/skills/**` reference files to git
- align `tests/test_stage_skills.py` with the current skill structure

## Scope
- `src/skills/**`
- `tests/test_stage_skills.py`

## Validation
- `pytest -q tests/test_stage_skills.py`