### PR TITLE
Return sidecar deltas for paper write artifacts

### DIFF
--- a/src/deepscientist/artifact/service.py
+++ b/src/deepscientist/artifact/service.py
@@ -2025,6 +2025,85 @@ class ArtifactService:
     def _paper_bundle_manifest_path(self, quest_root: Path, *, workspace_root: Path | None = None) -> Path:
         return self._paper_root(quest_root, workspace_root=workspace_root, create=True) / "paper_bundle_manifest.json"
 
+    def _paper_artifact_deltas_root(self, quest_root: Path, *, workspace_root: Path | None = None) -> Path:
+        return ensure_dir(self._paper_root(quest_root, workspace_root=workspace_root, create=True) / "artifact_deltas")
+
+    def _paper_artifact_delta_entry(
+        self,
+        quest_root: Path,
+        *,
+        workspace_root: Path | None,
+        label: str,
+        path: Path | str | None,
+    ) -> dict[str, Any] | None:
+        if path is None:
+            return None
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = self._workspace_root_for(quest_root, workspace_root) / candidate
+        resolved = candidate.resolve()
+        entry: dict[str, Any] = {
+            "label": label,
+            "path": self._paper_bundle_relative_path(quest_root, resolved, workspace_root=workspace_root)
+            or self._workspace_relative(quest_root, resolved)
+            or str(resolved),
+            "absolute_path": str(resolved),
+            "exists": resolved.exists(),
+        }
+        if resolved.exists():
+            try:
+                stat = resolved.stat()
+            except OSError:
+                return entry
+            entry["size_bytes"] = stat.st_size
+            entry["mtime_ns"] = stat.st_mtime_ns
+        return entry
+
+    def _write_paper_artifact_delta(
+        self,
+        quest_root: Path,
+        *,
+        workspace_root: Path | None,
+        tool_name: str,
+        delta_kind: str,
+        paths: list[tuple[str, Path | str | None]],
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        delta_id = generate_id("delta")
+        entries: list[dict[str, Any]] = []
+        for label, path in paths:
+            entry = self._paper_artifact_delta_entry(
+                quest_root,
+                workspace_root=workspace_root,
+                label=label,
+                path=path,
+            )
+            if entry is not None:
+                entries.append(entry)
+        sidecar_path = self._paper_artifact_deltas_root(quest_root, workspace_root=workspace_root) / f"{delta_id}.json"
+        payload = {
+            "schema_version": 1,
+            "delta_id": delta_id,
+            "delta_kind": delta_kind,
+            "tool_name": tool_name,
+            "created_at": utc_now(),
+            "quest_root": str(quest_root),
+            "workspace_root": str(self._workspace_root_for(quest_root, workspace_root)),
+            "paths": entries,
+            "metadata": metadata or {},
+        }
+        write_json(sidecar_path, payload)
+        return {
+            "schema_version": 1,
+            "delta_id": delta_id,
+            "delta_kind": delta_kind,
+            "sidecar_path": str(sidecar_path),
+            "sidecar_rel_path": self._paper_bundle_relative_path(quest_root, sidecar_path, workspace_root=workspace_root)
+            or self._workspace_relative(quest_root, sidecar_path),
+            "path_count": len(entries),
+            "changed_paths": [str(entry.get("path") or "") for entry in entries if str(entry.get("path") or "").strip()],
+        }
+
     def _paper_evidence_ledger_path(self, quest_root: Path) -> Path:
         return ensure_dir(quest_root / "paper") / "evidence_ledger.json"
 
@@ -12436,6 +12515,23 @@ class ArtifactService:
                 checkpoint=False,
                 workspace_root=workspace_root,
             )
+            delta_paths: list[tuple[str, Path | str | None]] = [("outline_json", candidate_path)]
+            if canonical_candidate_path.resolve() != candidate_path.resolve():
+                delta_paths.append(("canonical_outline_json", canonical_candidate_path))
+            if artifact.get("path"):
+                delta_paths.append(("artifact_json", str(artifact.get("path"))))
+            artifact_delta = self._write_paper_artifact_delta(
+                quest_root,
+                workspace_root=workspace_root,
+                tool_name="submit_paper_outline",
+                delta_kind="paper_outline_candidate",
+                paths=delta_paths,
+                metadata={
+                    "mode": normalized_mode,
+                    "outline_id": resolved_outline_id,
+                    "title": record.get("title"),
+                },
+            )
             return {
                 "ok": True,
                 "mode": normalized_mode,
@@ -12443,6 +12539,7 @@ class ArtifactService:
                 "outline_path": str(candidate_path),
                 "record": record,
                 "artifact": artifact,
+                "artifact_delta": artifact_delta,
             }
 
         source_outline_id = str(outline_id or existing_selected.get("outline_id") or "").strip()
@@ -12622,6 +12719,29 @@ class ArtifactService:
                 }
             ],
         )
+        delta_paths = [
+            ("selected_outline_json", selected_outline_path),
+            ("outline_manifest_json", self._paper_outline_manifest_path(quest_root, workspace_root=workspace_root)),
+            ("outline_selection_md", outline_selection_path),
+            ("paper_line_state_json", self._paper_line_state_path(quest_root, workspace_root=workspace_root)),
+            ("source_outline_json", source_candidate_path),
+            ("revised_outline_json", revised_outline_path),
+        ]
+        if artifact.get("path"):
+            delta_paths.append(("artifact_json", str(artifact.get("path"))))
+        artifact_delta = self._write_paper_artifact_delta(
+            quest_root,
+            workspace_root=workspace_root,
+            tool_name="submit_paper_outline",
+            delta_kind="paper_outline_selected" if normalized_mode == "select" else "paper_outline_revised",
+            paths=delta_paths,
+            metadata={
+                "mode": normalized_mode,
+                "outline_id": source_outline_id,
+                "title": resolved_record.get("title"),
+                "paper_line_id": paper_line_state.get("paper_line_id"),
+            },
+        )
         return {
             "ok": True,
             "mode": normalized_mode,
@@ -12635,6 +12755,7 @@ class ArtifactService:
             "paper_line_state": paper_line_state,
             "artifact": artifact,
             "interaction": interaction,
+            "artifact_delta": artifact_delta,
         }
 
     def submit_paper_bundle(
@@ -12938,6 +13059,30 @@ class ArtifactService:
                 }
             ],
         )
+        delta_paths = [
+            ("paper_bundle_manifest_json", manifest_path),
+            ("baseline_inventory_json", baseline_inventory_path),
+            ("evidence_ledger_json", evidence_ledger_path if evidence_ledger_path.exists() else None),
+            ("experiment_matrix_md", experiment_matrix_path if experiment_matrix_path.exists() else None),
+            ("experiment_matrix_json", experiment_matrix_json_path if experiment_matrix_json_path.exists() else None),
+            ("paper_line_state_json", self._paper_line_state_path(quest_root, workspace_root=workspace_root)),
+            ("manuscript_coverage_json", self._paper_manuscript_coverage_path(quest_root, workspace_root=workspace_root)),
+        ]
+        if artifact.get("path"):
+            delta_paths.append(("artifact_json", str(artifact.get("path"))))
+        artifact_delta = self._write_paper_artifact_delta(
+            quest_root,
+            workspace_root=workspace_root,
+            tool_name="submit_paper_bundle",
+            delta_kind=normalized_package_type,
+            paths=delta_paths,
+            metadata={
+                "title": manifest.get("title"),
+                "package_type": normalized_package_type,
+                "selected_outline_ref": manifest.get("selected_outline_ref"),
+                "paper_branch": paper_branch,
+            },
+        )
         return {
             "ok": True,
             "manifest_path": str(manifest_path),
@@ -12955,6 +13100,7 @@ class ArtifactService:
             "artifact": artifact,
             "interaction": interaction,
             "continuation": continuation_result,
+            "artifact_delta": artifact_delta,
         }
 
     def record_analysis_slice(

--- a/src/deepscientist/mcp/server.py
+++ b/src/deepscientist/mcp/server.py
@@ -1114,6 +1114,113 @@ def build_artifact_server(context: McpContext) -> FastMCP:
             state_change_note=ARTIFACT_STATE_CHANGE_WATCHDOG_NOTES.get(tool_name),
         )
 
+    def _quest_relative_path(value: Any) -> str | None:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        path = Path(text)
+        if not path.is_absolute():
+            return text
+        quest_root = context.require_quest_root().resolve()
+        try:
+            active_workspace_root = quest_service.active_workspace_root(quest_root)
+        except Exception:
+            active_workspace_root = None
+        roots = [context.worktree_root, active_workspace_root, context.quest_root]
+        seen: set[str] = set()
+        for raw_root in roots:
+            if raw_root is None:
+                continue
+            root = raw_root.resolve()
+            key = str(root)
+            if key in seen:
+                continue
+            seen.add(key)
+            try:
+                return path.resolve().relative_to(root).as_posix()
+            except ValueError:
+                continue
+        try:
+            return path.resolve().relative_to(quest_root).as_posix()
+        except ValueError:
+            return text
+
+    def _compact_artifact_delta(value: Any) -> dict[str, Any] | None:
+        if not isinstance(value, dict):
+            return None
+        return {
+            key: value.get(key)
+            for key in (
+                "schema_version",
+                "delta_id",
+                "delta_kind",
+                "sidecar_rel_path",
+                "path_count",
+                "changed_paths",
+            )
+            if value.get(key) is not None
+        }
+
+    def _compact_paths(payload: dict[str, Any], keys: tuple[str, ...]) -> dict[str, str]:
+        paths: dict[str, str] = {}
+        for key in keys:
+            relative = _quest_relative_path(payload.get(key))
+            if relative:
+                paths[key] = relative
+        return paths
+
+    def compact_paper_write_result(payload: dict[str, Any], *, tool_name: str) -> dict[str, Any]:
+        compact: dict[str, Any] = {
+            "ok": bool(payload.get("ok")),
+            "tool_name": tool_name,
+            "artifact_delta": _compact_artifact_delta(payload.get("artifact_delta")),
+            "hint": "Full paper artifact content was written to files; read the listed paths or artifact_delta sidecar only when needed.",
+        }
+        if tool_name == "submit_paper_outline":
+            compact.update(
+                {
+                    "mode": payload.get("mode"),
+                    "outline_id": payload.get("outline_id"),
+                    "paths": _compact_paths(
+                        payload,
+                        (
+                            "outline_path",
+                            "selected_outline_path",
+                            "outline_manifest_path",
+                            "paper_line_state_path",
+                            "outline_selection_path",
+                            "revised_outline_path",
+                        ),
+                    ),
+                }
+            )
+            return compact
+
+        manifest = payload.get("manifest") if isinstance(payload.get("manifest"), dict) else {}
+        paper_line_state = payload.get("paper_line_state") if isinstance(payload.get("paper_line_state"), dict) else {}
+        continuation = payload.get("continuation") if isinstance(payload.get("continuation"), dict) else {}
+        compact.update(
+            {
+                "package_type": manifest.get("package_type"),
+                "title": manifest.get("title"),
+                "selected_outline_ref": manifest.get("selected_outline_ref"),
+                "paper_branch": manifest.get("paper_branch") or paper_line_state.get("paper_branch"),
+                "next_anchor": continuation.get("anchor") or "decision",
+                "paths": _compact_paths(
+                    payload,
+                    (
+                        "manifest_path",
+                        "baseline_inventory_path",
+                        "evidence_ledger_path",
+                        "paper_line_state_path",
+                        "manuscript_coverage_path",
+                        "open_source_manifest_path",
+                    ),
+                ),
+            }
+        )
+        return compact
+
     if issue_only_profile:
         @server.tool(
             name="prepare_github_issue",
@@ -1829,7 +1936,10 @@ def build_artifact_server(context: McpContext) -> FastMCP:
                 review_result=review_result,
                 selected_reason=selected_reason,
             )
-            return finalize_state_changing_artifact_tool(result, tool_name="submit_paper_outline")
+            return finalize_state_changing_artifact_tool(
+                compact_paper_write_result(result, tool_name="submit_paper_outline"),
+                tool_name="submit_paper_outline",
+            )
         except (ValueError, FileNotFoundError, RuntimeError) as exc:
             return finalize_artifact_tool(
                 _artifact_guided_error_payload(
@@ -1873,7 +1983,7 @@ def build_artifact_server(context: McpContext) -> FastMCP:
         comment: str | dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         try:
-            return service.submit_paper_bundle(
+            result = service.submit_paper_bundle(
                 context.require_quest_root(),
                 title=title,
                 summary=summary,
@@ -1886,6 +1996,10 @@ def build_artifact_server(context: McpContext) -> FastMCP:
                 pdf_path=pdf_path,
                 latex_root_path=latex_root_path,
                 package_type=package_type,
+            )
+            return finalize_state_changing_artifact_tool(
+                compact_paper_write_result(result, tool_name="submit_paper_bundle"),
+                tool_name="submit_paper_bundle",
             )
         except (ValueError, FileNotFoundError, RuntimeError) as exc:
             return finalize_artifact_tool(

--- a/tests/test_mcp_servers.py
+++ b/tests/test_mcp_servers.py
@@ -1132,6 +1132,105 @@ def test_start_setup_prepare_profile_artifact_server_exposes_only_prepare_form_t
     asyncio.run(scenario())
 
 
+def test_artifact_mcp_compacts_paper_write_tool_returns(temp_home: Path) -> None:
+    async def scenario() -> None:
+        ensure_home_layout(temp_home)
+        ConfigManager(temp_home).ensure_files()
+        quest_service = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home))
+        quest = quest_service.create("mcp compact paper write quest")
+        quest_root = Path(quest["quest_root"])
+        context = McpContext(
+            home=temp_home,
+            quest_id=quest["quest_id"],
+            quest_root=quest_root,
+            run_id="run-mcp-compact-paper",
+            active_anchor="write",
+            conversation_id="quest:test",
+            agent_role="pi",
+            worker_id="worker-main",
+            worktree_root=None,
+            team_mode="single",
+        )
+        server = build_artifact_server(context)
+
+        candidate = _unwrap_tool_result(
+            await server.call_tool(
+                "submit_paper_outline",
+                {
+                    "mode": "candidate",
+                    "outline_id": "outline-compact",
+                    "title": "Compact outline",
+                    "note": "Keep the MCP return small.",
+                    "detailed_outline": {
+                        "title": "Compact outline",
+                        "research_questions": ["RQ-compact"],
+                        "experimental_designs": ["Exp-compact"],
+                        "contributions": ["C-compact"],
+                    },
+                },
+            )
+        )
+        assert candidate["ok"] is True
+        assert candidate["tool_name"] == "submit_paper_outline"
+        assert candidate["outline_id"] == "outline-compact"
+        assert candidate["paths"]["outline_path"].endswith("paper/outlines/candidates/outline-compact.json")
+        assert candidate["artifact_delta"]["sidecar_rel_path"].startswith("paper/artifact_deltas/")
+        assert Path(quest_service.active_workspace_root(quest_root) / candidate["artifact_delta"]["sidecar_rel_path"]).exists()
+        assert not {"record", "artifact", "interaction", "paper_line_state"} & set(candidate)
+        assert "sidecar_path" not in candidate["artifact_delta"]
+
+        selected = _unwrap_tool_result(
+            await server.call_tool(
+                "submit_paper_outline",
+                {
+                    "mode": "select",
+                    "outline_id": "outline-compact",
+                    "selected_reason": "Use the compact outline.",
+                },
+            )
+        )
+        assert selected["ok"] is True
+        assert selected["mode"] == "select"
+        assert selected["outline_id"] == "outline-compact"
+        assert selected["paths"]["selected_outline_path"] == "paper/selected_outline.json"
+        assert selected["paths"]["outline_manifest_path"] == "paper/outline/manifest.json"
+        assert selected["artifact_delta"]["delta_kind"] == "paper_outline_selected"
+        assert not {"record", "artifact", "interaction", "paper_line_state"} & set(selected)
+
+        paper_workspace = quest_service.active_workspace_root(quest_root)
+        paper_root = paper_workspace / "paper"
+        paper_root.mkdir(parents=True, exist_ok=True)
+        (paper_root / "draft.md").write_text("# Draft\n", encoding="utf-8")
+        (paper_root / "writing_plan.md").write_text("# Plan\n", encoding="utf-8")
+        (paper_root / "references.bib").write_text("@article{demo, title={Demo}}\n", encoding="utf-8")
+        (paper_root / "build").mkdir(parents=True, exist_ok=True)
+        write_json(paper_root / "build" / "compile_report.json", {"ok": True})
+        (paper_root / "paper.pdf").write_bytes(b"%PDF-1.4\n%paper\n")
+
+        bundle = _unwrap_tool_result(
+            await server.call_tool(
+                "submit_paper_bundle",
+                {
+                    "title": "Compact bundle",
+                    "summary": "Compact bundle return.",
+                    "pdf_path": "paper/paper.pdf",
+                },
+            )
+        )
+        assert bundle["ok"] is True
+        assert bundle["tool_name"] == "submit_paper_bundle"
+        assert bundle["package_type"] == "draft_checkpoint"
+        assert bundle["selected_outline_ref"] == "outline-compact"
+        assert bundle["paths"]["manifest_path"] == "paper/paper_bundle_manifest.json"
+        assert bundle["paths"]["paper_line_state_path"] == "paper/paper_line_state.json"
+        assert bundle["artifact_delta"]["delta_kind"] == "draft_checkpoint"
+        assert Path(quest_service.active_workspace_root(quest_root) / bundle["artifact_delta"]["sidecar_rel_path"]).exists()
+        assert not {"manifest", "artifact", "interaction", "paper_line_state", "continuation"} & set(bundle)
+        assert "sidecar_path" not in bundle["artifact_delta"]
+
+    asyncio.run(scenario())
+
+
 def test_artifact_mcp_copilot_workspace_keeps_branch_graph_visible(temp_home: Path) -> None:
     async def scenario() -> None:
         ensure_home_layout(temp_home)

--- a/tests/test_memory_and_artifact.py
+++ b/tests/test_memory_and_artifact.py
@@ -22,6 +22,26 @@ from deepscientist.shared import ensure_dir, read_json, read_jsonl, read_yaml, w
 from deepscientist.skills import SkillInstaller
 
 
+def _assert_artifact_delta(
+    delta: dict[str, Any],
+    *,
+    delta_kind: str,
+    expected_labels: set[str],
+) -> dict[str, Any]:
+    assert delta["schema_version"] == 1
+    assert delta["delta_kind"] == delta_kind
+    assert delta["path_count"] >= len(expected_labels)
+    assert delta["sidecar_rel_path"].startswith("paper/artifact_deltas/")
+    sidecar = read_json(Path(delta["sidecar_path"]), {})
+    assert sidecar["schema_version"] == 1
+    assert sidecar["delta_id"] == delta["delta_id"]
+    assert sidecar["delta_kind"] == delta_kind
+    by_label = {item["label"]: item for item in sidecar["paths"]}
+    assert expected_labels.issubset(by_label)
+    assert all(by_label[label]["exists"] is True for label in expected_labels)
+    return sidecar
+
+
 def _detailed_metric_contract(
     metric_ids: list[str],
     *,
@@ -1426,6 +1446,12 @@ def test_paper_outline_flow_and_outline_bound_analysis_campaign(temp_home: Path)
     assert candidate_1["outline_id"] == "outline-001"
     assert candidate_2["outline_id"] == "outline-002"
     assert candidate_3["outline_id"] == "outline-003"
+    candidate_delta = _assert_artifact_delta(
+        candidate_1["artifact_delta"],
+        delta_kind="paper_outline_candidate",
+        expected_labels={"outline_json", "artifact_json"},
+    )
+    assert candidate_delta["metadata"]["outline_id"] == "outline-001"
 
     selected = artifact.submit_paper_outline(
         quest_root,
@@ -1438,6 +1464,18 @@ def test_paper_outline_flow_and_outline_bound_analysis_campaign(temp_home: Path)
     assert Path(selected["outline_manifest_path"]).exists()
     assert Path(selected["paper_line_state_path"]).exists()
     assert Path(selected["outline_selection_path"]).exists()
+    selected_delta = _assert_artifact_delta(
+        selected["artifact_delta"],
+        delta_kind="paper_outline_selected",
+        expected_labels={
+            "selected_outline_json",
+            "outline_manifest_json",
+            "outline_selection_md",
+            "paper_line_state_json",
+            "artifact_json",
+        },
+    )
+    assert selected_delta["metadata"]["outline_id"] == "outline-002"
     assert quest_service.snapshot(quest["quest_id"])["active_anchor"] == "write"
 
     campaign = artifact.create_analysis_campaign(
@@ -1458,6 +1496,8 @@ def test_paper_outline_flow_and_outline_bound_analysis_campaign(temp_home: Path)
                 "tier": "main_required",
                 "paper_placement": "main_text",
                 "paper_role": "main_text",
+                "analysis_role": "ablation",
+                "target_display": "Main ablation",
                 "section_id": "analysis-main",
                 "item_id": "AN-001",
                 "claim_links": ["C1"],
@@ -2221,6 +2261,19 @@ def test_submit_paper_bundle_writes_draft_checkpoint_without_finalize(temp_home:
     assert Path(result["evidence_ledger_path"]).exists()
     assert Path(result["paper_line_state_path"]).exists()
     assert result["open_source_manifest_path"] is None
+    bundle_delta = _assert_artifact_delta(
+        result["artifact_delta"],
+        delta_kind="draft_checkpoint",
+        expected_labels={
+            "paper_bundle_manifest_json",
+            "baseline_inventory_json",
+            "evidence_ledger_json",
+            "paper_line_state_json",
+            "manuscript_coverage_json",
+            "artifact_json",
+        },
+    )
+    assert bundle_delta["metadata"]["package_type"] == "draft_checkpoint"
     baseline_inventory = read_json(Path(result["baseline_inventory_path"]), {})
     assert baseline_inventory["schema_version"] == 1
     manifest = read_json(Path(result["manifest_path"]), {})


### PR DESCRIPTION
## Summary
- add `paper/artifact_deltas/*.json` sidecars for paper outline and paper bundle write tools
- return a compact `artifact_delta` pointer with changed paths instead of inlining artifact content
- cover candidate/selected outlines and draft bundle submission in existing artifact tests

## Scope
This is limited to paper write artifact delta markers. It does not change paper authority policy, publication gates, daemon scheduling, or medical/MDS semantics.

## Verification
- `python -m py_compile src/deepscientist/artifact/service.py tests/test_memory_and_artifact.py`
- `git diff --check`
- `uv run --with pytest python -m pytest -q tests/test_memory_and_artifact.py::test_paper_outline_flow_and_outline_bound_analysis_campaign tests/test_memory_and_artifact.py::test_submit_paper_bundle_writes_draft_checkpoint_without_finalize`