### PR TITLE
[Bugfix] Make install.sh deterministic: npm ci + invalidate runtime Python env

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -225,6 +225,23 @@ safe_remove_dir() {
   rm -rf "$target"
 }
 
+invalidate_runtime_python_env() {
+  local runtime_dir="$BASE_DIR/runtime/python-env"
+  if [ ! -d "$runtime_dir/lib" ]; then
+    return
+  fi
+  local removed=0
+  while IFS= read -r -d '' target; do
+    rm -rf "$target"
+    removed=1
+  done < <(find "$runtime_dir/lib" -maxdepth 3 -type d \
+    \( -name 'deepscientist' -o -name 'deepscientist-*.dist-info' \) \
+    -print0 2>/dev/null)
+  if [ "$removed" -eq 1 ]; then
+    print_step "Invalidated runtime Python env; next 'ds' start will reinstall deepscientist"
+  fi
+}
+
 source_copy_excludes() {
   cat <<'EOF'
 ./.git
@@ -582,6 +599,8 @@ stop_existing_install
 safe_remove_dir "$INSTALL_DIR"
 mv "$STAGING_DIR" "$INSTALL_DIR"
 trap - EXIT
+
+invalidate_runtime_python_env
 
 print_step "Writing launcher wrappers"
 mkdir -p "$BIN_DIR"

--- a/install.sh
+++ b/install.sh
@@ -347,14 +347,14 @@ build_ui() {
     return
   fi
   print_step "Building web UI in install tree"
-  npm --prefix "$1/src/ui" install --include=dev --no-audit --no-fund
+  npm --prefix "$1/src/ui" ci --include=dev --no-audit --no-fund
   npm --prefix "$1/src/ui" run build
   rm -rf "$1/src/ui/node_modules" "$1/src/ui/lib/node_modules"
 }
 
 install_root_runtime() {
   print_step "Installing root runtime dependencies in install tree"
-  npm --prefix "$1" install --omit=dev --no-audit --no-fund
+  npm --prefix "$1" ci --omit=dev --no-audit --no-fund
 }
 
 build_tui() {
@@ -371,7 +371,7 @@ build_tui() {
     return
   fi
   print_step "Building TUI in install tree"
-  npm --prefix "$1/src/tui" install --include=dev --no-audit --no-fund
+  npm --prefix "$1/src/tui" ci --include=dev --no-audit --no-fund
   npm --prefix "$1/src/tui" run build
   npm --prefix "$1/src/tui" prune --omit=dev --no-audit --no-fund
 }


### PR DESCRIPTION
# [Bugfix] Make install.sh deterministic: npm ci + invalidate runtime Python env

## What changed

Two small `install.sh` changes that close two independent silent-failure paths during install. Both surfaced when re-installing on the same machine to pick up a local source change.

| # | Commit | Effect |
|---|---|---|
| 1 | `fix(install): use npm ci instead of npm install for deterministic builds` | Switches all three `npm install` sites (web UI, TUI, Node launcher runtime) to `npm ci`. Stops "install succeeded but actually missed packages" failures from being deferred to opaque `vite build` / `tsc` errors after the staging directory has already been cleaned. |
| 2 | `fix(install): invalidate runtime Python env on every install` | After the staging tree is moved into `INSTALL_DIR`, removes `deepscientist/` and `deepscientist-*.dist-info/` under `<base>/runtime/python-env/lib/python*/site-packages/`. Stops uv sync from reusing a stale install when the package source changed under the same version. |

## Why

### Bug 1: `npm install` silently drops packages

`npm install` is non-deterministic in the presence of a `package-lock.json`. On transient registry hiccups, partial cache hits, disk pressure, or even concurrent npm processes it can install a *subset* of declared dependencies and still exit 0. The next step (`vite build`, `tsc`) then fails with an opaque "failed to resolve import" error and — since `install.sh` cleans the staging directory on failure — the user sees this and has nothing to inspect:

```
[vite]: Rollup failed to resolve import "clsx" from
  "/home/ds/DeepScientist/cli.staging.415837/src/ui/src/lib/utils.ts".
This is most likely unintended because it can break your application at runtime.
```

`clsx` is in `src/ui/package.json` `dependencies` and `src/ui/package-lock.json`, and a fresh `npm install` in the source tree on the same machine succeeds. The staging install just lost it.

`npm ci`:

- **Requires** `package-lock.json` and refuses to install a package set that doesn't match it exactly. There is no path that ends in "succeeded but actually missed packages."
- **Exits non-zero on the first deviation**, surfacing real failures before they cascade into the next build step (where the diagnostic is much worse).
- Is also **2-3x faster** than `npm install` because it skips dependency resolution.

The cost is one new constraint on contributors: `package-lock.json` must be kept in sync with `package.json`. That is already the project's de-facto convention (lockfiles are committed at all three sites), so this PR doesn't introduce a new requirement — it enforces an existing one.

### Bug 2: runtime Python env doesn't pick up source changes

`bash install.sh` updates `cli/src/deepscientist/`, but the actual Python runtime lives at `<base>/runtime/python-env/lib/python*/site-packages/deepscientist/` and is bootstrapped lazily on the first `ds` start via `uv sync`. uv keys reuse on the package version recorded in `pyproject.toml`. If a local install ships changed source under the *same* version (any local patch, dev branch, or hotfix between releases), uv sync sees no version drift, skips the rebuild, and the runtime stays stuck on the previously-installed copy.

Concretely on a real install: `cli/src/deepscientist/artifact/service.py` had the new `quest_root_summary_path` field after `bash install.sh`, but `runtime/python-env/.../deepscientist/artifact/service.py` was the install from days earlier. `ds doctor` was happy, the daemon started fine, and the new behavior simply wasn't there. The only remediation was to manually `rm -rf` the `site-packages/deepscientist*` paths before running `ds`.

Fix: at the end of `install.sh`, after the staging install is moved into place, find and remove `deepscientist/` and `deepscientist-*.dist-info/` under `<base>/runtime/python-env/lib/python*/site-packages/`. The next `ds` start triggers uv sync, which now sees the package as missing and reinstalls fresh from `cli/src`.

Safe by construction:

- Only touches paths under `$BASE_DIR/runtime/python-env/lib`, no-op if that directory doesn't exist (first install).
- `find -maxdepth 3` anchored to `lib/`, name match restricted to exactly `deepscientist` and `deepscientist-*.dist-info` — won't catch other packages that have `deepscientist` as a prefix.
- Logs a `print_step` line when something was removed, so the operator sees the invalidation.

## Verification

**`npm ci`** — lockfile sync verified locally for all three sites by running `npm ci` from a clean tmpdir copy of each `package.json` + `package-lock.json` pair:

```
src/ui   → added 713 packages in 10s   (exit 0)
src/tui  → added 99 packages in 2s     (exit 0)
root     → added 105 packages in 37s   (exit 0)
```

**`invalidate_runtime_python_env`** — finder logic dry-run against a real installed runtime correctly resolves to exactly the two paths it should remove:

```
$ find <base>/runtime/python-env/lib -maxdepth 3 -type d \
    \( -name 'deepscientist' -o -name 'deepscientist-*.dist-info' \)
.../python3.12/site-packages/deepscientist-1.5.17.dist-info
.../python3.12/site-packages/deepscientist
```

`bash -n install.sh` clean.

## Documentation

No docs change. The `npm install` / `npm run build` mention in `CLAUDE.md` and `CONTRIBUTING.md` is for source-tree development, not the staging install path this PR touches; both remain `npm install` (the source tree is the authoritative writer of `package-lock.json`).

## Compatibility / migration

- No package.json or lockfile changes.
- `npm ci` and `npm install` accept the same `--include=dev`, `--omit=dev`, `--no-audit`, `--no-fund` flags used here.
- For users on environments without `package-lock.json` (none in this repo), `npm ci` would fail — but every install site already has a lockfile committed.
- `invalidate_runtime_python_env` is a no-op on first install (runtime dir doesn't exist yet) and idempotent on subsequent installs.
- No behavior change for fresh installs; the only observable differences are (a) louder npm failures on lockfile drift, and (b) the new `[install] Invalidated runtime Python env...` line on re-install.

## Related

- Surfaced when re-running `bash install.sh` to pick up local fix branches (refresh_summary mirror, weixin long-poll cap). Bug 1 (`npm install` drops `clsx`) caused the install itself to fail; Bug 2 (stale runtime) caused the install to silently succeed but the daemon to keep running the old code. Both wasted real diagnosis time.
- Independent of any other PR.

## AI assistance disclosure

Prepared with AI assistance. Verified end-to-end via clean-tmpdir `npm ci` runs at all three sites and dry-run `find` against a real installed runtime before submission. No commit is unreviewed AI output.
