### PR TITLE
[Core] Add homepage, discovery, and extended display fields to BenchStore catalog schema

### DIFF
--- a/docs/en/22_BENCHSTORE_YAML_REFERENCE.md
+++ b/docs/en/22_BENCHSTORE_YAML_REFERENCE.md
@@ -287,6 +287,9 @@ Useful fields:
 - `recommended_when`
 - `not_recommended_when`
 - `image_path`
+- `homepage`
+- `official_links`
+- `discovery`
 - `display`
 - `commercial`
 
@@ -297,6 +300,7 @@ BenchStore currently reads these top-level keys:
 - `schema_version`
 - `id`
 - `name`
+- `homepage`
 - `version`
 - `one_line`
 - `task_description`
@@ -326,6 +330,8 @@ BenchStore currently reads these top-level keys:
 - `resources`
 - `environment`
 - `commercial`
+- `official_links`
+- `discovery`
 - `display`
 - `image_path`
 
@@ -373,12 +379,25 @@ Nested objects currently recognized:
 - `display.palette_seed`
 - `display.art_style`
 - `display.accent_priority`
+- `display.placement`
+- `display.card_size`
+- `display.badge`
+- `official_links.homepage`
+- `official_links.github`
+- `official_links.docs`
+- `discovery.collection`
+- `discovery.collection_priority`
+- `discovery.recommendation_weight`
+- `discovery.featured`
+- `discovery.featured_reason`
 - `launch_profiles[].id`
 - `launch_profiles[].label`
 - `launch_profiles[].description`
 
-If you add extra keys beyond this set, do not assume the current UI, installer, or
-recommendation logic will use them.
+If you add extra keys beyond this set, they are preserved in `raw_payload` for downstream
+consumers but do not affect the current UI, installer, or recommendation logic directly.
+To propose a new first-class field, open an RFC issue and update this reference doc alongside
+the `service.py` and `prompt_builder.py` changes.
 
 ## 5. Fields you should not write manually
 

--- a/docs/zh/22_BENCHSTORE_YAML_REFERENCE.md
+++ b/docs/zh/22_BENCHSTORE_YAML_REFERENCE.md
@@ -295,6 +295,7 @@ BenchStore 目前会读取这些顶层字段：
 - `schema_version`
 - `id`
 - `name`
+- `homepage`
 - `version`
 - `one_line`
 - `task_description`
@@ -324,6 +325,8 @@ BenchStore 目前会读取这些顶层字段：
 - `resources`
 - `environment`
 - `commercial`
+- `official_links`
+- `discovery`
 - `display`
 - `image_path`
 
@@ -371,11 +374,22 @@ BenchStore 目前会读取这些顶层字段：
 - `display.palette_seed`
 - `display.art_style`
 - `display.accent_priority`
+- `display.placement`
+- `display.card_size`
+- `display.badge`
+- `official_links.homepage`
+- `official_links.github`
+- `official_links.docs`
+- `discovery.collection`
+- `discovery.collection_priority`
+- `discovery.recommendation_weight`
+- `discovery.featured`
+- `discovery.featured_reason`
 - `launch_profiles[].id`
 - `launch_profiles[].label`
 - `launch_profiles[].description`
 
-如果你额外加了别的 key，不要默认当前 UI、安装器或推荐逻辑会用到它。
+如果你额外加了别的 key，它们会被保留在 `raw_payload` 中供下游使用，但不会直接影响当前 UI、安装器或推荐逻辑。如需提议新的 first-class 字段，请先开 RFC issue，并同步更新本文档及 `service.py`、`prompt_builder.py`。
 
 ## 5. 不需要手动填写的字段
 

--- a/src/deepscientist/benchstore/prompt_builder.py
+++ b/src/deepscientist/benchstore/prompt_builder.py
@@ -71,6 +71,7 @@ class BenchStorePromptBuilder:
             f"- benchmark_id: {benchmark_id}",
             f"- benchmark_name: {name}",
             f"- one_line: {one_line or 'none'}",
+            f"- homepage: {str(entry.get('homepage') or 'none').strip() or 'none'}",
             f"- aisb_direction: {str(entry.get('aisb_direction') or 'unknown').strip() or 'unknown'}",
             f"- task_mode: {str(entry.get('task_mode') or 'unknown').strip() or 'unknown'}",
             f"- requires_execution: {bool(entry.get('requires_execution'))}",
@@ -173,6 +174,21 @@ class BenchStorePromptBuilder:
         lines.extend(["", "## Tags and Routing Hints"])
         lines.extend(_format_optional_lines("capability_tags", capability_tags))
         lines.extend(_format_optional_lines("track_fit", track_fit))
+        # Official links
+        official_links = entry.get("official_links") if isinstance(entry.get("official_links"), dict) else {}
+        if official_links:
+            lines.extend(["", "## Official Links"])
+            for k in ("homepage", "github", "docs"):
+                v = str(official_links.get(k) or "").strip()
+                if v:
+                    lines.append(f"- {k}: {v}")
+        # Discovery metadata
+        discovery = entry.get("discovery") if isinstance(entry.get("discovery"), dict) else {}
+        if discovery:
+            lines.extend(["", "## Discovery"])
+            lines.append(f"- collection: {str(discovery.get('collection') or 'none').strip() or 'none'}")
+            lines.append(f"- recommendation_weight: {discovery.get('recommendation_weight', 0)}")
+            lines.append(f"- featured: {discovery.get('featured', False)}")
         lines.extend(["", "## Fit Advice"])
         lines.extend([f"- recommended_when: {recommended_when or 'none'}", f"- not_recommended_when: {not_recommended_when or 'none'}"])
         if raw_payload:

--- a/src/deepscientist/benchstore/prompt_builder.py
+++ b/src/deepscientist/benchstore/prompt_builder.py
@@ -186,9 +186,18 @@ class BenchStorePromptBuilder:
         discovery = entry.get("discovery") if isinstance(entry.get("discovery"), dict) else {}
         if discovery:
             lines.extend(["", "## Discovery"])
-            lines.append(f"- collection: {str(discovery.get('collection') or 'none').strip() or 'none'}")
-            lines.append(f"- recommendation_weight: {discovery.get('recommendation_weight', 0)}")
-            lines.append(f"- featured: {discovery.get('featured', False)}")
+            collection = str(discovery.get("collection") or "").strip()
+            if collection:
+                lines.append(f"- collection: {collection}")
+            if discovery.get("collection_priority") is not None:
+                lines.append(f"- collection_priority: {discovery.get('collection_priority')}")
+            if discovery.get("recommendation_weight") is not None:
+                lines.append(f"- recommendation_weight: {discovery.get('recommendation_weight')}")
+            if discovery.get("featured") is not None:
+                lines.append(f"- featured: {bool(discovery.get('featured'))}")
+            featured_reason = str(discovery.get("featured_reason") or "").strip()
+            if featured_reason:
+                lines.append(f"- featured_reason: {featured_reason}")
         lines.extend(["", "## Fit Advice"])
         lines.extend([f"- recommended_when: {recommended_when or 'none'}", f"- not_recommended_when: {not_recommended_when or 'none'}"])
         if raw_payload:

--- a/src/deepscientist/benchstore/service.py
+++ b/src/deepscientist/benchstore/service.py
@@ -474,6 +474,8 @@ class BenchStoreService:
         environment_raw = payload.get("environment") if isinstance(payload.get("environment"), dict) else payload.get("environment")
         commercial_raw = payload.get("commercial") if isinstance(payload.get("commercial"), dict) else {}
         display_raw = payload.get("display") if isinstance(payload.get("display"), dict) else {}
+        official_links_raw = payload.get("official_links") if isinstance(payload.get("official_links"), dict) else {}
+        discovery_raw = payload.get("discovery") if isinstance(payload.get("discovery"), dict) else {}
         image_path = _optional_str(payload.get("image_path"))
 
         entry = {
@@ -483,6 +485,12 @@ class BenchStoreService:
             "version": _optional_str(payload.get("version")),
             "one_line": _optional_str(payload.get("one_line")),
             "task_description": _optional_str(payload.get("task_description")),
+            "homepage": _optional_str(payload.get("homepage")),
+            "official_links": {
+                "homepage": _optional_str(official_links_raw.get("homepage")),
+                "github": _optional_str(official_links_raw.get("github")),
+                "docs": _optional_str(official_links_raw.get("docs")),
+            },
             "capability_tags": _normalize_string_list(payload.get("capability_tags"), field_name="capability_tags"),
             "aisb_direction": _optional_str(payload.get("aisb_direction")),
             "track_fit": _normalize_string_list(payload.get("track_fit"), field_name="track_fit"),
@@ -493,6 +501,13 @@ class BenchStoreService:
             "snapshot_status": _optional_str(payload.get("snapshot_status")),
             "support_level": _optional_str(payload.get("support_level")),
             "primary_outputs": _normalize_string_list(payload.get("primary_outputs"), field_name="primary_outputs"),
+            "discovery": {
+                "collection": _optional_str(discovery_raw.get("collection")),
+                "collection_priority": int(_optional_number(discovery_raw.get("collection_priority"))) if _optional_number(discovery_raw.get("collection_priority")) is not None else None,
+                "recommendation_weight": int(_optional_number(discovery_raw.get("recommendation_weight"))) if _optional_number(discovery_raw.get("recommendation_weight")) is not None else None,
+                "featured": bool(discovery_raw.get("featured")) if discovery_raw.get("featured") is not None else False,
+                "featured_reason": _optional_str(discovery_raw.get("featured_reason")),
+            },
             "launch_profiles": _normalize_launch_profiles(payload.get("launch_profiles")),
             "cost_band": _optional_str(payload.get("cost_band")),
             "time_band": _optional_str(payload.get("time_band")),
@@ -533,6 +548,9 @@ class BenchStoreService:
                 "palette_seed": _optional_str(display_raw.get("palette_seed")),
                 "art_style": _optional_str(display_raw.get("art_style")),
                 "accent_priority": _optional_str(display_raw.get("accent_priority")),
+                "placement": _optional_str(display_raw.get("placement")),
+                "card_size": _optional_str(display_raw.get("card_size")),
+                "badge": _optional_str(display_raw.get("badge")),
             },
             "image_path": image_path,
             "image_url": f"/api/benchstore/entries/{entry_id}/image" if image_path else None,

--- a/src/deepscientist/benchstore/service.py
+++ b/src/deepscientist/benchstore/service.py
@@ -476,6 +476,31 @@ class BenchStoreService:
         display_raw = payload.get("display") if isinstance(payload.get("display"), dict) else {}
         official_links_raw = payload.get("official_links") if isinstance(payload.get("official_links"), dict) else {}
         discovery_raw = payload.get("discovery") if isinstance(payload.get("discovery"), dict) else {}
+        official_links = {
+            "homepage": _optional_str(official_links_raw.get("homepage")),
+            "github": _optional_str(official_links_raw.get("github")),
+            "docs": _optional_str(official_links_raw.get("docs")),
+        }
+        if not any(official_links.values()):
+            official_links = {}
+        collection_priority = _optional_number(discovery_raw.get("collection_priority"))
+        recommendation_weight = _optional_number(discovery_raw.get("recommendation_weight"))
+        featured = _optional_bool(discovery_raw.get("featured"))
+        discovery = {
+            "collection": _optional_str(discovery_raw.get("collection")),
+            "collection_priority": int(collection_priority) if collection_priority is not None else None,
+            "recommendation_weight": int(recommendation_weight) if recommendation_weight is not None else None,
+            "featured": featured,
+            "featured_reason": _optional_str(discovery_raw.get("featured_reason")),
+        }
+        if not (
+            discovery["collection"]
+            or discovery["collection_priority"] is not None
+            or discovery["recommendation_weight"] is not None
+            or discovery["featured"] is True
+            or discovery["featured_reason"]
+        ):
+            discovery = {}
         image_path = _optional_str(payload.get("image_path"))
 
         entry = {
@@ -486,11 +511,7 @@ class BenchStoreService:
             "one_line": _optional_str(payload.get("one_line")),
             "task_description": _optional_str(payload.get("task_description")),
             "homepage": _optional_str(payload.get("homepage")),
-            "official_links": {
-                "homepage": _optional_str(official_links_raw.get("homepage")),
-                "github": _optional_str(official_links_raw.get("github")),
-                "docs": _optional_str(official_links_raw.get("docs")),
-            },
+            "official_links": official_links,
             "capability_tags": _normalize_string_list(payload.get("capability_tags"), field_name="capability_tags"),
             "aisb_direction": _optional_str(payload.get("aisb_direction")),
             "track_fit": _normalize_string_list(payload.get("track_fit"), field_name="track_fit"),
@@ -501,13 +522,7 @@ class BenchStoreService:
             "snapshot_status": _optional_str(payload.get("snapshot_status")),
             "support_level": _optional_str(payload.get("support_level")),
             "primary_outputs": _normalize_string_list(payload.get("primary_outputs"), field_name="primary_outputs"),
-            "discovery": {
-                "collection": _optional_str(discovery_raw.get("collection")),
-                "collection_priority": int(_optional_number(discovery_raw.get("collection_priority"))) if _optional_number(discovery_raw.get("collection_priority")) is not None else None,
-                "recommendation_weight": int(_optional_number(discovery_raw.get("recommendation_weight"))) if _optional_number(discovery_raw.get("recommendation_weight")) is not None else None,
-                "featured": bool(discovery_raw.get("featured")) if discovery_raw.get("featured") is not None else False,
-                "featured_reason": _optional_str(discovery_raw.get("featured_reason")),
-            },
+            "discovery": discovery,
             "launch_profiles": _normalize_launch_profiles(payload.get("launch_profiles")),
             "cost_band": _optional_str(payload.get("cost_band")),
             "time_band": _optional_str(payload.get("time_band")),
@@ -1188,6 +1203,9 @@ class BenchStoreService:
                     "entry_name": entry.get("name"),
                     "one_line": entry.get("one_line"),
                     "task_description": entry.get("task_description"),
+                    "homepage": entry.get("homepage"),
+                    "official_links": entry.get("official_links") or {},
+                    "discovery": entry.get("discovery") or {},
                     "paper": paper,
                     "capability_tags": entry.get("capability_tags") or [],
                     "track_fit": entry.get("track_fit") or [],

--- a/src/ui/src/lib/types/benchstore.ts
+++ b/src/ui/src/lib/types/benchstore.ts
@@ -76,10 +76,27 @@ export type BenchCommercial = {
   annual_fee?: string | number | null;
 };
 
+export type BenchOfficialLinks = {
+  homepage?: string | null;
+  github?: string | null;
+  docs?: string | null;
+};
+
+export type BenchDiscovery = {
+  collection?: string | null;
+  collection_priority?: number | null;
+  recommendation_weight?: number | null;
+  featured?: boolean | null;
+  featured_reason?: string | null;
+};
+
 export type BenchDisplay = {
   palette_seed?: string | null;
   art_style?: string | null;
   accent_priority?: string | null;
+  placement?: "hero" | "grid" | string | null;
+  card_size?: "xl" | "l" | "m" | "s" | string | null;
+  badge?: string | null;
 };
 
 export type BenchEnvironment = {
@@ -121,6 +138,8 @@ export type BenchEntry = {
   version?: string | null;
   one_line?: string | null;
   task_description?: string | null;
+  homepage?: string | null;
+  official_links?: BenchOfficialLinks | null;
   capability_tags?: string[];
   aisb_direction?: string | null;
   track_fit?: string[];
@@ -131,6 +150,7 @@ export type BenchEntry = {
   snapshot_status?: string | null;
   support_level?: string | null;
   primary_outputs?: string[];
+  discovery?: BenchDiscovery | null;
   launch_profiles?: BenchLaunchProfile[];
   cost_band?: string | null;
   time_band?: string | null;

--- a/tests/test_benchstore.py
+++ b/tests/test_benchstore.py
@@ -301,6 +301,91 @@ def test_benchstore_entry_detail_includes_setup_prompt_preview(tmp_path: Path) -
     assert "Runtime Environment" in payload["entry"]["setup_prompt_preview"]
 
 
+def test_benchstore_extended_catalog_fields_surface_cleanly(tmp_path: Path) -> None:
+    repo_root = _make_repo_root(tmp_path)
+    catalog_root = repo_root / "AISB" / "catalog"
+    write_yaml(
+        catalog_root / "extended.yaml",
+        {
+            "name": "Extended Benchmark",
+            "id": "aisb.extended",
+            "one_line": "Extended metadata smoke.",
+            "homepage": "https://example.org/bench",
+            "official_links": {
+                "homepage": "https://example.org/bench",
+                "github": "https://github.com/example/bench",
+                "docs": "https://example.org/docs",
+            },
+            "discovery": {
+                "collection": "AISB Featured",
+                "collection_priority": 3,
+                "recommendation_weight": 7,
+                "featured": True,
+                "featured_reason": "Important benchmark",
+            },
+            "display": {
+                "placement": "hero",
+                "card_size": "xl",
+                "badge": "Featured",
+            },
+        },
+    )
+    write_yaml(
+        catalog_root / "legacy.yaml",
+        {
+            "name": "Legacy Benchmark",
+            "id": "aisb.legacy",
+            "one_line": "Legacy metadata smoke.",
+        },
+    )
+
+    service = BenchStoreService(tmp_path / "home", repo_root=repo_root)
+    payload = service.get_entry("aisb.extended", hardware_payload=_hardware_payload())
+    entry = payload["entry"]
+
+    assert entry["homepage"] == "https://example.org/bench"
+    assert entry["official_links"] == {
+        "homepage": "https://example.org/bench",
+        "github": "https://github.com/example/bench",
+        "docs": "https://example.org/docs",
+    }
+    assert entry["discovery"] == {
+        "collection": "AISB Featured",
+        "collection_priority": 3,
+        "recommendation_weight": 7,
+        "featured": True,
+        "featured_reason": "Important benchmark",
+    }
+    assert entry["display"]["placement"] == "hero"
+    assert entry["display"]["card_size"] == "xl"
+    assert entry["display"]["badge"] == "Featured"
+    assert entry["raw_payload"]["official_links"]["github"] == "https://github.com/example/bench"
+
+    setup_prompt = entry["setup_prompt_preview"]
+    assert "- homepage: https://example.org/bench" in setup_prompt
+    assert "## Official Links" in setup_prompt
+    assert "- github: https://github.com/example/bench" in setup_prompt
+    assert "## Discovery" in setup_prompt
+    assert "- collection: AISB Featured" in setup_prompt
+    assert "- collection_priority: 3" in setup_prompt
+    assert "- recommendation_weight: 7" in setup_prompt
+    assert "- featured_reason: Important benchmark" in setup_prompt
+
+    packet = service.build_setup_packet(entry_id="aisb.extended", hardware_payload=_hardware_payload())
+    context = packet["launch_payload"]["startup_contract"]["benchstore_context"]
+    assert context["homepage"] == "https://example.org/bench"
+    assert context["official_links"]["docs"] == "https://example.org/docs"
+    assert context["discovery"]["featured"] is True
+    assert context["display"]["placement"] == "hero"
+
+    legacy_entry = service.get_entry("aisb.legacy")["entry"]
+    legacy_prompt = legacy_entry["setup_prompt_preview"]
+    assert legacy_entry["official_links"] == {}
+    assert legacy_entry["discovery"] == {}
+    assert "## Official Links" not in legacy_prompt
+    assert "## Discovery" not in legacy_prompt
+
+
 def test_benchstore_api_handlers_surface_catalog_and_detail(tmp_path: Path) -> None:
     repo_root = _make_repo_root(tmp_path)
     write_yaml(


### PR DESCRIPTION
## Summary

Adds three new optional field groups to the BenchStore catalog schema, enabling richer benchmark discovery and display in the BenchStore UI.

### New fields

- **`homepage`** (top-level string): canonical benchmark website URL
- **`official_links`** (object): structured links (`homepage`, `github`, `docs`)
- **`discovery`** (object): collection grouping (`collection`, `collection_priority`), recommendation boost (`recommendation_weight`), hero-card flag (`featured`, `featured_reason`)
- **`display`** extensions: UI layout hints (`placement`: hero/grid, `card_size`: xl/l/m/s, `badge`: label string)

### Changes

- `src/deepscientist/benchstore/service.py`: parse new fields from catalog YAML (backward-compatible; unknown fields remain in `raw_payload` as before)
- `src/deepscientist/benchstore/prompt_builder.py`: inject new fields into setup packets for downstream agent consumption
- `docs/en/22_BENCHSTORE_YAML_REFERENCE.md` + `docs/zh/`: document all new fields with canonical values

### Why

AISB (AI Scientist Benchmark, https://github.com/ResearAI/NLPCC-2026-Task9-AISB) publishes 6 benchmark directions as BenchStore catalog entries (see PR #81). These entries need `homepage`, `discovery`, and `display` fields to properly present benchmark collections with hero-card visibility, recommendation weighting, and direct website links in the BenchStore UI.

### Backward compatibility

All new fields are optional. Unrecognized fields remain preserved in `raw_payload` as before. Existing catalog entries continue to load without errors.

### Test plan

- [x] Python syntax check: `service.py` and `prompt_builder.py` compile clean
- [x] All 6 AISB catalog entries load without errors with the new field support
- [x] No existing catalog entries (103 T3 entries) are affected

### Release note

No release asset needed for this PR. This is a code-only schema change.