### PR TITLE
Cache repeated MCP reads and add tool-budget telemetry

### DIFF
--- a/src/deepscientist/evidence_packets.py
+++ b/src/deepscientist/evidence_packets.py
@@ -13,6 +13,22 @@ DEFAULT_RUNNER_TOOL_RESULT_THRESHOLD_BYTES = 8_000
 _MAX_SUMMARY_CHARS = 900
 _MAX_BLOCKERS = 12
 _RAW_PAYLOAD_UNSET = object()
+_READ_CACHE_SCHEMA_VERSION = 1
+_HOT_TOOL_RESULT_THRESHOLDS_BYTES = {
+    "artifact.get_quest_state": 4_000,
+    "artifact.get_global_status": 4_000,
+    "artifact.get_paper_contract_health": 4_000,
+    "artifact.validate_manuscript_coverage": 4_000,
+    "artifact.list_paper_outlines": 2_000,
+    "bash_exec.bash_exec": 2_000,
+}
+_FULL_DETAIL_FORCE_COMPACT_TOOLS = {
+    "artifact.get_quest_state",
+    "artifact.get_global_status",
+    "artifact.get_paper_contract_health",
+    "artifact.validate_manuscript_coverage",
+    "artifact.list_paper_outlines",
+}
 
 
 def payload_json_bytes(payload: Any) -> bytes:
@@ -26,9 +42,64 @@ def payload_sha256(payload: Any) -> str:
     return hashlib.sha256(payload_json_bytes(payload)).hexdigest()
 
 
+def _normalized_tool_name(tool_name: str | None) -> str:
+    return str(tool_name or "").strip()
+
+
+def _compact_threshold_for_tool(tool_name: str, *, default_threshold: int) -> int:
+    hot_threshold = _HOT_TOOL_RESULT_THRESHOLDS_BYTES.get(_normalized_tool_name(tool_name))
+    if hot_threshold is None:
+        return int(default_threshold)
+    return min(int(default_threshold), hot_threshold)
+
+
+def _tool_force_compaction(*, tool_name: str, full_detail_requested: bool | None, force: bool) -> bool:
+    if force:
+        return True
+    return bool(full_detail_requested) and _normalized_tool_name(tool_name) in _FULL_DETAIL_FORCE_COMPACT_TOOLS
+
+
 def _slug(value: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value or "").strip())
     return normalized.strip("-")[:80] or "payload"
+
+
+def _strip_read_cache_volatile(value: Any) -> Any:
+    volatile_keys = {
+        "created_at",
+        "updated_at",
+        "generated_at",
+        "completed_at",
+        "read_cache",
+        "run_age_seconds",
+        "status_age_seconds",
+        "silent_seconds",
+        "progress_age_seconds",
+        "signal_age_seconds",
+    }
+    if isinstance(value, dict):
+        return {
+            key: _strip_read_cache_volatile(item)
+            for key, item in value.items()
+            if str(key) not in volatile_keys and not str(key).endswith("_age_seconds")
+        }
+    if isinstance(value, list):
+        return [_strip_read_cache_volatile(item) for item in value]
+    return value
+
+
+def _read_cache_path(*, quest_root: Path, tool_name: str, detail: str | None, cache_key: Any) -> Path:
+    key_hash = payload_sha256({"tool_name": tool_name, "detail": detail, "cache_key": cache_key})[:20]
+    return quest_root / ".ds" / "read_cache" / f"{_slug(tool_name)}-{key_hash}.json"
+
+
+def _command_fingerprint(payload: dict[str, Any]) -> str:
+    return payload_sha256(
+        {
+            "command": " ".join(str(payload.get("command") or "").split()),
+            "cwd": str(payload.get("cwd") or payload.get("workdir") or "").strip(),
+        }
+    )
 
 
 def _sidecar_path(
@@ -327,3 +398,193 @@ def compact_runner_tool_event(
         "output_bytes": output_bytes,
         "source_payload_bytes": source_payload_bytes,
     }
+
+
+def compact_mcp_tool_result(
+    payload: dict[str, Any],
+    *,
+    quest_root: Path,
+    run_id: str | None,
+    tool_name: str,
+    detail: str | None = None,
+    force: bool = False,
+    threshold_bytes: int | None = None,
+    reason: str | None = None,
+    full_detail_requested: bool | None = None,
+) -> dict[str, Any]:
+    normalized_detail = str(detail or "").strip().lower() or None
+    requested_full_detail = bool(full_detail_requested) or normalized_detail == "full"
+    default_threshold = DEFAULT_EVIDENCE_PACKET_THRESHOLD_BYTES if threshold_bytes is None else int(threshold_bytes)
+    effective_threshold = (
+        _compact_threshold_for_tool(tool_name, default_threshold=default_threshold)
+        if requested_full_detail
+        else default_threshold
+    )
+    compacted, _meta = compact_evidence_payload(
+        payload,
+        quest_root=quest_root,
+        run_id=run_id,
+        tool_name=tool_name,
+        detail=normalized_detail,
+        force=_tool_force_compaction(
+            tool_name=tool_name,
+            full_detail_requested=requested_full_detail,
+            force=force,
+        ),
+        threshold_bytes=effective_threshold,
+        reason=reason,
+        full_detail_requested=requested_full_detail,
+    )
+    return compacted if isinstance(compacted, dict) else payload
+
+
+def cached_compact_mcp_tool_result(
+    payload: dict[str, Any],
+    *,
+    quest_root: Path,
+    run_id: str | None,
+    tool_name: str,
+    detail: str | None = None,
+    cache_key: Any = None,
+    source_path: Path | None = None,
+    force: bool = False,
+    threshold_bytes: int | None = None,
+    reason: str | None = None,
+    full_detail_requested: bool | None = None,
+) -> dict[str, Any]:
+    normalized_detail = str(detail or "").strip().lower() or None
+    if _normalized_tool_name(tool_name) == "bash_exec.bash_exec":
+        payload = dict(payload)
+        if not payload.get("cwd"):
+            payload["cwd"] = str(quest_root)
+        if not payload.get("command_fingerprint"):
+            payload["command_fingerprint"] = _command_fingerprint(payload)
+    resolved_source = source_path.expanduser().resolve() if source_path is not None else None
+    source_stat = resolved_source.stat() if resolved_source is not None and resolved_source.exists() else None
+    stable_payload = _strip_read_cache_volatile(payload)
+    payload_fingerprint = payload_sha256(stable_payload)
+    original_bytes = len(payload_json_bytes(payload))
+    resolved_cache_key = cache_key if cache_key is not None else {"detail": normalized_detail}
+    cache_path = _read_cache_path(
+        quest_root=quest_root,
+        tool_name=tool_name,
+        detail=normalized_detail,
+        cache_key=resolved_cache_key,
+    )
+    cached = read_json(cache_path, {})
+    cache_hit = (
+        isinstance(cached, dict)
+        and int(cached.get("schema_version") or 0) == _READ_CACHE_SCHEMA_VERSION
+        and cached.get("payload_fingerprint") == payload_fingerprint
+    )
+    read_cache = {
+        "schema_version": _READ_CACHE_SCHEMA_VERSION,
+        "cache_hit": cache_hit,
+        "cache_path": str(cache_path),
+        "payload_fingerprint": payload_fingerprint,
+        "payload_bytes": original_bytes,
+        "source_path": str(resolved_source) if resolved_source is not None else None,
+        "source_mtime_ns": getattr(source_stat, "st_mtime_ns", None) if source_stat is not None else None,
+        "source_size": getattr(source_stat, "st_size", None) if source_stat is not None else None,
+    }
+    if cache_hit:
+        cached_evidence_packet = (
+            dict(cached.get("evidence_packet") or {})
+            if isinstance(cached.get("evidence_packet"), dict)
+            else None
+        )
+        if cached_evidence_packet is None:
+            sidecar_payload, _sidecar_meta = compact_evidence_payload(
+                payload,
+                quest_root=quest_root,
+                run_id=run_id,
+                tool_name=tool_name,
+                detail=normalized_detail,
+                force=True,
+                threshold_bytes=1,
+                reason="read_cache_sidecar_ref",
+                full_detail_requested=full_detail_requested,
+            )
+            if isinstance(sidecar_payload, dict) and isinstance(sidecar_payload.get("evidence_packet"), dict):
+                cached_evidence_packet = dict(sidecar_payload["evidence_packet"])
+                cached["evidence_packet"] = cached_evidence_packet
+                write_json(cache_path, cached)
+        read_cache["saved_bytes"] = max(0, original_bytes)
+        if cached_evidence_packet:
+            read_cache["sidecar_path"] = cached_evidence_packet.get("sidecar_path")
+            read_cache["payload_sha256"] = cached_evidence_packet.get("payload_sha256")
+        ok_value = _ok_from_payload_or_status(payload)
+        result = {
+            "ok": ok_value if ok_value is not None else True,
+            "compacted": True,
+            "delta_marker": True,
+            "delta_kind": "unchanged_read_cache",
+            "tool_name": tool_name,
+            "detail": normalized_detail,
+            "fingerprint": payload_fingerprint,
+            "summary": cached.get("summary") or summarize_payload(payload, tool_name=tool_name),
+            "read_cache": read_cache,
+            "command_fingerprint": payload.get("command_fingerprint"),
+            "cwd": payload.get("cwd"),
+        }
+        if cached_evidence_packet:
+            result["evidence_packet"] = cached_evidence_packet
+        return result
+
+    compacted = compact_mcp_tool_result(
+        payload,
+        quest_root=quest_root,
+        run_id=run_id,
+        tool_name=tool_name,
+        detail=normalized_detail,
+        force=force,
+        threshold_bytes=threshold_bytes,
+        reason=reason,
+        full_detail_requested=full_detail_requested,
+    )
+    evidence_packet = (
+        dict(compacted.get("evidence_packet") or {})
+        if isinstance(compacted, dict) and isinstance(compacted.get("evidence_packet"), dict)
+        else None
+    )
+    if evidence_packet is None:
+        sidecar_payload, _sidecar_meta = compact_evidence_payload(
+            payload,
+            quest_root=quest_root,
+            run_id=run_id,
+            tool_name=tool_name,
+            detail=normalized_detail,
+            force=True,
+            threshold_bytes=1,
+            reason="read_cache_sidecar_ref",
+            full_detail_requested=full_detail_requested,
+        )
+        if isinstance(sidecar_payload, dict) and isinstance(sidecar_payload.get("evidence_packet"), dict):
+            evidence_packet = dict(sidecar_payload["evidence_packet"])
+    read_cache["saved_bytes"] = 0
+    if evidence_packet:
+        read_cache["sidecar_path"] = evidence_packet.get("sidecar_path")
+        read_cache["payload_sha256"] = evidence_packet.get("payload_sha256")
+    compacted["read_cache"] = read_cache
+    if evidence_packet and compacted.get("compacted") is True and "evidence_packet" not in compacted:
+        compacted["evidence_packet"] = evidence_packet
+    ensure_dir(cache_path.parent)
+    write_json(
+        cache_path,
+        {
+            "schema_version": _READ_CACHE_SCHEMA_VERSION,
+            "created_at": utc_now(),
+            "updated_at": utc_now(),
+            "tool_name": tool_name,
+            "detail": normalized_detail,
+            "cache_key": resolved_cache_key,
+            "payload_fingerprint": payload_fingerprint,
+            "payload_bytes": original_bytes,
+            "summary": summarize_payload(payload, tool_name=tool_name),
+            "source_path": str(resolved_source) if resolved_source is not None else None,
+            "source_mtime_ns": getattr(source_stat, "st_mtime_ns", None) if source_stat is not None else None,
+            "source_size": getattr(source_stat, "st_size", None) if source_stat is not None else None,
+            "evidence_packet": evidence_packet,
+        },
+    )
+    return compacted

--- a/src/deepscientist/mcp/server.py
+++ b/src/deepscientist/mcp/server.py
@@ -16,6 +16,7 @@ from mcp.types import ToolAnnotations
 from ..artifact import ArtifactService
 from ..artifact.metrics import MetricContractValidationError
 from ..bash_exec import BashExecService
+from ..evidence_packets import cached_compact_mcp_tool_result, compact_mcp_tool_result
 from ..memory import MemoryService
 from ..quest import QuestService
 from ..shared import read_json
@@ -1430,9 +1431,20 @@ def build_artifact_server(context: McpContext) -> FastMCP:
         detail: str = "summary",
         comment: str | dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        return service.get_paper_contract_health(
+        result = service.get_paper_contract_health(
             context.require_quest_root(),
             detail=detail,
+        )
+        normalized_detail = str(detail or "summary").strip().lower() or "summary"
+        return compact_mcp_tool_result(
+            result,
+            quest_root=context.require_quest_root(),
+            run_id=context.run_id,
+            tool_name="artifact.get_paper_contract_health",
+            detail=normalized_detail,
+            force=normalized_detail == "full",
+            reason="artifact_full_detail_context_budget",
+            full_detail_requested=normalized_detail == "full",
         )
 
     @server.tool(
@@ -1533,9 +1545,21 @@ def build_artifact_server(context: McpContext) -> FastMCP:
         detail: str = "summary",
         comment: str | dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        return service.get_quest_state(
+        result = service.get_quest_state(
             context.require_quest_root(),
             detail=detail,
+        )
+        normalized_detail = str(detail or "summary").strip().lower() or "summary"
+        return cached_compact_mcp_tool_result(
+            result,
+            quest_root=context.require_quest_root(),
+            run_id=context.run_id,
+            tool_name="artifact.get_quest_state",
+            detail=normalized_detail,
+            cache_key={"detail": normalized_detail},
+            force=normalized_detail == "full",
+            reason="artifact_full_detail_context_budget",
+            full_detail_requested=normalized_detail == "full",
         )
 
     @server.tool(
@@ -1551,10 +1575,23 @@ def build_artifact_server(context: McpContext) -> FastMCP:
         locale: str = "zh",
         comment: str | dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        return service.get_global_status(
+        result = service.get_global_status(
             context.require_quest_root(),
             detail=detail,
             locale=locale,
+        )
+        normalized_detail = str(detail or "brief").strip().lower() or "brief"
+        normalized_locale = str(locale or "zh").strip().lower() or "zh"
+        return cached_compact_mcp_tool_result(
+            result,
+            quest_root=context.require_quest_root(),
+            run_id=context.run_id,
+            tool_name="artifact.get_global_status",
+            detail=normalized_detail,
+            cache_key={"detail": normalized_detail, "locale": normalized_locale},
+            force=normalized_detail == "full",
+            reason="artifact_full_detail_context_budget",
+            full_detail_requested=normalized_detail == "full",
         )
 
     @server.tool(
@@ -1850,7 +1887,15 @@ def build_artifact_server(context: McpContext) -> FastMCP:
         annotations=_read_only_tool_annotations(title="List paper outlines"),
     )
     def list_paper_outlines(comment: str | dict[str, Any] | None = None) -> dict[str, Any]:
-        return service.list_paper_outlines(context.require_quest_root())
+        return cached_compact_mcp_tool_result(
+            service.list_paper_outlines(context.require_quest_root()),
+            quest_root=context.require_quest_root(),
+            run_id=context.run_id,
+            tool_name="artifact.list_paper_outlines",
+            detail="inventory",
+            cache_key={"detail": "inventory"},
+            reason="artifact_inventory_context_budget",
+        )
 
     @server.tool(
         name="submit_paper_bundle",
@@ -2368,6 +2413,28 @@ def build_bash_exec_server(context: McpContext) -> FastMCP:
         quest_root = context.require_quest_root().resolve()
 
         def finalize(payload: dict[str, Any]) -> dict[str, Any]:
+            if normalized_mode == "read":
+                bash_id = str(payload.get("bash_id") or payload.get("id") or id or "")
+                payload = cached_compact_mcp_tool_result(
+                    payload,
+                    quest_root=quest_root,
+                    run_id=context.run_id,
+                    tool_name="bash_exec.bash_exec",
+                    detail="read",
+                    cache_key={
+                        "mode": "read",
+                        "bash_id": bash_id,
+                        "start": start,
+                        "tail": tail,
+                        "tail_limit": tail_limit,
+                        "before_seq": before_seq,
+                        "after_seq": after_seq,
+                        "order": order,
+                        "include_log": include_log,
+                    },
+                    source_path=service.terminal_log_path(quest_root, bash_id) if bash_id else None,
+                    reason="bash_exec_read_context_budget",
+                )
             quest_service.record_tool_activity(
                 quest_root,
                 tool_name=f"bash_exec.{normalized_mode}",

--- a/src/deepscientist/runners/codex.py
+++ b/src/deepscientist/runners/codex.py
@@ -34,6 +34,12 @@ from .base import (
     extract_start_setup_session_patch_from_text,
     resolve_mcp_tool_profile_for_quest,
 )
+from .codex_telemetry import (
+    DEFAULT_TURN_TOOL_CALL_BUDGET,
+    _finalize_tool_budget_telemetry,
+    _new_tool_budget_telemetry,
+    _record_tool_budget_event,
+)
 
 _TOOL_EVENT_ARGS_TEXT_LIMIT = 8_000
 _TOOL_EVENT_OUTPUT_TEXT_LIMIT = 16_000
@@ -958,6 +964,10 @@ class CodexRunner:
                 "windows_gbk_replacements": prompt_sanitization,
             },
         )
+        configured_tool_budget = runner_config.get("tool_call_budget")
+        if not isinstance(configured_tool_budget, int):
+            configured_tool_budget = DEFAULT_TURN_TOOL_CALL_BUDGET
+        tool_budget_telemetry = _new_tool_budget_telemetry(tool_call_budget=configured_tool_budget)
         telemetry: dict[str, Any] = {
             "version": 1,
             "quest_id": request.quest_id,
@@ -974,11 +984,11 @@ class CodexRunner:
             "prompt_bytes": len(prompt.encode("utf-8", errors="replace")),
             "stdout_event_count": 0,
             "stdout_bytes": 0,
-            "tool_call_count": 0,
             "tool_result_count": 0,
             "tool_result_bytes_total": 0,
             "compacted_tool_result_count": 0,
             "full_detail_tool_call_count": 0,
+            **tool_budget_telemetry,
             "token_usage": {},
             "created_at": utc_now(),
         }
@@ -1125,7 +1135,7 @@ class CodexRunner:
                 )
                 if tool_event is not None:
                     if str(tool_event.get("type") or "") == "runner.tool_call":
-                        telemetry["tool_call_count"] = int(telemetry.get("tool_call_count") or 0) + 1
+                        _record_tool_budget_event(telemetry, tool_event)
                         args_text = str(tool_event.get("args") or "")
                         if "detail" in args_text and "full" in args_text.lower():
                             telemetry["full_detail_tool_call_count"] = int(
@@ -1156,6 +1166,7 @@ class CodexRunner:
                             telemetry["compacted_tool_result_count"] = int(
                                 telemetry.get("compacted_tool_result_count") or 0
                             ) + 1
+                        _record_tool_budget_event(telemetry, tool_event)
                     append_jsonl(quest_events, tool_event)
                 message_events, message_output_parts = _message_events(
                     payload,
@@ -1195,6 +1206,7 @@ class CodexRunner:
             telemetry["stderr_bytes"] = len(stderr_text.encode("utf-8", errors="replace"))
             telemetry["output_text_bytes"] = len(output_text.encode("utf-8", errors="replace"))
             telemetry["completed_at"] = utc_now()
+            _finalize_tool_budget_telemetry(telemetry)
             telemetry_path = run_root / "telemetry.json"
             write_json(telemetry_path, telemetry)
             append_jsonl(
@@ -1225,10 +1237,20 @@ class CodexRunner:
                     "model": request.model,
                     "prompt_bytes": telemetry.get("prompt_bytes"),
                     "stdout_bytes": telemetry.get("stdout_bytes"),
+                    "tool_call_budget": telemetry.get("tool_call_budget"),
                     "tool_call_count": telemetry.get("tool_call_count"),
+                    "tool_count": telemetry.get("tool_count"),
+                    "tool_call_budget_remaining": telemetry.get("tool_call_budget_remaining"),
+                    "tool_call_budget_exceeded": telemetry.get("tool_call_budget_exceeded"),
+                    "unique_command_count": telemetry.get("unique_command_count"),
+                    "read_tool_call_count": telemetry.get("read_tool_call_count"),
+                    "repeated_read_result_count": telemetry.get("repeated_read_result_count"),
+                    "repeated_read_ratio": telemetry.get("repeated_read_ratio"),
                     "tool_result_bytes_total": telemetry.get("tool_result_bytes_total"),
                     "compacted_tool_result_count": telemetry.get("compacted_tool_result_count"),
+                    "saved_bytes": telemetry.get("saved_bytes"),
                     "full_detail_tool_call_count": telemetry.get("full_detail_tool_call_count"),
+                    "full_detail_count": telemetry.get("full_detail_count"),
                     "token_usage": telemetry.get("token_usage"),
                     "telemetry_path": str(telemetry_path),
                     "created_at": utc_now(),

--- a/src/deepscientist/runners/codex_telemetry.py
+++ b/src/deepscientist/runners/codex_telemetry.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+DEFAULT_TURN_TOOL_CALL_BUDGET = 24
+
+
+def _parse_tool_args(raw_args: object) -> dict[str, Any]:
+    if isinstance(raw_args, dict):
+        return dict(raw_args)
+    if not isinstance(raw_args, str) or not raw_args.strip():
+        return {}
+    try:
+        parsed = json.loads(raw_args)
+    except json.JSONDecodeError:
+        return {}
+    return dict(parsed) if isinstance(parsed, dict) else {}
+
+
+def _tool_result_structured_payload(event: dict[str, Any]) -> dict[str, Any]:
+    output = event.get("output")
+    if not isinstance(output, str) or not output.strip():
+        return {}
+    try:
+        parsed = json.loads(output)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    structured = parsed.get("structured_content") or parsed.get("structuredContent")
+    return dict(structured) if isinstance(structured, dict) else parsed
+
+
+def _is_read_tool_event(event: dict[str, Any]) -> bool:
+    tool_name = str(event.get("tool_name") or "").strip()
+    mcp_server = str(event.get("mcp_server") or "").strip()
+    mcp_tool = str(event.get("mcp_tool") or "").strip()
+    if tool_name.startswith("mcp__"):
+        parts = tool_name.split("__", 2)
+        if len(parts) == 3:
+            mcp_server = mcp_server or parts[1]
+            mcp_tool = mcp_tool or parts[2]
+            tool_name = f"{parts[1]}.{parts[2]}"
+    if mcp_server and mcp_tool and "." not in tool_name:
+        tool_name = f"{mcp_server}.{mcp_tool}"
+    args = _parse_tool_args(event.get("args"))
+    mode = str(args.get("mode") or "").strip().lower()
+    return tool_name in {
+        "artifact.get_quest_state",
+        "artifact.list_paper_outlines",
+        "artifact.get_global_status",
+        "artifact.get_paper_contract_health",
+        "artifact.validate_manuscript_coverage",
+        "artifact.read_quest_documents",
+    } or (tool_name == "bash_exec.bash_exec" and mode == "read")
+
+
+def _new_tool_budget_telemetry(*, tool_call_budget: int = DEFAULT_TURN_TOOL_CALL_BUDGET) -> dict[str, Any]:
+    return {
+        "tool_call_budget": max(1, int(tool_call_budget)),
+        "tool_call_count": 0,
+        "tool_count": 0,
+        "tool_call_budget_remaining": max(1, int(tool_call_budget)),
+        "tool_call_budget_exceeded": False,
+        "unique_command_count": 0,
+        "read_tool_call_count": 0,
+        "repeated_read_result_count": 0,
+        "repeated_read_ratio": 0.0,
+        "full_detail_count": 0,
+        "saved_bytes": 0,
+        "_unique_command_fingerprints": set(),
+    }
+
+
+def _record_tool_budget_event(telemetry: dict[str, Any], event: dict[str, Any]) -> None:
+    event_type = str(event.get("type") or "")
+    metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    result_payload = _tool_result_structured_payload(event) if event_type == "runner.tool_result" else {}
+    command_fingerprint = str(
+        event.get("command_fingerprint")
+        or metadata.get("command_fingerprint")
+        or result_payload.get("command_fingerprint")
+        or ""
+    ).strip()
+    fingerprints = telemetry.setdefault("_unique_command_fingerprints", set())
+    if command_fingerprint:
+        fingerprints.add(command_fingerprint)
+        telemetry["unique_command_count"] = len(fingerprints)
+    if event_type == "runner.tool_call":
+        telemetry["tool_call_count"] = int(telemetry.get("tool_call_count") or 0) + 1
+        telemetry["tool_count"] = telemetry["tool_call_count"]
+        budget = max(1, int(telemetry.get("tool_call_budget") or DEFAULT_TURN_TOOL_CALL_BUDGET))
+        remaining = max(0, budget - int(telemetry["tool_call_count"]))
+        telemetry["tool_call_budget_remaining"] = remaining
+        telemetry["tool_call_budget_exceeded"] = int(telemetry["tool_call_count"]) > budget
+        if _is_read_tool_event(event):
+            telemetry["read_tool_call_count"] = int(telemetry.get("read_tool_call_count") or 0) + 1
+        args_text = str(event.get("args") or "")
+        if "detail" in args_text and "full" in args_text.lower():
+            telemetry["full_detail_count"] = int(telemetry.get("full_detail_count") or 0) + 1
+        _refresh_repeated_read_ratio(telemetry)
+        return
+    if event_type == "runner.tool_result":
+        delta_marker = bool(event.get("delta_marker") or result_payload.get("delta_marker"))
+        delta_kind = str(event.get("delta_kind") or result_payload.get("delta_kind") or "")
+        if delta_marker and (
+            delta_kind == "unchanged_read_cache"
+            or (delta_kind == "unchanged_tool_result" and _is_read_tool_event(event))
+        ):
+            telemetry["repeated_read_result_count"] = int(telemetry.get("repeated_read_result_count") or 0) + 1
+        read_cache = result_payload.get("read_cache") if isinstance(result_payload.get("read_cache"), dict) else {}
+        telemetry["saved_bytes"] = int(telemetry.get("saved_bytes") or 0) + int(read_cache.get("saved_bytes") or 0)
+    _refresh_repeated_read_ratio(telemetry)
+
+
+def _refresh_repeated_read_ratio(telemetry: dict[str, Any]) -> None:
+    read_count = int(telemetry.get("read_tool_call_count") or 0)
+    repeated_count = int(telemetry.get("repeated_read_result_count") or 0)
+    telemetry["repeated_read_ratio"] = (repeated_count / read_count) if read_count else 0.0
+
+
+def _finalize_tool_budget_telemetry(telemetry: dict[str, Any]) -> None:
+    telemetry.pop("_unique_command_fingerprints", None)
+    telemetry["tool_count"] = int(telemetry.get("tool_call_count") or telemetry.get("tool_count") or 0)
+    telemetry["saved_bytes"] = int(telemetry.get("saved_bytes") or telemetry.get("tool_result_bytes_saved_total") or 0)
+    _refresh_repeated_read_ratio(telemetry)

--- a/tests/test_codex_runner.py
+++ b/tests/test_codex_runner.py
@@ -17,6 +17,7 @@ from deepscientist.runners.codex import (
     _sanitize_text_for_windows_gbk,
     _tool_event,
 )
+from deepscientist.runners.codex_telemetry import _new_tool_budget_telemetry, _record_tool_budget_event
 from deepscientist.runners.runtime_overrides import apply_claude_runtime_overrides
 from deepscientist.shared import read_json, read_jsonl, read_yaml, write_yaml
 from deepscientist.skills import SkillInstaller
@@ -320,6 +321,103 @@ def test_codex_runner_sidecars_raw_payload_before_render_truncation(temp_home: P
     assert sidecar["payload"]["items"] == large_result["items"]
     assert sidecar["payload"]["missing_items"] == ["paper/references.bib"]
     assert "[truncated " not in json.dumps(sidecar["payload"], ensure_ascii=False)
+
+
+def test_codex_runner_tool_budget_telemetry_counts_unique_commands_and_repeated_reads() -> None:
+    telemetry = _new_tool_budget_telemetry(tool_call_budget=3)
+
+    _record_tool_budget_event(
+        telemetry,
+        {
+            "type": "runner.tool_call",
+            "tool_name": "bash_exec.bash_exec",
+            "args": json.dumps({"mode": "read", "id": "bash-001", "tail_limit": 100}),
+            "metadata": {"command_fingerprint": "cmd-1"},
+        },
+    )
+    _record_tool_budget_event(
+        telemetry,
+        {
+            "type": "runner.tool_result",
+            "tool_name": "bash_exec.bash_exec",
+            "args": json.dumps({"mode": "read", "id": "bash-001", "tail_limit": 100}),
+            "delta_marker": True,
+            "delta_kind": "unchanged_tool_result",
+            "metadata": {"command_fingerprint": "cmd-1"},
+        },
+    )
+    _record_tool_budget_event(
+        telemetry,
+        {
+            "type": "runner.tool_call",
+            "tool_name": "artifact.get_quest_state",
+            "args": json.dumps({"detail": "full"}),
+        },
+    )
+    _record_tool_budget_event(
+        telemetry,
+        {
+            "type": "runner.tool_call",
+            "tool_name": "bash_exec.bash_exec",
+            "args": json.dumps({"mode": "read", "id": "bash-001", "tail_limit": 200}),
+            "metadata": {"command_fingerprint": "cmd-1"},
+        },
+    )
+    _record_tool_budget_event(
+        telemetry,
+        {
+            "type": "runner.tool_call",
+            "tool_name": "artifact.list_paper_outlines",
+            "args": "{}",
+        },
+    )
+
+    assert telemetry["tool_call_budget"] == 3
+    assert telemetry["tool_call_count"] == 4
+    assert telemetry["tool_count"] == 4
+    assert telemetry["tool_call_budget_remaining"] == 0
+    assert telemetry["tool_call_budget_exceeded"] is True
+    assert telemetry["unique_command_count"] == 1
+    assert telemetry["read_tool_call_count"] == 4
+    assert telemetry["repeated_read_result_count"] == 1
+    assert telemetry["repeated_read_ratio"] == 1 / 4
+    assert telemetry["full_detail_count"] == 1
+    assert telemetry["saved_bytes"] == 0
+
+
+def test_codex_runner_tool_budget_telemetry_counts_embedded_read_cache_delta() -> None:
+    telemetry = _new_tool_budget_telemetry(tool_call_budget=4)
+    _record_tool_budget_event(
+        telemetry,
+        {
+            "type": "runner.tool_call",
+            "tool_name": "artifact.get_global_status",
+            "args": json.dumps({"detail": "full"}),
+        },
+    )
+    _record_tool_budget_event(
+        telemetry,
+        {
+            "type": "runner.tool_result",
+            "tool_name": "artifact.get_global_status",
+            "output": json.dumps(
+                {
+                    "structured_content": {
+                        "ok": True,
+                        "delta_marker": True,
+                        "delta_kind": "unchanged_read_cache",
+                        "read_cache": {"saved_bytes": 1234},
+                        "command_fingerprint": "cmd-result",
+                    }
+                }
+            ),
+        },
+    )
+
+    assert telemetry["unique_command_count"] == 1
+    assert telemetry["repeated_read_result_count"] == 1
+    assert telemetry["repeated_read_ratio"] == 1.0
+    assert telemetry["saved_bytes"] == 1234
 
 
 def test_codex_runner_writes_tool_result_telemetry_and_sidecar(

--- a/tests/test_mcp_servers.py
+++ b/tests/test_mcp_servers.py
@@ -831,6 +831,166 @@ def test_artifact_mcp_server_tools_cover_core_flows(temp_home: Path) -> None:
     asyncio.run(scenario())
 
 
+def test_artifact_mcp_server_repeated_outline_read_returns_delta_marker(temp_home: Path) -> None:
+    async def scenario() -> None:
+        ensure_home_layout(temp_home)
+        ConfigManager(temp_home).ensure_files()
+        quest = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home)).create(
+            "mcp repeated outline read quest"
+        )
+        quest_root = Path(quest["quest_root"])
+        context = McpContext(
+            home=temp_home,
+            quest_id=quest["quest_id"],
+            quest_root=quest_root,
+            run_id="run-read-cache",
+            active_anchor="write",
+            conversation_id="quest:test",
+            agent_role="pi",
+            worker_id="worker-main",
+            worktree_root=None,
+            team_mode="single",
+        )
+        server = build_artifact_server(context)
+
+        first = _unwrap_tool_result(await server.call_tool("list_paper_outlines", {}))
+        second = _unwrap_tool_result(await server.call_tool("list_paper_outlines", {}))
+
+        assert first["ok"] is True
+        assert first.get("delta_marker") is not True
+        assert first["read_cache"]["cache_hit"] is False
+        assert second["ok"] is True
+        assert second["delta_marker"] is True
+        assert second["delta_kind"] == "unchanged_read_cache"
+        assert second["read_cache"]["cache_hit"] is True
+        assert second["read_cache"]["saved_bytes"] > 0
+
+    asyncio.run(scenario())
+
+
+def test_artifact_mcp_server_repeated_full_quest_state_uses_read_cache_delta(temp_home: Path) -> None:
+    async def scenario() -> None:
+        ensure_home_layout(temp_home)
+        ConfigManager(temp_home).ensure_files()
+        quest = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home)).create(
+            "mcp repeated full quest state read"
+        )
+        quest_root = Path(quest["quest_root"])
+        context = McpContext(
+            home=temp_home,
+            quest_id=quest["quest_id"],
+            quest_root=quest_root,
+            run_id="run-full-state-cache",
+            active_anchor="baseline",
+            conversation_id="quest:test",
+            agent_role="pi",
+            worker_id="worker-main",
+            worktree_root=None,
+            team_mode="single",
+        )
+        server = build_artifact_server(context)
+
+        first = _unwrap_tool_result(await server.call_tool("get_quest_state", {"detail": "full"}))
+        second = _unwrap_tool_result(await server.call_tool("get_quest_state", {"detail": "full"}))
+
+        assert first["ok"] is True
+        assert first["compacted"] is True
+        assert first["evidence_packet"]["full_detail_requested"] is True
+        assert first["read_cache"]["cache_hit"] is False
+        assert second["ok"] is True
+        assert second["delta_marker"] is True
+        assert second["delta_kind"] == "unchanged_read_cache"
+        assert second["read_cache"]["cache_hit"] is True
+        assert Path(second["evidence_packet"]["sidecar_path"]).exists()
+
+    asyncio.run(scenario())
+
+
+def test_artifact_mcp_server_repeated_global_status_uses_read_cache_sidecar_ref(temp_home: Path) -> None:
+    async def scenario() -> None:
+        ensure_home_layout(temp_home)
+        ConfigManager(temp_home).ensure_files()
+        quest = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home)).create(
+            "mcp repeated global status read"
+        )
+        quest_root = Path(quest["quest_root"])
+        context = McpContext(
+            home=temp_home,
+            quest_id=quest["quest_id"],
+            quest_root=quest_root,
+            run_id="run-global-status-cache",
+            active_anchor="decision",
+            conversation_id="quest:test",
+            agent_role="pi",
+            worker_id="worker-main",
+            worktree_root=None,
+            team_mode="single",
+        )
+        server = build_artifact_server(context)
+
+        first = _unwrap_tool_result(await server.call_tool("get_global_status", {"detail": "full"}))
+        second = _unwrap_tool_result(await server.call_tool("get_global_status", {"detail": "full"}))
+
+        assert first["ok"] is True
+        assert first["compacted"] is True
+        assert first["read_cache"]["cache_hit"] is False
+        assert Path(first["evidence_packet"]["sidecar_path"]).exists()
+        assert second["ok"] is True
+        assert second["delta_marker"] is True
+        assert second["delta_kind"] == "unchanged_read_cache"
+        assert second["read_cache"]["cache_hit"] is True
+        assert Path(second["evidence_packet"]["sidecar_path"]).exists()
+        assert second["evidence_packet"]["sidecar_path"] == first["evidence_packet"]["sidecar_path"]
+
+    asyncio.run(scenario())
+
+
+def test_bash_exec_read_result_records_fingerprint_and_cache_hit(temp_home: Path) -> None:
+    async def scenario() -> None:
+        ensure_home_layout(temp_home)
+        ConfigManager(temp_home).ensure_files()
+        quest = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home)).create(
+            "mcp repeated bash read quest"
+        )
+        quest_root = Path(quest["quest_root"])
+        _write_fake_bash_session(
+            temp_home,
+            quest_root,
+            "bash-001",
+            log_lines=["alpha", "beta"],
+            status="completed",
+        )
+        context = McpContext(
+            home=temp_home,
+            quest_id=quest["quest_id"],
+            quest_root=quest_root,
+            run_id="run-bash-read-cache",
+            active_anchor="baseline",
+            conversation_id="quest:test",
+            agent_role="pi",
+            worker_id="worker-main",
+            worktree_root=None,
+            team_mode="single",
+        )
+        server = build_bash_exec_server(context)
+
+        first = _unwrap_tool_result(await server.call_tool("bash_exec", {"mode": "read", "id": "bash-001"}))
+        second = _unwrap_tool_result(await server.call_tool("bash_exec", {"mode": "read", "id": "bash-001"}))
+
+        assert first["bash_id"] == "bash-001"
+        assert first["command_fingerprint"]
+        assert first["cwd"]
+        assert first["read_cache"]["cache_hit"] is False
+        assert first["read_cache"]["source_mtime_ns"] > 0
+        assert second["ok"] is True
+        assert second["delta_marker"] is True
+        assert second["read_cache"]["cache_hit"] is True
+        assert second["command_fingerprint"] == first["command_fingerprint"]
+        assert Path(second["evidence_packet"]["sidecar_path"]).exists()
+
+    asyncio.run(scenario())
+
+
 def test_artifact_overwrite_baseline_tool_refreshes_confirmed_ref(temp_home: Path) -> None:
     async def scenario() -> None:
         ensure_home_layout(temp_home)


### PR DESCRIPTION
## Summary
- add generic MCP read-cache helpers that return `unchanged_read_cache` deltas for repeated artifact and bash read calls while preserving the first-read payload shape
- compact full-detail artifact reads into evidence-packet sidecars and expose `read_cache.saved_bytes` metadata for repeated reads
- add Codex runner tool-budget telemetry: budget remaining/exceeded, unique commands, read call count, repeated-read ratio, saved bytes, and full-detail count

## Provenance / exclusions
Adapted from MedDeepScientist runtime optimizations, limited to generic DeepScientist context-budget mechanics.

This intentionally excludes MAS/MDS medical semantics, manuscript/publication authority policy, provider UI changes, and new controller policy surfaces.

## Verification
- `python -m py_compile src/deepscientist/evidence_packets.py src/deepscientist/runners/codex.py src/deepscientist/runners/codex_telemetry.py src/deepscientist/mcp/server.py tests/test_codex_runner.py tests/test_mcp_servers.py`
- `git diff --check`
- `uv run --with pytest python -m pytest -q tests/test_codex_runner.py::test_codex_runner_tool_budget_telemetry_counts_unique_commands_and_repeated_reads tests/test_codex_runner.py::test_codex_runner_tool_budget_telemetry_counts_embedded_read_cache_delta tests/test_codex_runner.py::test_codex_runner_writes_tool_result_telemetry_and_sidecar tests/test_mcp_servers.py::test_artifact_mcp_server_repeated_outline_read_returns_delta_marker tests/test_mcp_servers.py::test_artifact_mcp_server_repeated_full_quest_state_uses_read_cache_delta tests/test_mcp_servers.py::test_artifact_mcp_server_repeated_global_status_uses_read_cache_sidecar_ref tests/test_mcp_servers.py::test_bash_exec_read_result_records_fingerprint_and_cache_hit tests/test_mcp_servers.py::test_bash_exec_mcp_server_read_supports_start_and_tail_windows`