### PR TITLE
Extract runtime storage maintenance helpers

### DIFF
--- a/scripts/dedupe_quest_worktree_cold_files.py
+++ b/scripts/dedupe_quest_worktree_cold_files.py
@@ -2,108 +2,15 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
-import os
+import json
+import sys
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from typing import Iterable
 
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
 
-def _sha256(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        while True:
-            chunk = handle.read(chunk_size)
-            if not chunk:
-                break
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _iter_targets(worktrees_root: Path, *, min_bytes: int) -> list[Path]:
-    patterns = [
-        "**/.codex/sessions/**/*.jsonl",
-        "**/experiments/**/*.json",
-    ]
-    files: list[Path] = []
-    for pattern in patterns:
-        for path in worktrees_root.glob(pattern):
-            if not path.is_file():
-                continue
-            try:
-                if path.stat().st_size < min_bytes:
-                    continue
-            except OSError:
-                continue
-            files.append(path)
-    return sorted(files)
-
-
-def _replace_with_hardlink(target: Path, source: Path) -> None:
-    with NamedTemporaryFile("wb", delete=False, dir=target.parent, prefix=f"{target.name}.", suffix=".linktmp") as handle:
-        temp_path = Path(handle.name)
-    try:
-        temp_path.unlink(missing_ok=True)
-        os.link(source, temp_path)
-        temp_path.replace(target)
-    finally:
-        temp_path.unlink(missing_ok=True)
-
-
-def dedupe_worktree_files(quest_root: Path, *, min_bytes: int) -> dict:
-    worktrees_root = quest_root / ".ds" / "worktrees"
-    size_buckets: dict[int, list[Path]] = {}
-    for path in _iter_targets(worktrees_root, min_bytes=min_bytes):
-        try:
-            size_buckets.setdefault(path.stat().st_size, []).append(path)
-        except OSError:
-            continue
-
-    manifest = {
-        "quest_root": str(quest_root),
-        "worktrees_root": str(worktrees_root),
-        "min_bytes": min_bytes,
-        "groups_examined": 0,
-        "files_relinked": 0,
-        "bytes_deduped": 0,
-        "groups": [],
-    }
-
-    for size, paths in sorted(size_buckets.items(), key=lambda item: -item[0]):
-        if len(paths) < 2:
-            continue
-        manifest["groups_examined"] += 1
-        hash_buckets: dict[str, list[Path]] = {}
-        for path in paths:
-            try:
-                hash_buckets.setdefault(_sha256(path), []).append(path)
-            except OSError:
-                continue
-        for digest, dupes in hash_buckets.items():
-            if len(dupes) < 2:
-                continue
-            canonical = dupes[0]
-            relinked: list[str] = []
-            for duplicate in dupes[1:]:
-                try:
-                    if canonical.stat().st_ino == duplicate.stat().st_ino:
-                        continue
-                except OSError:
-                    continue
-                _replace_with_hardlink(duplicate, canonical)
-                manifest["files_relinked"] += 1
-                manifest["bytes_deduped"] += size
-                relinked.append(str(duplicate.relative_to(quest_root)))
-            if relinked:
-                manifest["groups"].append(
-                    {
-                        "sha256": digest,
-                        "size_bytes": size,
-                        "canonical": str(canonical.relative_to(quest_root)),
-                        "relinked": relinked,
-                    }
-                )
-    return manifest
+from deepscientist.runtime_storage import dedupe_worktree_files
 
 
 def main() -> None:
@@ -114,8 +21,6 @@ def main() -> None:
 
     quest_root = Path(args.quest_root).expanduser().resolve()
     result = dedupe_worktree_files(quest_root, min_bytes=max(1, args.min_mb) * 1024 * 1024)
-    import json
-
     print(json.dumps(result, ensure_ascii=False, indent=2))
 
 

--- a/scripts/slim_quest_oversized_jsonl.py
+++ b/scripts/slim_quest_oversized_jsonl.py
@@ -2,193 +2,15 @@
 from __future__ import annotations
 
 import argparse
-import gzip
-import hashlib
 import json
-import os
-import re
-from datetime import UTC, datetime
+import sys
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from typing import Any
 
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
 
-EVENT_ID_RE = re.compile(rb'"event_id"\s*:\s*"([^"]+)"')
-TYPE_RE = re.compile(rb'"(?:type|event_type)"\s*:\s*"([^"]+)"')
-RUN_ID_RE = re.compile(rb'"run_id"\s*:\s*"([^"]+)"')
-TOOL_NAME_RE = re.compile(rb'"tool_name"\s*:\s*"([^"]+)"')
-TIMESTAMP_RE = re.compile(rb'"timestamp"\s*:\s*"([^"]+)"')
-SEQ_RE = re.compile(rb'"seq"\s*:\s*(\d+)')
-STREAM_RE = re.compile(rb'"stream"\s*:\s*"([^"]+)"')
-
-
-def _extract(pattern: re.Pattern[bytes], raw: bytes) -> str | None:
-    match = pattern.search(raw)
-    if match is None:
-        return None
-    try:
-        return match.group(1).decode("utf-8", errors="ignore").strip() or None
-    except Exception:
-        return None
-
-
-def _replace_file(path: Path, lines: list[bytes]) -> None:
-    with NamedTemporaryFile("wb", delete=False, dir=path.parent, prefix=f"{path.name}.", suffix=".tmp") as handle:
-        temp_path = Path(handle.name)
-        for line in lines:
-            handle.write(line)
-    temp_path.replace(path)
-
-
-def _backup_raw_line(backup_root: Path, *, file_rel: str, line_no: int, raw: bytes) -> str:
-    digest = hashlib.sha256(raw).hexdigest()[:16]
-    safe_rel = file_rel.replace("/", "__")
-    backup_name = f"{safe_rel}__line_{line_no:06d}__{digest}.jsonl.gz"
-    backup_path = backup_root / backup_name
-    backup_path.parent.mkdir(parents=True, exist_ok=True)
-    with gzip.open(backup_path, "wb") as handle:
-        handle.write(raw)
-    return str(backup_path)
-
-
-def _event_placeholder(raw: bytes, *, original_bytes: int, backup_ref: str, file_rel: str, line_no: int) -> dict[str, Any]:
-    payload: dict[str, Any] = {
-        "event_id": _extract(EVENT_ID_RE, raw) or f"evt-slim-{line_no}",
-        "type": _extract(TYPE_RE, raw) or "runner.tool_result",
-        "run_id": _extract(RUN_ID_RE, raw),
-        "tool_name": _extract(TOOL_NAME_RE, raw),
-        "status": "compacted",
-        "summary": f"Oversized quest event payload ({original_bytes} bytes) was compacted into a quest-local backup.",
-        "oversized_event": True,
-        "original_bytes": original_bytes,
-        "backup_ref": backup_ref,
-        "created_at": datetime.now(UTC).isoformat(),
-    }
-    return {key: value for key, value in payload.items() if value is not None}
-
-
-def _bash_log_placeholder(raw: bytes, *, original_bytes: int, backup_ref: str) -> dict[str, Any]:
-    payload: dict[str, Any] = {
-        "seq": int(_extract(SEQ_RE, raw) or 0),
-        "stream": _extract(STREAM_RE, raw) or "stdout",
-        "timestamp": _extract(TIMESTAMP_RE, raw),
-        "line": f"[compacted oversized bash log entry: {original_bytes} bytes -> {backup_ref}]",
-        "oversized_payload": True,
-        "original_bytes": original_bytes,
-        "backup_ref": backup_ref,
-    }
-    return {key: value for key, value in payload.items() if value is not None}
-
-
-def _stdout_placeholder(raw: bytes, *, original_bytes: int, backup_ref: str) -> dict[str, Any]:
-    payload: dict[str, Any] = {
-        "timestamp": _extract(TIMESTAMP_RE, raw),
-        "line": f"[compacted oversized stdout entry: {original_bytes} bytes -> {backup_ref}]",
-        "oversized_payload": True,
-        "original_bytes": original_bytes,
-        "backup_ref": backup_ref,
-    }
-    return {key: value for key, value in payload.items() if value is not None}
-
-
-def _codex_history_placeholder(raw: bytes, *, original_bytes: int, backup_ref: str) -> dict[str, Any]:
-    payload: dict[str, Any] = {
-        "timestamp": _extract(TIMESTAMP_RE, raw),
-        "event": {
-            "type": "oversized_payload",
-            "summary": f"Oversized codex history entry ({original_bytes} bytes) was compacted into a quest-local backup.",
-            "backup_ref": backup_ref,
-            "original_bytes": original_bytes,
-        },
-    }
-    return payload
-
-
-def _placeholder_for(path: Path, raw: bytes, *, original_bytes: int, backup_ref: str, file_rel: str, line_no: int) -> dict[str, Any]:
-    normalized = file_rel.replace("\\", "/")
-    if normalized == ".ds/events.jsonl":
-        return _event_placeholder(raw, original_bytes=original_bytes, backup_ref=backup_ref, file_rel=file_rel, line_no=line_no)
-    if normalized.startswith(".ds/bash_exec/") and normalized.endswith("/log.jsonl"):
-        return _bash_log_placeholder(raw, original_bytes=original_bytes, backup_ref=backup_ref)
-    if normalized.startswith(".ds/runs/") and normalized.endswith("/stdout.jsonl"):
-        return _stdout_placeholder(raw, original_bytes=original_bytes, backup_ref=backup_ref)
-    if normalized.startswith(".ds/codex_history/") and normalized.endswith("/events.jsonl"):
-        return _codex_history_placeholder(raw, original_bytes=original_bytes, backup_ref=backup_ref)
-    return {
-        "oversized_payload": True,
-        "original_bytes": original_bytes,
-        "backup_ref": backup_ref,
-    }
-
-
-def _iter_target_files(ds_root: Path) -> list[Path]:
-    files: list[Path] = []
-    direct_events = ds_root / "events.jsonl"
-    if direct_events.exists():
-        files.append(direct_events)
-    files.extend(sorted((ds_root / "bash_exec").glob("**/log.jsonl")))
-    files.extend(sorted((ds_root / "codex_history").glob("**/events.jsonl")))
-    files.extend(sorted((ds_root / "runs").glob("**/stdout.jsonl")))
-    return [path for path in files if path.is_file()]
-
-
-def slim_quest_jsonl(quest_root: Path, *, threshold_bytes: int) -> dict[str, Any]:
-    ds_root = quest_root / ".ds"
-    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
-    backup_root = ds_root / "slim_backups" / timestamp
-    manifest: dict[str, Any] = {
-        "quest_root": str(quest_root),
-        "threshold_bytes": threshold_bytes,
-        "backup_root": str(backup_root),
-        "processed_at": datetime.now(UTC).isoformat(),
-        "files": [],
-        "compacted_line_count": 0,
-        "compacted_bytes_total": 0,
-    }
-
-    for path in _iter_target_files(ds_root):
-        rel = path.relative_to(quest_root).as_posix()
-        line_no = 0
-        compacted_lines = 0
-        compacted_bytes = 0
-        rewritten: list[bytes] = []
-        with path.open("rb") as handle:
-            for raw in handle:
-                line_no += 1
-                line_bytes = len(raw)
-                if line_bytes <= threshold_bytes:
-                    rewritten.append(raw)
-                    continue
-                backup_ref = _backup_raw_line(backup_root, file_rel=rel, line_no=line_no, raw=raw)
-                placeholder = _placeholder_for(
-                    path,
-                    raw,
-                    original_bytes=line_bytes,
-                    backup_ref=Path(backup_ref).relative_to(quest_root).as_posix(),
-                    file_rel=rel,
-                    line_no=line_no,
-                )
-                rewritten.append((json.dumps(placeholder, ensure_ascii=False) + "\n").encode("utf-8"))
-                compacted_lines += 1
-                compacted_bytes += line_bytes
-        if compacted_lines:
-            _replace_file(path, rewritten)
-            manifest["files"].append(
-                {
-                    "path": rel,
-                    "compacted_lines": compacted_lines,
-                    "compacted_bytes": compacted_bytes,
-                }
-            )
-            manifest["compacted_line_count"] += compacted_lines
-            manifest["compacted_bytes_total"] += compacted_bytes
-
-    if manifest["compacted_line_count"]:
-        backup_root.mkdir(parents=True, exist_ok=True)
-        manifest_path = backup_root / "manifest.json"
-        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        manifest["manifest_path"] = str(manifest_path)
-    return manifest
+from deepscientist.runtime_storage import slim_quest_jsonl
 
 
 def main() -> None:
@@ -198,8 +20,7 @@ def main() -> None:
     args = parser.parse_args()
 
     quest_root = Path(args.quest_root).expanduser().resolve()
-    threshold_bytes = max(1, int(args.threshold_mb)) * 1024 * 1024
-    manifest = slim_quest_jsonl(quest_root, threshold_bytes=threshold_bytes)
+    manifest = slim_quest_jsonl(quest_root, threshold_bytes=max(1, args.threshold_mb) * 1024 * 1024)
     print(json.dumps(manifest, ensure_ascii=False, indent=2))
 
 

--- a/src/deepscientist/runtime_storage.py
+++ b/src/deepscientist/runtime_storage.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import os
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+
+EVENT_ID_RE = re.compile(rb'"event_id"\s*:\s*"([^"]+)"')
+TYPE_RE = re.compile(rb'"(?:type|event_type)"\s*:\s*"([^"]+)"')
+RUN_ID_RE = re.compile(rb'"run_id"\s*:\s*"([^"]+)"')
+TOOL_NAME_RE = re.compile(rb'"tool_name"\s*:\s*"([^"]+)"')
+TIMESTAMP_RE = re.compile(rb'"timestamp"\s*:\s*"([^"]+)"')
+SEQ_RE = re.compile(rb'"seq"\s*:\s*(\d+)')
+STREAM_RE = re.compile(rb'"stream"\s*:\s*"([^"]+)"')
+
+
+def _extract(pattern: re.Pattern[bytes], raw: bytes) -> str | None:
+    match = pattern.search(raw)
+    if match is None:
+        return None
+    try:
+        return match.group(1).decode("utf-8", errors="ignore").strip() or None
+    except Exception:
+        return None
+
+
+def _replace_file(path: Path, lines: list[bytes]) -> None:
+    with NamedTemporaryFile("wb", delete=False, dir=path.parent, prefix=f"{path.name}.", suffix=".tmp") as handle:
+        temp_path = Path(handle.name)
+        for line in lines:
+            handle.write(line)
+    temp_path.replace(path)
+
+
+def _backup_raw_line(backup_root: Path, *, file_rel: str, line_no: int, raw: bytes) -> Path:
+    digest = hashlib.sha256(raw).hexdigest()[:16]
+    safe_rel = file_rel.replace("/", "__")
+    backup_name = f"{safe_rel}__line_{line_no:06d}__{digest}.jsonl.gz"
+    backup_path = backup_root / backup_name
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(backup_path, "wb") as handle:
+        handle.write(raw)
+    return backup_path
+
+
+def _event_placeholder(raw: bytes, *, original_bytes: int, backup_ref: str, line_no: int) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "event_id": _extract(EVENT_ID_RE, raw) or f"evt-slim-{line_no}",
+        "type": _extract(TYPE_RE, raw) or "runner.tool_result",
+        "run_id": _extract(RUN_ID_RE, raw),
+        "tool_name": _extract(TOOL_NAME_RE, raw),
+        "status": "compacted",
+        "summary": f"Oversized quest event payload ({original_bytes} bytes) was compacted into a quest-local backup.",
+        "oversized_event": True,
+        "original_bytes": original_bytes,
+        "backup_ref": backup_ref,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _bash_log_placeholder(raw: bytes, *, original_bytes: int, backup_ref: str) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "seq": int(_extract(SEQ_RE, raw) or 0),
+        "stream": _extract(STREAM_RE, raw) or "stdout",
+        "timestamp": _extract(TIMESTAMP_RE, raw),
+        "line": f"[compacted oversized bash log entry: {original_bytes} bytes -> {backup_ref}]",
+        "oversized_payload": True,
+        "original_bytes": original_bytes,
+        "backup_ref": backup_ref,
+    }
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _stdout_placeholder(raw: bytes, *, original_bytes: int, backup_ref: str) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "timestamp": _extract(TIMESTAMP_RE, raw),
+        "line": f"[compacted oversized stdout entry: {original_bytes} bytes -> {backup_ref}]",
+        "oversized_payload": True,
+        "original_bytes": original_bytes,
+        "backup_ref": backup_ref,
+    }
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _codex_history_placeholder(raw: bytes, *, original_bytes: int, backup_ref: str) -> dict[str, Any]:
+    return {
+        "timestamp": _extract(TIMESTAMP_RE, raw),
+        "event": {
+            "type": "oversized_payload",
+            "summary": f"Oversized codex history entry ({original_bytes} bytes) was compacted into a quest-local backup.",
+            "backup_ref": backup_ref,
+            "original_bytes": original_bytes,
+        },
+    }
+
+
+def _placeholder_for(
+    path: Path,
+    raw: bytes,
+    *,
+    original_bytes: int,
+    backup_ref: str,
+    file_rel: str,
+    line_no: int,
+) -> dict[str, Any]:
+    normalized = file_rel.replace("\\", "/")
+    if normalized == ".ds/events.jsonl":
+        return _event_placeholder(raw, original_bytes=original_bytes, backup_ref=backup_ref, line_no=line_no)
+    if normalized.startswith(".ds/bash_exec/") and normalized.endswith("/log.jsonl"):
+        return _bash_log_placeholder(raw, original_bytes=original_bytes, backup_ref=backup_ref)
+    if normalized.startswith(".ds/runs/") and normalized.endswith("/stdout.jsonl"):
+        return _stdout_placeholder(raw, original_bytes=original_bytes, backup_ref=backup_ref)
+    if normalized.startswith(".ds/codex_history/") and normalized.endswith("/events.jsonl"):
+        return _codex_history_placeholder(raw, original_bytes=original_bytes, backup_ref=backup_ref)
+    return {
+        "oversized_payload": True,
+        "original_bytes": original_bytes,
+        "backup_ref": backup_ref,
+    }
+
+
+def _iter_jsonl_slim_targets(ds_root: Path) -> list[Path]:
+    files: list[Path] = []
+    direct_events = ds_root / "events.jsonl"
+    if direct_events.exists():
+        files.append(direct_events)
+    files.extend(sorted((ds_root / "bash_exec").glob("**/log.jsonl")))
+    files.extend(sorted((ds_root / "codex_history").glob("**/events.jsonl")))
+    files.extend(sorted((ds_root / "runs").glob("**/stdout.jsonl")))
+    return [path for path in files if path.is_file()]
+
+
+def slim_quest_jsonl(quest_root: Path, *, threshold_bytes: int) -> dict[str, Any]:
+    resolved_root = Path(quest_root).expanduser().resolve()
+    ds_root = resolved_root / ".ds"
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    backup_root = ds_root / "slim_backups" / timestamp
+    manifest: dict[str, Any] = {
+        "quest_root": str(resolved_root),
+        "threshold_bytes": threshold_bytes,
+        "backup_root": str(backup_root),
+        "processed_at": datetime.now(UTC).isoformat(),
+        "files": [],
+        "compacted_line_count": 0,
+        "compacted_bytes_total": 0,
+    }
+    if threshold_bytes <= 0 or not ds_root.exists():
+        return manifest
+
+    for path in _iter_jsonl_slim_targets(ds_root):
+        rel = path.relative_to(resolved_root).as_posix()
+        line_no = 0
+        compacted_lines = 0
+        compacted_bytes = 0
+        rewritten: list[bytes] = []
+        with path.open("rb") as handle:
+            for raw in handle:
+                line_no += 1
+                line_bytes = len(raw)
+                if line_bytes <= threshold_bytes:
+                    rewritten.append(raw)
+                    continue
+                backup_path = _backup_raw_line(backup_root, file_rel=rel, line_no=line_no, raw=raw)
+                backup_ref = backup_path.relative_to(resolved_root).as_posix()
+                placeholder = _placeholder_for(
+                    path,
+                    raw,
+                    original_bytes=line_bytes,
+                    backup_ref=backup_ref,
+                    file_rel=rel,
+                    line_no=line_no,
+                )
+                rewritten.append((json.dumps(placeholder, ensure_ascii=False) + "\n").encode("utf-8"))
+                compacted_lines += 1
+                compacted_bytes += line_bytes
+        if compacted_lines:
+            _replace_file(path, rewritten)
+            manifest["files"].append(
+                {
+                    "path": rel,
+                    "compacted_lines": compacted_lines,
+                    "compacted_bytes": compacted_bytes,
+                }
+            )
+            manifest["compacted_line_count"] += compacted_lines
+            manifest["compacted_bytes_total"] += compacted_bytes
+
+    if manifest["compacted_line_count"]:
+        backup_root.mkdir(parents=True, exist_ok=True)
+        manifest_path = backup_root / "manifest.json"
+        manifest["manifest_path"] = str(manifest_path)
+        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return manifest
+
+
+def _sha256(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _iter_dedupe_targets(worktrees_root: Path, *, min_bytes: int) -> list[Path]:
+    patterns = [
+        "**/.codex/sessions/**/*.jsonl",
+        "**/experiments/**/*.json",
+    ]
+    files: list[Path] = []
+    for pattern in patterns:
+        for path in worktrees_root.glob(pattern):
+            if not path.is_file():
+                continue
+            try:
+                if path.stat().st_size < min_bytes:
+                    continue
+            except OSError:
+                continue
+            files.append(path)
+    return sorted(files)
+
+
+def _replace_with_hardlink(target: Path, source: Path) -> None:
+    with NamedTemporaryFile("wb", delete=False, dir=target.parent, prefix=f"{target.name}.", suffix=".linktmp") as handle:
+        temp_path = Path(handle.name)
+    try:
+        temp_path.unlink(missing_ok=True)
+        os.link(source, temp_path)
+        temp_path.replace(target)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def dedupe_worktree_files(quest_root: Path, *, min_bytes: int) -> dict[str, Any]:
+    resolved_root = Path(quest_root).expanduser().resolve()
+    worktrees_root = resolved_root / ".ds" / "worktrees"
+    manifest: dict[str, Any] = {
+        "quest_root": str(resolved_root),
+        "worktrees_root": str(worktrees_root),
+        "min_bytes": min_bytes,
+        "groups_examined": 0,
+        "files_relinked": 0,
+        "bytes_deduped": 0,
+        "groups": [],
+    }
+    if min_bytes <= 0 or not worktrees_root.exists():
+        return manifest
+
+    size_buckets: dict[int, list[Path]] = {}
+    for path in _iter_dedupe_targets(worktrees_root, min_bytes=min_bytes):
+        try:
+            size_buckets.setdefault(path.stat().st_size, []).append(path)
+        except OSError:
+            continue
+
+    for size, paths in sorted(size_buckets.items(), key=lambda item: -item[0]):
+        if len(paths) < 2:
+            continue
+        manifest["groups_examined"] += 1
+        hash_buckets: dict[str, list[Path]] = {}
+        for path in paths:
+            try:
+                hash_buckets.setdefault(_sha256(path), []).append(path)
+            except OSError:
+                continue
+        for digest, dupes in hash_buckets.items():
+            if len(dupes) < 2:
+                continue
+            canonical = dupes[0]
+            relinked: list[str] = []
+            for duplicate in dupes[1:]:
+                try:
+                    if canonical.stat().st_ino == duplicate.stat().st_ino:
+                        continue
+                except OSError:
+                    continue
+                _replace_with_hardlink(duplicate, canonical)
+                manifest["files_relinked"] += 1
+                manifest["bytes_deduped"] += size
+                relinked.append(str(duplicate.relative_to(resolved_root)))
+            if relinked:
+                manifest["groups"].append(
+                    {
+                        "sha256": digest,
+                        "size_bytes": size,
+                        "canonical": str(canonical.relative_to(resolved_root)),
+                        "relinked": relinked,
+                    }
+                )
+    return manifest
+
+
+__all__ = ["dedupe_worktree_files", "slim_quest_jsonl"]

--- a/tests/test_runtime_storage.py
+++ b/tests/test_runtime_storage.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import gzip
+import json
+import os
+from pathlib import Path
+
+from deepscientist.runtime_storage import dedupe_worktree_files, slim_quest_jsonl
+
+
+def _jsonl_line(payload: dict[str, object]) -> bytes:
+    return (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def test_slim_quest_jsonl_rewrites_oversized_lines_and_keeps_backup(temp_home: Path) -> None:
+    quest_root = temp_home / "quests" / "q-storage"
+    events_path = quest_root / ".ds" / "events.jsonl"
+    log_path = quest_root / ".ds" / "bash_exec" / "bash-001" / "log.jsonl"
+    events_path.parent.mkdir(parents=True)
+    log_path.parent.mkdir(parents=True)
+    small_event = _jsonl_line({"event_id": "evt-small", "type": "runner.message", "text": "small"})
+    large_event = _jsonl_line(
+        {
+            "event_id": "evt-large",
+            "type": "runner.tool_result",
+            "run_id": "run-001",
+            "tool_name": "artifact.get_quest_state",
+            "payload": "x" * 512,
+        }
+    )
+    large_log = _jsonl_line(
+        {
+            "seq": 7,
+            "stream": "stdout",
+            "timestamp": "2026-04-01T00:00:00+00:00",
+            "line": "y" * 512,
+        }
+    )
+    events_path.write_bytes(small_event + large_event)
+    log_path.write_bytes(large_log)
+
+    manifest = slim_quest_jsonl(quest_root, threshold_bytes=200)
+
+    assert manifest["compacted_line_count"] == 2
+    assert manifest["compacted_bytes_total"] == len(large_event) + len(large_log)
+    assert {item["path"] for item in manifest["files"]} == {
+        ".ds/events.jsonl",
+        ".ds/bash_exec/bash-001/log.jsonl",
+    }
+    manifest_path = Path(str(manifest["manifest_path"]))
+    assert manifest_path.exists()
+    rewritten_events = events_path.read_text(encoding="utf-8").splitlines()
+    assert json.loads(rewritten_events[0])["event_id"] == "evt-small"
+    event_placeholder = json.loads(rewritten_events[1])
+    assert event_placeholder["event_id"] == "evt-large"
+    assert event_placeholder["type"] == "runner.tool_result"
+    assert event_placeholder["oversized_event"] is True
+    assert event_placeholder["backup_ref"].startswith(".ds/slim_backups/")
+    log_placeholder = json.loads(log_path.read_text(encoding="utf-8"))
+    assert log_placeholder["seq"] == 7
+    assert log_placeholder["oversized_payload"] is True
+    backup_path = quest_root / event_placeholder["backup_ref"]
+    with gzip.open(backup_path, "rb") as handle:
+        assert handle.read() == large_event
+
+
+def test_slim_quest_jsonl_noops_when_no_lines_exceed_threshold(temp_home: Path) -> None:
+    quest_root = temp_home / "quests" / "q-storage-noop"
+    events_path = quest_root / ".ds" / "events.jsonl"
+    events_path.parent.mkdir(parents=True)
+    raw = _jsonl_line({"event_id": "evt-small", "type": "runner.message", "text": "small"})
+    events_path.write_bytes(raw)
+
+    manifest = slim_quest_jsonl(quest_root, threshold_bytes=1024)
+
+    assert manifest["compacted_line_count"] == 0
+    assert "manifest_path" not in manifest
+    assert events_path.read_bytes() == raw
+
+
+def test_dedupe_worktree_files_relinks_duplicate_large_cold_files(temp_home: Path) -> None:
+    quest_root = temp_home / "quests" / "q-storage-dedupe"
+    first = quest_root / ".ds" / "worktrees" / "branch-a" / ".codex" / "sessions" / "a.jsonl"
+    second = quest_root / ".ds" / "worktrees" / "branch-b" / ".codex" / "sessions" / "b.jsonl"
+    different = quest_root / ".ds" / "worktrees" / "branch-c" / "experiments" / "result.json"
+    for path in (first, second, different):
+        path.parent.mkdir(parents=True, exist_ok=True)
+    duplicate_payload = b'{"payload":"' + (b"x" * 1024) + b'"}\n'
+    first.write_bytes(duplicate_payload)
+    second.write_bytes(duplicate_payload)
+    different.write_bytes(b'{"payload":"' + (b"z" * 1024) + b'"}\n')
+
+    manifest = dedupe_worktree_files(quest_root, min_bytes=128)
+
+    assert manifest["groups_examined"] == 1
+    assert manifest["files_relinked"] == 1
+    assert manifest["bytes_deduped"] == len(duplicate_payload)
+    assert manifest["groups"][0]["canonical"] == first.relative_to(quest_root).as_posix()
+    assert manifest["groups"][0]["relinked"] == [second.relative_to(quest_root).as_posix()]
+    assert os.stat(first).st_ino == os.stat(second).st_ino
+    assert os.stat(first).st_ino != os.stat(different).st_ino


### PR DESCRIPTION
## Summary
- move the existing oversized JSONL slimming and worktree hardlink-dedupe logic into `deepscientist.runtime_storage`
- keep the two existing scripts as thin CLI wrappers over the library
- add focused unit tests for JSONL slimming backups/placeholders and duplicate worktree file relinking

## Scope
This is intentionally limited to library extraction and tests for the existing maintenance behavior. It does not add cold archive/restore manifests, daemon scheduling, or new runtime policy surfaces.

## Verification
- `python -m py_compile src/deepscientist/runtime_storage.py scripts/slim_quest_oversized_jsonl.py scripts/dedupe_quest_worktree_cold_files.py tests/test_runtime_storage.py`
- `git diff --check`
- `uv run --with pytest python -m pytest -q tests/test_runtime_storage.py`
- `python scripts/slim_quest_oversized_jsonl.py --help`
- `python scripts/dedupe_quest_worktree_cold_files.py --help`