### PR TITLE
[Bugfix] Mirror refresh_summary to quest_root and resolve sharedmemory:: read paths

### DIFF
--- a/src/deepscientist/artifact/service.py
+++ b/src/deepscientist/artifact/service.py
@@ -14227,8 +14227,12 @@ class ArtifactService:
                 payload = read_json(Path(item["path"]), {})
                 summary = payload.get("summary") or "No summary provided."
                 lines.append(f"- `{payload.get('run_id') or payload.get('artifact_id')}`: {summary}")
+        summary_body = "\n".join(lines).rstrip() + "\n"
         summary_path = workspace_root / "SUMMARY.md"
-        write_text(summary_path, "\n".join(lines).rstrip() + "\n")
+        write_text(summary_path, summary_body)
+        quest_root_summary_path = quest_root / "SUMMARY.md"
+        if quest_root_summary_path.resolve() != summary_path.resolve():
+            write_text(quest_root_summary_path, summary_body)
         artifact = self.record(
             quest_root,
             {
@@ -14238,7 +14242,10 @@ class ArtifactService:
                 "report_id": generate_id("report"),
                 "summary": "Quest summary refreshed from recent artifacts.",
                 "reason": reason or "Summary refreshed after artifact updates.",
-                "paths": {"summary_md": str(summary_path)},
+                "paths": {
+                    "summary_md": str(summary_path),
+                    "quest_root_summary_md": str(quest_root_summary_path),
+                },
                 "source": {"kind": "system", "role": "artifact"},
             },
             workspace_root=workspace_root,
@@ -14246,6 +14253,7 @@ class ArtifactService:
         return {
             "ok": True,
             "summary_path": str(summary_path),
+            "quest_root_summary_path": str(quest_root_summary_path),
             "artifact": artifact,
             "guidance": "Use the refreshed SUMMARY.md as the compact quest state for the next turn.",
         }

--- a/src/deepscientist/memory/service.py
+++ b/src/deepscientist/memory/service.py
@@ -74,6 +74,12 @@ class MemoryService:
         quest_root: Path | None = None,
     ) -> Path:
         if path:
+            shared = self.parse_shared_document_id(path)
+            if shared is not None:
+                source_quest_id, relative = shared
+                shared_candidate = self.home / "quests" / source_quest_id / "memory" / relative
+                if shared_candidate.exists():
+                    return shared_candidate
             candidate = Path(path)
             if candidate.exists():
                 return candidate

--- a/tests/test_memory_and_artifact.py
+++ b/tests/test_memory_and_artifact.py
@@ -850,6 +850,50 @@ def test_memory_document_open_uses_quest_root_when_active_workspace_is_worktree(
     assert "Memory content should still resolve from quest root." in opened["content"]
 
 
+def test_refresh_summary_mirrors_to_quest_root_when_active_workspace_is_worktree(temp_home: Path) -> None:
+    ensure_home_layout(temp_home)
+    ConfigManager(temp_home).ensure_files()
+    quest_service = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home))
+    quest = quest_service.create("refresh summary worktree mirror")
+    quest_root = Path(quest["quest_root"])
+    artifact = ArtifactService(temp_home)
+
+    worktree_root = quest_root / ".ds" / "worktrees" / "idea-branch-mirror"
+    worktree_root.mkdir(parents=True, exist_ok=True)
+    quest_service.update_research_state(
+        quest_root,
+        current_workspace_root=str(worktree_root),
+        research_head_worktree_root=str(worktree_root),
+    )
+
+    result = artifact.refresh_summary(quest_root, reason="mirror to quest root")
+    assert result["ok"] is True
+
+    workspace_summary = Path(result["summary_path"])
+    quest_root_summary = Path(result["quest_root_summary_path"])
+    assert workspace_summary == worktree_root / "SUMMARY.md"
+    assert quest_root_summary == quest_root / "SUMMARY.md"
+    assert workspace_summary.exists()
+    assert quest_root_summary.exists()
+    assert workspace_summary.read_text(encoding="utf-8") == quest_root_summary.read_text(encoding="utf-8")
+    assert "mirror to quest root" in quest_root_summary.read_text(encoding="utf-8")
+
+
+def test_refresh_summary_writes_once_when_workspace_equals_quest_root(temp_home: Path) -> None:
+    ensure_home_layout(temp_home)
+    ConfigManager(temp_home).ensure_files()
+    quest_service = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home))
+    quest = quest_service.create("refresh summary no worktree")
+    quest_root = Path(quest["quest_root"])
+    artifact = ArtifactService(temp_home)
+
+    result = artifact.refresh_summary(quest_root, reason="no worktree")
+    assert result["ok"] is True
+    assert Path(result["summary_path"]) == quest_root / "SUMMARY.md"
+    assert Path(result["quest_root_summary_path"]) == quest_root / "SUMMARY.md"
+    assert (quest_root / "SUMMARY.md").exists()
+
+
 def test_artifact_interact_and_prepare_branch(temp_home: Path) -> None:
     ensure_home_layout(temp_home)
     ConfigManager(temp_home).ensure_files()

--- a/tests/test_memory_and_artifact.py
+++ b/tests/test_memory_and_artifact.py
@@ -816,6 +816,39 @@ def test_shared_memory_visibility_reads_other_quests_but_opens_them_read_only(te
     assert Path(remote_card["path"]).exists()
 
 
+def test_memory_read_resolves_sharedmemory_document_id_from_other_quest(temp_home: Path) -> None:
+    ensure_home_layout(temp_home)
+    ConfigManager(temp_home).ensure_files()
+    quest_service = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home))
+    quest_local = quest_service.create("shared memory read local")
+    quest_remote = quest_service.create("shared memory read remote")
+    local_root = Path(quest_local["quest_root"])
+    remote_root = Path(quest_remote["quest_root"])
+    memory = MemoryService(temp_home)
+
+    remote_card = memory.write_card(
+        scope="quest",
+        kind="knowledge",
+        title="Cross quest checkpoint",
+        body="checkpoint body for cross-quest read",
+        quest_root=remote_root,
+        quest_id=quest_remote["quest_id"],
+    )
+    relative = Path(remote_card["path"]).relative_to(remote_root / "memory").as_posix()
+    document_id = f"sharedmemory::{quest_remote['quest_id']}::{relative}"
+
+    opened = memory.read_card(path=document_id, scope="quest", quest_root=local_root)
+    assert opened["path"] == str(Path(remote_card["path"]))
+    assert opened["body"].strip() == "checkpoint body for cross-quest read"
+
+    with pytest.raises(FileNotFoundError):
+        memory.read_card(
+            path=f"sharedmemory::{quest_remote['quest_id']}::knowledge/missing-card.md",
+            scope="quest",
+            quest_root=local_root,
+        )
+
+
 def test_memory_document_open_uses_quest_root_when_active_workspace_is_worktree(temp_home: Path) -> None:
     ensure_home_layout(temp_home)
     ConfigManager(temp_home).ensure_files()


### PR DESCRIPTION
# [Bugfix] Mirror refresh_summary to quest_root and resolve sharedmemory:: read paths

## What changed

Two independent service-layer bugfixes, one PR. Both surfaced in quest 016 post-mortem and both make a documented public surface actually work end-to-end.

| # | Commit | File(s) touched | Effect |
|---|---|---|---|
| 1 | `fix(artifact): refresh_summary mirrors SUMMARY.md to quest_root` | `src/deepscientist/artifact/service.py`, `tests/test_memory_and_artifact.py` | `artifact.refresh_summary` now writes the refreshed `SUMMARY.md` to **both** the active workspace (preserves the existing branch-versioned write) **and** to `quest_root/SUMMARY.md` as a plain mirror. Return payload gains `quest_root_summary_path` so callers can verify. |
| 2 | `fix(memory): read_card resolves sharedmemory:: document IDs` | `src/deepscientist/memory/service.py`, `tests/test_memory_and_artifact.py` | `MemoryService._resolve_existing_card` now parses `sharedmemory::<quest_id>::<relative>` document IDs and resolves them to `home/quests/<id>/memory/<relative>`. Closes the round-trip between `list_visible_quest_cards` (which already produces these IDs) and `read_card`. |

## Why

Both bugs were observed in quest 016 (cross-quest knowledge-transfer pilot, [#75](https://github.com/ResearAI/DeepScientist/pull/75)) where the agent attempted to use the documented APIs and they silently failed.

### Bug 1: `refresh_summary` writes to worktree, not quest_root

`refresh_summary` is positioned as the way to keep `SUMMARY.md` (the canonical compact quest state at the quest root) up to date. The implementation in main computes `workspace_root = self._workspace_root_for(quest_root)` — which resolves to the active worktree once any `idea` has been submitted — and writes only there.

Effect on quest 016: every stage after `idea` parks the agent in a worktree, so `quest_root/SUMMARY.md` stayed at the creation default (`"No completed milestones yet."`) for the entire run, even after `refresh_summary` was called successfully. From the quest root there was no way to tell the quest had progressed.

The worktree write is still useful (it gets versioned in the branch), so the fix keeps it and additionally mirrors to `quest_root/SUMMARY.md` as a plain `write_text` (no commit, no git side-effects). When the workspace already equals quest_root, the second write is a no-op (verified by test).

### Bug 2: `memory.read sharedmemory::...` returns "card not found"

When `read_visibility_mode = shared_across_quests`, `MemoryService.list_visible_quest_cards` returns cross-quest cards with `document_id = sharedmemory::<quest_id>::<relative>`. The natural use is to feed that ID back into `memory.read(path=document_id)`. But `_resolve_existing_card` only does `Path(path).exists()` on the literal string — `Path("sharedmemory::015::knowledge/foo.md")` does not exist on disk — and falls through to the `card_id` glob branch which can't find it either, so the read raises `FileNotFoundError("Memory card not found")`.

The parser already exists (`MemoryService.parse_shared_document_id`, used elsewhere). It was simply never called from `_resolve_existing_card`.

Effect on quest 016: agent issued exactly the path documented in `docs/en/07_MEMORY_AND_MCP.md`:
```
memory.read(path="sharedmemory::015::knowledge/checkpoint-015-...md")
memory.read(path="sharedmemory::014::knowledge/recap-re-...md")
```
Both failed. The agent worked around it by calling `bash_exec cat /home/ds/DeepScientist/quests/.../memory/knowledge/...md` directly — the file was always reachable, just not via the documented MCP API.

## Tests

Three new tests:

- `test_refresh_summary_mirrors_to_quest_root_when_active_workspace_is_worktree` — sets up a worktree via `update_research_state(current_workspace_root=...)`, calls `refresh_summary`, asserts both `worktree/SUMMARY.md` and `quest_root/SUMMARY.md` exist with identical content.
- `test_refresh_summary_writes_once_when_workspace_equals_quest_root` — fresh quest with no worktree, asserts the no-op-mirror branch behaves correctly and the return value still exposes `quest_root_summary_path`.
- `test_memory_read_resolves_sharedmemory_document_id_from_other_quest` — creates a knowledge card in quest A, reads it from quest B's context via `sharedmemory::A::knowledge/<title>.md`, asserts body matches; also asserts a missing shared path raises `FileNotFoundError`.

Local pytest sweep:
```bash
pytest tests/test_memory_and_artifact.py tests/test_mcp_servers.py
```

Outcome on this branch: 125 pass, 4 fail. The 4 failures are pre-existing on `origin/main` at the same commit (verified by re-running the same set with the patched files reverted) and unrelated to either fix:
- `test_artifact_stage_milestones_emit_semantic_connector_messages`
- `test_supplementary_experiment_protocol_supports_runtime_ref_queries_and_unified_fields`
- `test_artifact_mcp_server_tools_cover_core_flows`
- `test_artifact_mcp_server_analysis_campaign_infers_parent_main_run_from_runtime_refs`

## Documentation

No doc changes needed — both fixes restore the behavior the existing docs already describe. `docs/en/07_MEMORY_AND_MCP.md` already documents the `sharedmemory::` round-trip; `refresh_summary`'s contract already says it refreshes the quest's compact state.

## Compatibility / migration

- Both changes are additive at the behavior level. Existing callers see one extra file write (Bug 1) or one previously-broken path now resolving (Bug 2).
- `refresh_summary` return payload gains a new key `quest_root_summary_path`. The existing `summary_path` key is unchanged. The `paths` map on the recorded report artifact gains `quest_root_summary_md` alongside the existing `summary_md`.
- `memory.read` accepts a strict superset of paths (the previously-failing `sharedmemory::...` form now succeeds). No path that previously worked changes meaning.
- No new MCP namespace, no new artifact kind, no new closure gate, no schema migration, no config flip.

## Related

- Surfaced during quest 016 audit while validating [#77](https://github.com/ResearAI/DeepScientist/pull/77) (cross-quest knowledge transfer via the file system). Bug 1 was flagged as "known unrelated issue" in that PR; Bug 2 was not surfaced at the time but exhibits the same shape (a documented surface that doesn't actually round-trip).
- Independent of [#76](https://github.com/ResearAI/DeepScientist/pull/76) (`fix_weixin_long_poll_cap`), which addresses a connector-side stall on the same quest run.

## AI assistance disclosure

Prepared with AI assistance. Both fixes were authored, reviewed line by line against the surfaces they touch, and validated end-to-end via targeted tests plus the full `tests/test_memory_and_artifact.py` + `tests/test_mcp_servers.py` sweep before submission. No commit is unreviewed AI output.
