### PR TITLE
Runner: sidecar oversized Codex tool results

### DIFF
--- a/src/deepscientist/evidence_packets.py
+++ b/src/deepscientist/evidence_packets.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from .shared import ensure_dir, read_json, utc_now, write_json
+
+DEFAULT_EVIDENCE_PACKET_THRESHOLD_BYTES = 48_000
+DEFAULT_RUNNER_TOOL_RESULT_THRESHOLD_BYTES = 8_000
+_MAX_SUMMARY_CHARS = 900
+_MAX_BLOCKERS = 12
+
+
+def payload_json_bytes(payload: Any) -> bytes:
+    try:
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str).encode("utf-8")
+    except Exception:
+        return str(payload).encode("utf-8", errors="replace")
+
+
+def payload_sha256(payload: Any) -> str:
+    return hashlib.sha256(payload_json_bytes(payload)).hexdigest()
+
+
+def _slug(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "").strip())
+    return normalized.strip("-")[:80] or "payload"
+
+
+def _sidecar_path(
+    *,
+    quest_root: Path,
+    run_id: str | None,
+    tool_name: str,
+    payload_hash: str,
+    item_id: str | None = None,
+) -> Path:
+    run_segment = _slug(run_id or "manual")
+    item_segment = _slug(item_id or payload_hash[:12])
+    tool_segment = _slug(tool_name)
+    return quest_root / ".ds" / "evidence_packets" / run_segment / f"{tool_segment}-{item_segment}.json"
+
+
+def _collect_blockers(value: Any, blockers: list[str]) -> None:
+    if len(blockers) >= _MAX_BLOCKERS:
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            lowered = str(key or "").lower()
+            if any(marker in lowered for marker in ("block", "gap", "missing", "error", "invalid", "unresolved")):
+                if isinstance(item, str) and item.strip():
+                    blockers.append(item.strip())
+                elif isinstance(item, list):
+                    for child in item:
+                        if len(blockers) >= _MAX_BLOCKERS:
+                            break
+                        if isinstance(child, str) and child.strip():
+                            blockers.append(child.strip())
+                        elif isinstance(child, dict):
+                            title = str(child.get("title") or child.get("summary") or child.get("reason") or "").strip()
+                            status = str(child.get("status") or "").strip()
+                            if title:
+                                blockers.append(f"{status}: {title}".strip(": "))
+                elif isinstance(item, dict):
+                    title = str(item.get("title") or item.get("summary") or item.get("reason") or "").strip()
+                    if title:
+                        blockers.append(title)
+            if isinstance(item, (dict, list)):
+                _collect_blockers(item, blockers)
+            if len(blockers) >= _MAX_BLOCKERS:
+                break
+    elif isinstance(value, list):
+        for item in value:
+            _collect_blockers(item, blockers)
+            if len(blockers) >= _MAX_BLOCKERS:
+                break
+
+
+def extract_key_blockers(payload: Any) -> list[str]:
+    blockers: list[str] = []
+    _collect_blockers(payload, blockers)
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for blocker in blockers:
+        text = " ".join(str(blocker).split())
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        ordered.append(text[:240])
+        if len(ordered) >= _MAX_BLOCKERS:
+            break
+    return ordered
+
+
+def _first_text(payload: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return " ".join(value.split())
+    return None
+
+
+def summarize_payload(payload: Any, *, tool_name: str) -> str:
+    if not isinstance(payload, dict):
+        text = str(payload).strip()
+        return (text[: _MAX_SUMMARY_CHARS - 1].rstrip() + "...") if len(text) > _MAX_SUMMARY_CHARS else text
+
+    parts: list[str] = []
+    ok_value = payload.get("ok")
+    if isinstance(ok_value, bool):
+        parts.append(f"ok={ok_value}")
+    status = _first_text(payload, ("status", "state", "detail", "summary", "message"))
+    if status:
+        parts.append(f"status={status}")
+    for key in ("count", "total", "item_count", "log_line_count"):
+        if key in payload and isinstance(payload.get(key), int | float | str):
+            parts.append(f"{key}={payload.get(key)}")
+    for key in ("items", "results", "entries", "files"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            parts.append(f"{key}={len(value)}")
+            break
+
+    blockers = extract_key_blockers(payload)
+    if blockers:
+        parts.append(f"key_blockers={len(blockers)}")
+        parts.append(f"first_blocker={blockers[0]}")
+
+    summary = f"{tool_name}: " + "; ".join(str(part) for part in parts if str(part).strip())
+    if summary.strip() == f"{tool_name}:":
+        summary = f"{tool_name}: compact evidence packet available in sidecar."
+    if len(summary) > _MAX_SUMMARY_CHARS:
+        summary = summary[: _MAX_SUMMARY_CHARS - 3].rstrip() + "..."
+    return summary
+
+
+def compact_evidence_payload(
+    payload: Any,
+    *,
+    quest_root: Path,
+    run_id: str | None,
+    tool_name: str,
+    detail: str | None = None,
+    item_id: str | None = None,
+    force: bool = False,
+    threshold_bytes: int = DEFAULT_EVIDENCE_PACKET_THRESHOLD_BYTES,
+    reason: str | None = None,
+    full_detail_requested: bool | None = None,
+) -> tuple[Any, dict[str, Any]]:
+    payload_bytes = len(payload_json_bytes(payload))
+    threshold = max(1, int(threshold_bytes))
+    if not force and payload_bytes <= threshold:
+        return payload, {
+            "compacted": False,
+            "payload_bytes": payload_bytes,
+            "threshold_bytes": threshold,
+        }
+
+    digest = payload_sha256(payload)
+    sidecar_path = _sidecar_path(
+        quest_root=quest_root,
+        run_id=run_id,
+        tool_name=tool_name,
+        payload_hash=digest,
+        item_id=item_id,
+    )
+    ensure_dir(sidecar_path.parent)
+    key_blockers = extract_key_blockers(payload)
+    summary = summarize_payload(payload, tool_name=tool_name)
+    write_json(
+        sidecar_path,
+        {
+            "version": 1,
+            "created_at": utc_now(),
+            "tool_name": tool_name,
+            "detail": detail,
+            "summary": summary,
+            "key_blockers": key_blockers,
+            "payload_sha256": digest,
+            "payload_bytes": payload_bytes,
+            "payload": payload,
+        },
+    )
+    index_path = sidecar_path.parent / "index.json"
+    existing_index = read_json(index_path, {})
+    existing_items = (
+        [dict(item) for item in (existing_index.get("items") or []) if isinstance(item, dict)]
+        if isinstance(existing_index, dict)
+        else []
+    )
+    entry = {
+        "tool_name": tool_name,
+        "detail": detail,
+        "summary": summary,
+        "sidecar_path": str(sidecar_path),
+        "payload_sha256": digest,
+        "payload_bytes": payload_bytes,
+        "key_blockers": key_blockers,
+        "created_at": utc_now(),
+    }
+    write_json(
+        index_path,
+        {
+            "version": 1,
+            "updated_at": utc_now(),
+            "run_id": run_id,
+            "items": [*existing_items, entry][-200:],
+        },
+    )
+    evidence_packet = {
+        "version": 1,
+        "tool_name": tool_name,
+        "detail": detail,
+        "summary": summary,
+        "sidecar_path": str(sidecar_path),
+        "index_path": str(index_path),
+        "payload_sha256": digest,
+        "payload_bytes": payload_bytes,
+        "key_blockers": key_blockers,
+        "full_detail_requested": bool(full_detail_requested),
+        "compaction_reason": reason or "context_budget",
+        "drill_down_rule": "Read sidecar_path only when the compact facts are insufficient for the next decision.",
+    }
+    compacted = {
+        "ok": bool(payload.get("ok")) if isinstance(payload, dict) and isinstance(payload.get("ok"), bool) else True,
+        "compacted": True,
+        "evidence_packet": evidence_packet,
+    }
+    return compacted, {
+        "compacted": True,
+        "sidecar_path": str(sidecar_path),
+        "payload_sha256": digest,
+        "payload_bytes": payload_bytes,
+        "summary": summary,
+        "key_blocker_count": len(key_blockers),
+    }
+
+
+def compact_runner_tool_event(
+    event: dict[str, Any],
+    *,
+    quest_root: Path,
+    run_id: str,
+    threshold_bytes: int = DEFAULT_RUNNER_TOOL_RESULT_THRESHOLD_BYTES,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if str(event.get("type") or "") != "runner.tool_result":
+        return event, {"compacted": False}
+    output = str(event.get("output") or "")
+    tool_name = str(event.get("tool_name") or event.get("mcp_tool") or "tool").strip() or "tool"
+    args = str(event.get("args") or "")
+    full_detail_requested = "detail" in args and "full" in args.lower()
+    output_bytes = len(output.encode("utf-8", errors="replace"))
+    if output_bytes <= max(1, int(threshold_bytes)):
+        return event, {
+            "compacted": False,
+            "output_bytes": output_bytes,
+            "threshold_bytes": int(threshold_bytes),
+        }
+
+    parsed_payload: Any
+    try:
+        parsed_payload = json.loads(output)
+    except json.JSONDecodeError:
+        parsed_payload = {"text": output}
+    compacted_payload, meta = compact_evidence_payload(
+        parsed_payload,
+        quest_root=quest_root,
+        run_id=run_id,
+        tool_name=tool_name,
+        item_id=str(event.get("event_id") or event.get("tool_call_id") or ""),
+        force=True,
+        threshold_bytes=threshold_bytes,
+        reason="runner_tool_result_context_budget",
+        full_detail_requested=full_detail_requested,
+    )
+    compacted_event = dict(event)
+    compacted_event["output"] = json.dumps(compacted_payload, ensure_ascii=False, indent=2)
+    compacted_event["output_bytes"] = output_bytes
+    compacted_event["output_sha256"] = hashlib.sha256(output.encode("utf-8", errors="replace")).hexdigest()
+    compacted_event["output_compacted"] = True
+    compacted_event["evidence_packet"] = (
+        compacted_payload.get("evidence_packet") if isinstance(compacted_payload, dict) else None
+    )
+    return compacted_event, {
+        **meta,
+        "output_bytes": output_bytes,
+    }

--- a/src/deepscientist/evidence_packets.py
+++ b/src/deepscientist/evidence_packets.py
@@ -12,6 +12,7 @@ DEFAULT_EVIDENCE_PACKET_THRESHOLD_BYTES = 48_000
 DEFAULT_RUNNER_TOOL_RESULT_THRESHOLD_BYTES = 8_000
 _MAX_SUMMARY_CHARS = 900
 _MAX_BLOCKERS = 12
+_RAW_PAYLOAD_UNSET = object()
 
 
 def payload_json_bytes(payload: Any) -> bytes:
@@ -137,6 +138,30 @@ def summarize_payload(payload: Any, *, tool_name: str) -> str:
     return summary
 
 
+def _ok_from_payload_or_status(payload: Any, *, status: str | None = None) -> bool | None:
+    if isinstance(payload, dict):
+        ok_value = payload.get("ok")
+        if isinstance(ok_value, bool):
+            return ok_value
+        success_value = payload.get("success")
+        if isinstance(success_value, bool):
+            return success_value
+        for key in ("status", "state"):
+            value = payload.get(key)
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                if normalized in {"failed", "failure", "error", "errored", "cancelled", "canceled", "invalid"}:
+                    return False
+                if normalized in {"completed", "complete", "success", "succeeded", "ok", "ready"}:
+                    return True
+    normalized_status = str(status or "").strip().lower()
+    if normalized_status in {"failed", "failure", "error", "errored", "cancelled", "canceled", "invalid"}:
+        return False
+    if normalized_status in {"completed", "complete", "success", "succeeded", "ok", "ready"}:
+        return True
+    return None
+
+
 def compact_evidence_payload(
     payload: Any,
     *,
@@ -149,6 +174,7 @@ def compact_evidence_payload(
     threshold_bytes: int = DEFAULT_EVIDENCE_PACKET_THRESHOLD_BYTES,
     reason: str | None = None,
     full_detail_requested: bool | None = None,
+    status: str | None = None,
 ) -> tuple[Any, dict[str, Any]]:
     payload_bytes = len(payload_json_bytes(payload))
     threshold = max(1, int(threshold_bytes))
@@ -225,10 +251,12 @@ def compact_evidence_payload(
         "drill_down_rule": "Read sidecar_path only when the compact facts are insufficient for the next decision.",
     }
     compacted = {
-        "ok": bool(payload.get("ok")) if isinstance(payload, dict) and isinstance(payload.get("ok"), bool) else True,
         "compacted": True,
         "evidence_packet": evidence_packet,
     }
+    ok_value = _ok_from_payload_or_status(payload, status=status)
+    if ok_value is not None:
+        compacted["ok"] = ok_value
     return compacted, {
         "compacted": True,
         "sidecar_path": str(sidecar_path),
@@ -245,6 +273,7 @@ def compact_runner_tool_event(
     quest_root: Path,
     run_id: str,
     threshold_bytes: int = DEFAULT_RUNNER_TOOL_RESULT_THRESHOLD_BYTES,
+    raw_payload: Any = _RAW_PAYLOAD_UNSET,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     if str(event.get("type") or "") != "runner.tool_result":
         return event, {"compacted": False}
@@ -253,20 +282,25 @@ def compact_runner_tool_event(
     args = str(event.get("args") or "")
     full_detail_requested = "detail" in args and "full" in args.lower()
     output_bytes = len(output.encode("utf-8", errors="replace"))
-    if output_bytes <= max(1, int(threshold_bytes)):
+    has_raw_payload = raw_payload is not _RAW_PAYLOAD_UNSET
+    source_payload = raw_payload if has_raw_payload else _RAW_PAYLOAD_UNSET
+    source_payload_bytes = len(payload_json_bytes(source_payload)) if has_raw_payload else 0
+    threshold = max(1, int(threshold_bytes))
+    if output_bytes <= threshold and source_payload_bytes <= threshold:
         return event, {
             "compacted": False,
             "output_bytes": output_bytes,
-            "threshold_bytes": int(threshold_bytes),
+            "source_payload_bytes": source_payload_bytes,
+            "threshold_bytes": threshold,
         }
 
-    parsed_payload: Any
-    try:
-        parsed_payload = json.loads(output)
-    except json.JSONDecodeError:
-        parsed_payload = {"text": output}
+    if not has_raw_payload:
+        try:
+            source_payload = json.loads(output)
+        except json.JSONDecodeError:
+            source_payload = {"text": output}
     compacted_payload, meta = compact_evidence_payload(
-        parsed_payload,
+        source_payload,
         quest_root=quest_root,
         run_id=run_id,
         tool_name=tool_name,
@@ -275,11 +309,15 @@ def compact_runner_tool_event(
         threshold_bytes=threshold_bytes,
         reason="runner_tool_result_context_budget",
         full_detail_requested=full_detail_requested,
+        status=str(event.get("status") or ""),
     )
     compacted_event = dict(event)
     compacted_event["output"] = json.dumps(compacted_payload, ensure_ascii=False, indent=2)
     compacted_event["output_bytes"] = output_bytes
     compacted_event["output_sha256"] = hashlib.sha256(output.encode("utf-8", errors="replace")).hexdigest()
+    if has_raw_payload:
+        compacted_event["source_payload_bytes"] = source_payload_bytes
+        compacted_event["source_payload_sha256"] = payload_sha256(source_payload)
     compacted_event["output_compacted"] = True
     compacted_event["evidence_packet"] = (
         compacted_payload.get("evidence_packet") if isinstance(compacted_payload, dict) else None
@@ -287,4 +325,5 @@ def compact_runner_tool_event(
     return compacted_event, {
         **meta,
         "output_bytes": output_bytes,
+        "source_payload_bytes": source_payload_bytes,
     }

--- a/src/deepscientist/runners/codex.py
+++ b/src/deepscientist/runners/codex.py
@@ -17,6 +17,7 @@ from ..codex_cli_compat import (
     provider_profile_metadata_from_home,
 )
 from ..config import ConfigManager
+from ..evidence_packets import compact_runner_tool_event
 from ..gitops import export_git_graph
 from ..process_control import process_session_popen_kwargs
 from ..prompts import PromptBuilder
@@ -130,6 +131,40 @@ _WINDOWS_GBK_SAFE_REPLACEMENTS: dict[str, str] = {
     "̀": "",
     "́": "",
 }
+
+
+def _usage_metrics_from_event(event: dict[str, Any]) -> dict[str, int]:
+    candidates: list[dict[str, Any]] = []
+    for key in ("usage", "token_usage", "turn_usage"):
+        value = event.get(key)
+        if isinstance(value, dict):
+            candidates.append(value)
+    item = event.get("item")
+    if isinstance(item, dict):
+        for key in ("usage", "token_usage", "turn_usage"):
+            value = item.get(key)
+            if isinstance(value, dict):
+                candidates.append(value)
+    aliases = {
+        "input_tokens": ("input_tokens", "prompt_tokens"),
+        "cached_input_tokens": ("cached_input_tokens", "cached_tokens", "cached_prompt_tokens"),
+        "output_tokens": ("output_tokens", "completion_tokens"),
+        "total_tokens": ("total_tokens",),
+    }
+    merged: dict[str, int] = {}
+    for candidate in candidates:
+        for target, source_keys in aliases.items():
+            if target in merged:
+                continue
+            for key in source_keys:
+                value = candidate.get(key)
+                if isinstance(value, int):
+                    merged[target] = value
+                    break
+                if isinstance(value, float):
+                    merged[target] = int(value)
+                    break
+    return merged
 
 
 def _compact_text(value: object, *, limit: int = 1200) -> str:
@@ -873,6 +908,30 @@ class CodexRunner:
                 "windows_gbk_replacements": prompt_sanitization,
             },
         )
+        telemetry: dict[str, Any] = {
+            "version": 1,
+            "quest_id": request.quest_id,
+            "run_id": request.run_id,
+            "skill_id": request.skill_id,
+            "turn_reason": request.turn_reason,
+            "turn_intent": request.turn_intent,
+            "turn_mode": request.turn_mode,
+            "model": request.model,
+            "model_inherited": str(request.model or "").strip().lower()
+            in {"", "inherit", "default", "codex-default", "inherit_local_codex_default"},
+            "reasoning_effort": request.reasoning_effort,
+            "runner_profile": str(runner_config.get("profile") or "").strip() or None,
+            "prompt_bytes": len(prompt.encode("utf-8", errors="replace")),
+            "stdout_event_count": 0,
+            "stdout_bytes": 0,
+            "tool_call_count": 0,
+            "tool_result_count": 0,
+            "tool_result_bytes_total": 0,
+            "compacted_tool_result_count": 0,
+            "full_detail_tool_call_count": 0,
+            "token_usage": {},
+            "created_at": utc_now(),
+        }
 
         env = dict(**os.environ)
         runner_env = runner_config.get("env") if isinstance(runner_config.get("env"), dict) else {}
@@ -985,10 +1044,17 @@ class CodexRunner:
                 line = raw_line.rstrip("\n")
                 if not line:
                     continue
+                telemetry["stdout_event_count"] = int(telemetry.get("stdout_event_count") or 0) + 1
+                telemetry["stdout_bytes"] = int(telemetry.get("stdout_bytes") or 0) + len(
+                    line.encode("utf-8", errors="replace")
+                )
                 try:
                     payload = json.loads(line)
                 except json.JSONDecodeError:
                     payload = {"raw": line}
+                usage_metrics = _usage_metrics_from_event(payload)
+                if usage_metrics:
+                    telemetry["token_usage"] = usage_metrics
                 timestamp = utc_now()
                 append_jsonl(history_events, {"timestamp": timestamp, "event": payload})
                 append_jsonl(stdout_events, {"timestamp": timestamp, "line": line})
@@ -1008,6 +1074,28 @@ class CodexRunner:
                     created_at=timestamp,
                 )
                 if tool_event is not None:
+                    if str(tool_event.get("type") or "") == "runner.tool_call":
+                        telemetry["tool_call_count"] = int(telemetry.get("tool_call_count") or 0) + 1
+                        args_text = str(tool_event.get("args") or "")
+                        if "detail" in args_text and "full" in args_text.lower():
+                            telemetry["full_detail_tool_call_count"] = int(
+                                telemetry.get("full_detail_tool_call_count") or 0
+                            ) + 1
+                    if str(tool_event.get("type") or "") == "runner.tool_result":
+                        compacted_tool_event, compaction_meta = compact_runner_tool_event(
+                            tool_event,
+                            quest_root=request.quest_root,
+                            run_id=request.run_id,
+                        )
+                        tool_event = compacted_tool_event
+                        telemetry["tool_result_count"] = int(telemetry.get("tool_result_count") or 0) + 1
+                        telemetry["tool_result_bytes_total"] = int(
+                            telemetry.get("tool_result_bytes_total") or 0
+                        ) + int(compaction_meta.get("output_bytes") or compaction_meta.get("payload_bytes") or 0)
+                        if bool(compaction_meta.get("compacted")):
+                            telemetry["compacted_tool_result_count"] = int(
+                                telemetry.get("compacted_tool_result_count") or 0
+                            ) + 1
                     append_jsonl(quest_events, tool_event)
                 message_events, message_output_parts = _message_events(
                     payload,
@@ -1043,6 +1131,12 @@ class CodexRunner:
                 output_text=output_text,
                 quest_events=quest_events,
             )
+            telemetry["exit_code"] = exit_code
+            telemetry["stderr_bytes"] = len(stderr_text.encode("utf-8", errors="replace"))
+            telemetry["output_text_bytes"] = len(output_text.encode("utf-8", errors="replace"))
+            telemetry["completed_at"] = utc_now()
+            telemetry_path = run_root / "telemetry.json"
+            write_json(telemetry_path, telemetry)
             append_jsonl(
                 quest_events,
                 {
@@ -1059,6 +1153,27 @@ class CodexRunner:
                     "created_at": utc_now(),
                 },
             )
+            append_jsonl(
+                quest_events,
+                {
+                    "event_id": generate_id("evt"),
+                    "type": "runner.turn_telemetry",
+                    "quest_id": request.quest_id,
+                    "run_id": request.run_id,
+                    "source": "codex",
+                    "skill_id": request.skill_id,
+                    "model": request.model,
+                    "prompt_bytes": telemetry.get("prompt_bytes"),
+                    "stdout_bytes": telemetry.get("stdout_bytes"),
+                    "tool_call_count": telemetry.get("tool_call_count"),
+                    "tool_result_bytes_total": telemetry.get("tool_result_bytes_total"),
+                    "compacted_tool_result_count": telemetry.get("compacted_tool_result_count"),
+                    "full_detail_tool_call_count": telemetry.get("full_detail_tool_call_count"),
+                    "token_usage": telemetry.get("token_usage"),
+                    "telemetry_path": str(telemetry_path),
+                    "created_at": utc_now(),
+                },
+            )
             write_text(history_root / "assistant.md", (output_text or "") + ("\n" if output_text else ""))
             write_text(run_root / "stderr.txt", stderr_text)
             result_payload = {
@@ -1068,6 +1183,7 @@ class CodexRunner:
                 "exit_code": exit_code,
                 "history_root": str(history_root),
                 "run_root": str(run_root),
+                "telemetry_path": str(telemetry_path),
                 "output_text": output_text,
                 "stderr_text": stderr_text,
                 "completed_at": utc_now(),

--- a/src/deepscientist/runners/codex.py
+++ b/src/deepscientist/runners/codex.py
@@ -573,6 +573,56 @@ def _mcp_result_payload(item: dict[str, Any]) -> dict[str, Any]:
     return {}
 
 
+def _parse_single_text_content(value: Any) -> Any | None:
+    if not isinstance(value, list) or len(value) != 1:
+        return None
+    item = value[0]
+    if not isinstance(item, dict):
+        return None
+    text = item.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def _raw_tool_result_payload(event: dict[str, Any]) -> Any | None:
+    item = event.get("item") if isinstance(event.get("item"), dict) else {}
+    item_type = str(item.get("type") or event.get("item_type") or "")
+    if item_type == "mcp_tool_call":
+        result = item.get("result")
+        if isinstance(result, dict):
+            structured = result.get("structured_content") or result.get("structuredContent")
+            if structured is not None:
+                return structured
+            parsed_content = _parse_single_text_content(result.get("content"))
+            if parsed_content is not None:
+                return parsed_content
+            return result
+        if result is not None:
+            return result
+
+    for value in (
+        item.get("result"),
+        item.get("aggregated_output"),
+        item.get("changes"),
+        item.get("output"),
+        item.get("content"),
+        item.get("error"),
+        event.get("result"),
+        event.get("aggregated_output"),
+        event.get("changes"),
+        event.get("output"),
+        event.get("content"),
+        event.get("error"),
+    ):
+        if value is not None:
+            return value
+    return None
+
+
 def _mcp_tool_metadata(
     *,
     quest_id: str,
@@ -1082,16 +1132,26 @@ class CodexRunner:
                                 telemetry.get("full_detail_tool_call_count") or 0
                             ) + 1
                     if str(tool_event.get("type") or "") == "runner.tool_result":
+                        raw_tool_payload = _raw_tool_result_payload(payload)
+                        compaction_kwargs: dict[str, Any] = {}
+                        if raw_tool_payload is not None:
+                            compaction_kwargs["raw_payload"] = raw_tool_payload
                         compacted_tool_event, compaction_meta = compact_runner_tool_event(
                             tool_event,
                             quest_root=request.quest_root,
                             run_id=request.run_id,
+                            **compaction_kwargs,
                         )
                         tool_event = compacted_tool_event
                         telemetry["tool_result_count"] = int(telemetry.get("tool_result_count") or 0) + 1
                         telemetry["tool_result_bytes_total"] = int(
                             telemetry.get("tool_result_bytes_total") or 0
-                        ) + int(compaction_meta.get("output_bytes") or compaction_meta.get("payload_bytes") or 0)
+                        ) + int(
+                            compaction_meta.get("source_payload_bytes")
+                            or compaction_meta.get("output_bytes")
+                            or compaction_meta.get("payload_bytes")
+                            or 0
+                        )
                         if bool(compaction_meta.get("compacted")):
                             telemetry["compacted_tool_result_count"] = int(
                                 telemetry.get("compacted_tool_result_count") or 0

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -175,6 +175,216 @@ def test_codex_compacts_extreme_tool_result_payload_before_event_write() -> None
     assert rendered["metadata"]["bash_id"] == "bash-extreme"
 
 
+def test_codex_runner_sidecars_oversized_tool_result_event(temp_home: Path) -> None:
+    from deepscientist.evidence_packets import compact_runner_tool_event
+
+    quest_root = temp_home / "quest"
+    quest_root.mkdir(parents=True, exist_ok=True)
+    large_result = {
+        "ok": True,
+        "status": "completed",
+        "items": [{"path": f"file-{index}.txt", "status": "current"} for index in range(600)],
+        "blockers": ["missing required source file"],
+    }
+    event = {
+        "event_id": "evt-large-tool",
+        "type": "runner.tool_result",
+        "quest_id": "q-001",
+        "run_id": "run-001",
+        "source": "codex",
+        "skill_id": "baseline",
+        "tool_call_id": "tool-large",
+        "tool_name": "artifact.read_quest_documents",
+        "status": "completed",
+        "args": '{"detail": "summary"}',
+        "output": json.dumps(large_result, ensure_ascii=False),
+    }
+
+    compacted, meta = compact_runner_tool_event(event, quest_root=quest_root, run_id="run-001")
+
+    assert meta["compacted"] is True
+    assert compacted["output_compacted"] is True
+    assert compacted["output_sha256"]
+    rendered = json.loads(compacted["output"])
+    packet = rendered["evidence_packet"]
+    assert packet["tool_name"] == "artifact.read_quest_documents"
+    assert packet["payload_bytes"] > 8_000
+    assert packet["summary"].startswith("artifact.read_quest_documents:")
+    sidecar_path = Path(packet["sidecar_path"])
+    assert sidecar_path.exists()
+    sidecar = read_json(sidecar_path, {})
+    assert sidecar["payload_sha256"] == packet["payload_sha256"]
+    assert sidecar["payload"]["items"][0]["path"] == "file-0.txt"
+    assert "missing required source file" in sidecar["key_blockers"]
+
+
+def test_codex_runner_leaves_normal_tool_result_event_parseable(temp_home: Path) -> None:
+    from deepscientist.evidence_packets import compact_runner_tool_event
+
+    quest_root = temp_home / "quest"
+    quest_root.mkdir(parents=True, exist_ok=True)
+    event = {
+        "event_id": "evt-small-tool",
+        "type": "runner.tool_result",
+        "quest_id": "q-001",
+        "run_id": "run-001",
+        "source": "codex",
+        "skill_id": "baseline",
+        "tool_call_id": "tool-small",
+        "tool_name": "artifact.get_quest_state",
+        "status": "completed",
+        "args": '{"detail": "summary"}',
+        "output": json.dumps({"ok": True, "status": "ready"}, ensure_ascii=False),
+    }
+
+    compacted, meta = compact_runner_tool_event(event, quest_root=quest_root, run_id="run-001")
+
+    assert meta["compacted"] is False
+    assert compacted == event
+    assert json.loads(compacted["output"])["status"] == "ready"
+
+
+def test_codex_runner_writes_tool_result_telemetry_and_sidecar(
+    monkeypatch,
+    temp_home: Path,
+) -> None:  # type: ignore[no-untyped-def]
+    quest_root = temp_home / "quest"
+    quest_root.mkdir(parents=True, exist_ok=True)
+    write_yaml(quest_root / "quest.yaml", {"quest_id": "q-telemetry", "active_anchor": "baseline"})
+    large_log = "\n".join(f"line {index}: {'x' * 160}" for index in range(300))
+    tool_result_payload = {
+        "bash_id": "bash-large",
+        "status": "completed",
+        "command": "cat huge.log",
+        "cwd": str(quest_root),
+        "log": large_log,
+        "exit_code": 0,
+    }
+    stdout_payloads = [
+        {
+            "type": "item.started",
+            "item_type": "mcp_tool_call",
+            "item": {
+                "type": "mcp_tool_call",
+                "id": "tool-large",
+                "server": "bash_exec",
+                "tool": "bash_exec",
+                "status": "in_progress",
+                "arguments": {"mode": "read", "id": "bash-large", "detail": "full"},
+            },
+        },
+        {
+            "type": "item.completed",
+            "item_type": "mcp_tool_call",
+            "item": {
+                "type": "mcp_tool_call",
+                "id": "tool-large",
+                "server": "bash_exec",
+                "tool": "bash_exec",
+                "status": "completed",
+                "arguments": {"mode": "read", "id": "bash-large", "detail": "full"},
+                "result": {"structured_content": tool_result_payload},
+            },
+            "usage": {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+        },
+        {
+            "type": "item.completed",
+            "item_type": "agent_message",
+            "item": {
+                "type": "agent_message",
+                "id": "msg-final",
+                "content": [{"type": "output_text", "text": "Done."}],
+            },
+        },
+    ]
+
+    class _Pipe:
+        def __init__(self, lines: list[str] | None = None, read_text: str = "") -> None:
+            self._lines = lines or []
+            self._read_text = read_text
+            self.written = ""
+
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            return iter(self._lines)
+
+        def write(self, value: str) -> None:
+            self.written += value
+
+        def close(self) -> None:
+            return None
+
+        def read(self) -> str:
+            return self._read_text
+
+    class _Process:
+        pid = 12345
+
+        def __init__(self) -> None:
+            self.stdin = _Pipe()
+            self.stdout = _Pipe([json.dumps(payload, ensure_ascii=False) + "\n" for payload in stdout_payloads])
+            self.stderr = _Pipe(read_text="")
+            self.returncode: int | None = None
+
+        def wait(self, timeout: float | None = None) -> int:
+            self.returncode = 0
+            return 0
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+    monkeypatch.setattr("deepscientist.runners.codex.subprocess.Popen", lambda *args, **kwargs: _Process())
+    monkeypatch.setattr("deepscientist.runners.codex.export_git_graph", lambda *args, **kwargs: None)
+    monkeypatch.setattr(CodexRunner, "_load_runner_config", lambda self: {})
+    monkeypatch.setattr(
+        CodexRunner,
+        "_prepare_project_codex_home",
+        lambda self, workspace_root, *, quest_root, quest_id, run_id, runner_config=None: quest_root / ".ds" / "codex-home",
+    )
+    artifact_service = SimpleNamespace(
+        quest_service=SimpleNamespace(schedule_projection_refresh=lambda *args, **kwargs: None),
+        record=lambda *args, **kwargs: {"ok": True},
+    )
+    runner = CodexRunner(
+        home=temp_home,
+        repo_root=temp_home,
+        binary="codex",
+        logger=SimpleNamespace(log=lambda *args, **kwargs: None),
+        prompt_builder=SimpleNamespace(build=lambda **kwargs: "Prompt body"),
+        artifact_service=artifact_service,
+    )
+
+    result = runner.run(
+        RunRequest(
+            quest_id="q-telemetry",
+            quest_root=quest_root,
+            worktree_root=None,
+            run_id="run-telemetry",
+            skill_id="baseline",
+            message="continue",
+            model="inherit",
+            approval_policy="never",
+            sandbox_mode="danger-full-access",
+        )
+    )
+
+    assert result.ok is True
+    telemetry = read_json(quest_root / ".ds" / "runs" / "run-telemetry" / "telemetry.json", {})
+    assert telemetry["prompt_bytes"] == len("Prompt body".encode("utf-8"))
+    assert telemetry["tool_result_count"] == 1
+    assert telemetry["compacted_tool_result_count"] == 1
+    assert telemetry["full_detail_tool_call_count"] == 1
+    assert telemetry["tool_result_bytes_total"] > 8_000
+    assert telemetry["token_usage"] == {"input_tokens": 11, "output_tokens": 7, "total_tokens": 18}
+    quest_events = read_jsonl(quest_root / ".ds" / "events.jsonl")
+    telemetry_events = [event for event in quest_events if event.get("type") == "runner.turn_telemetry"]
+    assert telemetry_events
+    assert telemetry_events[-1]["compacted_tool_result_count"] == 1
+    tool_results = [event for event in quest_events if event.get("type") == "runner.tool_result"]
+    assert tool_results[-1]["output_compacted"] is True
+    packet = tool_results[-1]["evidence_packet"]
+    assert Path(packet["sidecar_path"]).exists()
+
+
 def test_codex_tool_event_carries_bash_id_from_id_only_monitor_call() -> None:
     event = {
         "type": "item.started",

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -13,6 +13,7 @@ from deepscientist.runners import ClaudeRunner, CodexRunner, OpenCodeRunner, Run
 from deepscientist.runners.codex import (
     _compact_tool_event_payload,
     _message_events,
+    _raw_tool_result_payload,
     _sanitize_text_for_windows_gbk,
     _tool_event,
 )
@@ -244,6 +245,83 @@ def test_codex_runner_leaves_normal_tool_result_event_parseable(temp_home: Path)
     assert json.loads(compacted["output"])["status"] == "ready"
 
 
+def test_codex_runner_compacted_failed_tool_result_does_not_default_success(temp_home: Path) -> None:
+    from deepscientist.evidence_packets import compact_runner_tool_event
+
+    quest_root = temp_home / "quest"
+    quest_root.mkdir(parents=True, exist_ok=True)
+    event = {
+        "event_id": "evt-failed-tool",
+        "type": "runner.tool_result",
+        "quest_id": "q-001",
+        "run_id": "run-001",
+        "source": "codex",
+        "skill_id": "baseline",
+        "tool_call_id": "tool-failed",
+        "tool_name": "artifact.read_quest_documents",
+        "status": "failed",
+        "args": '{"detail": "full"}',
+        "output": json.dumps({"message": "x" * 12_000}, ensure_ascii=False),
+    }
+
+    compacted, meta = compact_runner_tool_event(event, quest_root=quest_root, run_id="run-001")
+
+    assert meta["compacted"] is True
+    rendered = json.loads(compacted["output"])
+    assert rendered["ok"] is False
+
+
+def test_codex_runner_sidecars_raw_payload_before_render_truncation(temp_home: Path) -> None:
+    from deepscientist.evidence_packets import compact_runner_tool_event
+
+    quest_root = temp_home / "quest"
+    quest_root.mkdir(parents=True, exist_ok=True)
+    large_result = {
+        "status": "completed",
+        "items": [{"path": f"paper-section-{index}.md", "text": "x" * 120} for index in range(300)],
+        "missing_items": ["paper/references.bib"],
+    }
+    raw_event = {
+        "type": "item.completed",
+        "item_type": "mcp_tool_call",
+        "item": {
+            "type": "mcp_tool_call",
+            "id": "tool-raw-large",
+            "server": "artifact",
+            "tool": "read_quest_documents",
+            "status": "completed",
+            "arguments": {"detail": "full"},
+            "result": {"structured_content": large_result},
+        },
+    }
+    rendered_event = _tool_event(
+        raw_event,
+        quest_id="q-001",
+        run_id="run-001",
+        skill_id="write",
+        known_tool_names={},
+        created_at="2026-03-21T00:00:00Z",
+    )
+
+    assert rendered_event is not None
+    assert len(rendered_event["output"]) < 2_000
+    assert "paper-section-299.md" not in rendered_event["output"]
+    compacted, meta = compact_runner_tool_event(
+        rendered_event,
+        quest_root=quest_root,
+        run_id="run-001",
+        raw_payload=_raw_tool_result_payload(raw_event),
+    )
+
+    assert meta["compacted"] is True
+    assert meta["source_payload_bytes"] > 8_000
+    packet = json.loads(compacted["output"])["evidence_packet"]
+    sidecar = read_json(Path(packet["sidecar_path"]), {})
+    assert sidecar["payload"]["items"] == large_result["items"]
+    assert sidecar["payload"]["missing_items"] == ["paper/references.bib"]
+    assert "[truncated " not in json.dumps(sidecar["payload"], ensure_ascii=False)
+
+
 def test_codex_runner_writes_tool_result_telemetry_and_sidecar(
     monkeypatch,
     temp_home: Path,
@@ -382,7 +460,10 @@ def test_codex_runner_writes_tool_result_telemetry_and_sidecar(
     tool_results = [event for event in quest_events if event.get("type") == "runner.tool_result"]
     assert tool_results[-1]["output_compacted"] is True
     packet = tool_results[-1]["evidence_packet"]
-    assert Path(packet["sidecar_path"]).exists()
+    sidecar = read_json(Path(packet["sidecar_path"]), {})
+    assert sidecar["payload"]["log"] == large_log
+    assert "[truncated " not in sidecar["payload"]["log"]
+    assert sidecar["payload_sha256"] == packet["payload_sha256"]
 
 
 def test_codex_tool_event_carries_bash_id_from_id_only_monitor_call() -> None:


### PR DESCRIPTION
## Problem
Large Codex `runner.tool_result` events can bloat quest event logs and consume follow-up context. The runner also had no durable telemetry for prompt/tool-result byte budgets or compacted result counts.

## Solution
- Add a generic `evidence_packets` helper that writes oversized tool-result payloads to quest-local `.ds/evidence_packets/<run_id>/` sidecars.
- Keep `runner.tool_result` events parseable by replacing oversized output with a compact JSON packet containing path, hash, payload bytes, summary, and key blockers.
- Add Codex runner telemetry for prompt bytes, stdout bytes, tool-result bytes, compacted result count, full-detail tool-call count, token usage, and the telemetry sidecar path.

## MDS provenance
Adapted the generic context-budget parts of MedDeepScientist commits `793ff56` and `b911a53`. MedDeepScientist, MAS, medical-fork, manuscript-readiness, and publication-authority semantics were intentionally excluded.

## Tests
- `python -m py_compile src/deepscientist/evidence_packets.py src/deepscientist/runners/codex.py`
- `git diff --check`
- `uv run pytest -q tests/test_codex_runner.py::test_codex_tool_event_preserves_parseable_bash_exec_payload_and_metadata tests/test_codex_runner.py::test_codex_tool_event_truncates_oversized_bash_exec_log_but_keeps_json_parseable tests/test_codex_runner.py::test_codex_compacts_extreme_tool_result_payload_before_event_write tests/test_codex_runner.py::test_codex_runner_sidecars_oversized_tool_result_event tests/test_codex_runner.py::test_codex_runner_leaves_normal_tool_result_event_parseable tests/test_codex_runner.py::test_codex_runner_writes_tool_result_telemetry_and_sidecar`
