### PR TITLE
Add AISB B1-B12 benchmark catalog entries for BenchStore

### DIFF
--- a/AISB/catalog/aisb.b1.agentic_coding.yaml
+++ b/AISB/catalog/aisb.b1.agentic_coding.yaml
@@ -1,0 +1,245 @@
+schema_version: 1
+id: aisb.b1.agentic_coding
+name: AISB B1 Agentic Coding
+version: 0.1.0
+catalog_version: 0.1.0
+one_line: FeatureBench-lite public-dev package for repository navigation, code edits, and test-driven
+  repair.
+task_description: AISB B1 Agentic Coding is an AISB BenchStore catalog pilot entry. The package is intended
+  for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track submission
+  scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B1 智能体编程
+    one_line: 面向仓库导航、代码编辑和测试驱动修复的 FeatureBench-lite public-dev 包。
+    task_description: AISB B1 智能体编程 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开 evaluator
+      检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- agentic_coding
+- software_engineering
+- feature_implementation
+aisb_direction: B1
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: software_engineering_agent
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 700
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B1_Agentic_Coding
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: medium
+time_band: 1-8h
+difficulty: hard
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 4
+    ram_gb: 16
+    disk_gb: 20
+    gpu_count: 0
+  recommended:
+    cpu_cores: 16
+    ram_gb: 64
+    disk_gb: 200
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B1_Agentic_Coding
+  bench_yaml: benchmarks/aisb/B1_Agentic_Coding/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b1.agentic_coding-v0.1.0.zip
+  url: http://localhost:8080/aisb.b1.agentic_coding-v0.1.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B1_Agentic_Coding
+  archive_type: zip
+  local_dir_name: aisb.b1.agentic_coding
+  sha256: 5abe83b517511e83ce299fa009503f31a44bc3972acdd905630d0398f0664669
+  size_bytes: 47750
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: true
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b1_public_dev_smoke
+  label: B1 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B1 --dest .work/benchstore/B1
+  - python scripts/agent_tools.py evaluate B1 --bench-dir .work/benchstore/B1 --submission .work/benchstore/B1/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B1/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B1/submission --output .work/benchstore/B1/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B1/submission --track B1
+  one_click_prompt: Start AISB B1 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: task_completion
+  benchmark_source: FeatureBench public subset
+  packaged_data_status: real FeatureBench-lite public-dev rows plus scorer-private official harness replay
+    rows
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: FeatureBench-lite
+    source: LiberCoders/FeatureBench (HF)
+    tasks: 3
+    metric: task_completion
+    sota: 20% Lite (GPT-5.1-Codex, ICLR 2026)
+    public_score: 0.0
+  alternatives:
+  - name: SWE-bench Pro
+    source: ScaleAI/SWE-bench_Pro (HF)
+    tasks: 500+
+    metric: resolved_rate
+    sota: 59.10% (GPT-5.4 xHigh)
+    note: clean benchmark; B3 primary
+  - name: SWE-bench Verified
+    source: princeton-nlp/SWE-bench_Verified
+    note: DEPRECATED — contaminated; only legacy reference
+  - name: SWE-rebench
+    source: cais/re-bench
+    metric: task_success
+    note: research engineering benchmark; B1/B3 cross
+papers:
+  highlights:
+  - title: 'FeatureBench: Benchmarking Agentic Coding for Complex Feature Development'
+    arxiv: '2602.10975'
+    url: https://arxiv.org/abs/2602.10975
+    venue: ICLR 2026
+    why: Primary benchmark paper; SOTA 12.5% Full / 20% Lite
+  - title: 'SWE-Edit: Rethinking Code Editing for Efficient SWE-Agents'
+    arxiv: '2604.26102'
+    url: https://arxiv.org/abs/2604.26102
+    venue: April 2026
+    why: +2.1% resolved rate, -17.9% inference cost
+  - title: 'AgentForge: Execution-grounded Multi-Agent Framework'
+    arxiv: '2604.13120'
+    url: https://arxiv.org/abs/2604.13120
+    venue: April 2026
+    why: 5-agent architecture; SWE-Bench Lite 40.0%
+  - title: Many SWE-bench-Passing PRs Would Not Be Merged
+    url: https://metr.org/blog/2026-03-19-many-swe-bench-prs-not-merged/
+    source: METR blog, March 2026
+    why: 'Critical evaluation: patch correctness vs mergeability'
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B1_*/references/papers.json
+nlpcc_tracks:
+- track: T1
+  name: AI/CS Reasoning & Engineering
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T1
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b1.agentic_coding.svg

--- a/AISB/catalog/aisb.b10.climate_earth.yaml
+++ b/AISB/catalog/aisb.b10.climate_earth.yaml
@@ -1,0 +1,236 @@
+schema_version: 1
+id: aisb.b10.climate_earth
+name: AISB B10 Climate and Earth Science
+version: 0.1.0
+catalog_version: 0.1.0
+one_line: WeatherBench2-mini ERA5 package for latitude-weighted weather forecasting validation.
+task_description: AISB B10 Climate and Earth Science is an AISB BenchStore catalog pilot entry. The package
+  is intended for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track
+  submission scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B10 气候与地球科学
+    one_line: 用于纬度加权天气预报验证的 WeatherBench2-mini ERA5 包。
+    task_description: AISB B10 气候与地球科学 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开
+      evaluator 检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- climate
+- earth_science
+- weather
+- forecasting
+aisb_direction: B10
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: experiment_driven
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 700
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B10_ClimateEarth
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: medium
+time_band: 1-2h
+difficulty: hard
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 4
+    ram_gb: 8
+    disk_gb: 10
+    gpu_count: 0
+  recommended:
+    cpu_cores: 8
+    ram_gb: 16
+    disk_gb: 20
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B10_ClimateEarth
+  bench_yaml: benchmarks/aisb/B10_ClimateEarth/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b10.climate_earth-v0.1.0.zip
+  url: http://localhost:8080/aisb.b10.climate_earth-v0.1.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B10_ClimateEarth
+  archive_type: zip
+  local_dir_name: aisb.b10.climate_earth
+  sha256: 693a771c756519eb09e18256da519d0a1a7b3371b32cb60c81c60291428b0ece
+  size_bytes: 25280
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: true
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b10_public_dev_smoke
+  label: B10 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B10 --dest .work/benchstore/B10
+  - python scripts/agent_tools.py evaluate B10 --bench-dir .work/benchstore/B10 --submission .work/benchstore/B10/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B10/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B10/submission --output .work/benchstore/B10/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B10/submission --track B10
+  one_click_prompt: Start AISB B10 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: 1/(1+RMSE) latitude-weighted
+  benchmark_source: WeatherBench2-mini ERA5 64x32
+  packaged_data_status: real WeatherBench2 ERA5 64x32 grid plus label-stripped held-out inputs
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: WeatherBench2-mini ERA5 64x32
+    source: google-research/weatherbench2 (gs://)
+    dev_count: 64
+    hidden_count: 32
+    metric: latitude-weighted 1/(1+RMSE)
+    sota: GenCast (Nature 2024), Aurora (Microsoft 2024), NeuralGCM (Nature 2024), AIFS (ECMWF)
+    our_baseline: 0.0016
+  alternatives:
+  - name: ClimateBench v1.0 ssp245
+    source: Zenodo CC BY 4.0
+    note: legacy compatibility fixture; 48 rows; superseded by WB2
+  - name: ClimAgent/ClimaBench
+    source: arXiv:2604.16922
+    note: April 2026; AI-driven climate science discovery benchmark
+papers:
+  highlights:
+  - title: 'WeatherBench 2: A Framework for Next-Generation Data-Driven Weather Forecasting'
+    source: JAMES 2024 / google-research/weatherbench2
+    why: Primary benchmark; 62 variables, 13 pressure levels, ERA5 data
+  - title: 'GenCast: Diffusion-based Ensemble Forecasting'
+    arxiv: '2312.15796'
+    url: https://arxiv.org/abs/2312.15796
+    venue: Nature 2024
+    why: 'SOTA: beats ECMWF ENS on 99.8% of targets'
+  - title: 'ClimAgent: LLM Agents for Autonomous Climate Science Analysis'
+    arxiv: '2604.16922'
+    url: https://arxiv.org/abs/2604.16922
+    venue: April 2026
+    why: 'ClimaBench: first comprehensive climate discovery benchmark'
+  - title: ClimateBench v1.0 (legacy)
+    source: Zenodo 7064308, CC BY 4.0
+    why: Legacy compatibility fixture; superseded by WeatherBench 2
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B10_*/references/papers.json
+nlpcc_tracks:
+- track: T3
+  name: Scientific Discovery
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T3
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+- attribution_review_pending
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b10.climate_earth.svg

--- a/AISB/catalog/aisb.b11.model_efficiency.yaml
+++ b/AISB/catalog/aisb.b11.model_efficiency.yaml
@@ -1,0 +1,232 @@
+schema_version: 1
+id: aisb.b11.model_efficiency
+name: AISB B11 Model Efficiency
+version: 0.2.0
+catalog_version: 0.1.0
+one_line: LongBench-v2 mini request set for quality-latency-cost metric validation.
+task_description: AISB B11 Model Efficiency is an AISB BenchStore catalog pilot entry. The package is
+  intended for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track
+  submission scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B11 模型效率
+    one_line: 用于质量、延迟和成本指标验证的 LongBench-v2 mini 请求集。
+    task_description: AISB B11 模型效率 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开 evaluator
+      检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- model_efficiency
+- long_context
+- latency
+aisb_direction: B11
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: quality_latency_cost_logged_inference
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 500
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B11_ModelEfficiency
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: medium
+time_band: 1-4h
+difficulty: hard
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 2
+    ram_gb: 4
+    disk_gb: 4
+    gpu_count: 0
+  recommended:
+    cpu_cores: 8
+    ram_gb: 16
+    disk_gb: 20
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B11_ModelEfficiency
+  bench_yaml: benchmarks/aisb/B11_ModelEfficiency/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b11.model_efficiency-v0.2.0.zip
+  url: http://localhost:8080/aisb.b11.model_efficiency-v0.2.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B11_ModelEfficiency
+  archive_type: zip
+  local_dir_name: aisb.b11.model_efficiency
+  sha256: 890c432a9beed8912271a6fa72dde4c08fd58b89d74df5674e741e4a04c904db
+  size_bytes: 974447
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: false
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b11_public_dev_smoke
+  label: B11 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B11 --dest .work/benchstore/B11
+  - python scripts/agent_tools.py evaluate B11 --bench-dir .work/benchstore/B11 --submission .work/benchstore/B11/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B11/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B11/submission --output .work/benchstore/B11/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B11/submission --track B11
+  one_click_prompt: Start AISB B11 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: quality_latency_cost_score
+  benchmark_source: LongBench-v2 mini request set
+  packaged_data_status: real LongBench-v2 public-dev request set plus scorer-private hidden rows
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: LongBench-v2 mini
+    source: THUDM/LongBench-v2 (HF, Apache-2.0)
+    tasks: 3
+    hidden: 3
+    metric: quality_latency_cost_score (quality 0.55, latency 0.20, memory 0.10, tokens 0.10, cost 0.05)
+    sota: 63.3% (Gemini-2.5-Pro, w/ CoT)
+    our_baseline: 0.3529
+  alternatives:
+  - name: RULER
+    source: github.com/hsiehjackson/RULER
+    note: long-context efficiency; alternative metric
+  - name: MLPerf Inference
+    source: mlcommons.org
+    note: hardware-normalized; future candidate
+papers:
+  highlights:
+  - title: 'LongBench v2: Towards Deeper Understanding on Realistic Long-Context Multitasks'
+    source: THUDM/LongBench-v2 (HF, Apache-2.0)
+    why: Primary benchmark; SOTA 63.3% (Gemini-2.5-Pro)
+  - title: 'Youtu-LLM: Unleashing Native Agent Potential for Lightweight LLMs'
+    arxiv: '2512.24618'
+    url: https://arxiv.org/abs/2512.24618
+    venue: Dec 2025
+    why: 1.96B params; sub-2B SOTA; quality-latency-cost balance
+  - title: 'MARS: Efficient Adaptive Co-Scheduling for Heterogeneous Agent Systems'
+    arxiv: '2604.26963'
+    url: https://arxiv.org/abs/2604.26963
+    venue: April 2026
+    why: 5.94x end-to-end latency reduction; GPU-CPU co-scheduling
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B11_*/references/papers.json
+nlpcc_tracks:
+- track: T1
+  name: AI/CS Reasoning & Engineering
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T1
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+- hardware_normalization_pending
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b11.model_efficiency.svg

--- a/AISB/catalog/aisb.b12.embodied_ai.yaml
+++ b/AISB/catalog/aisb.b12.embodied_ai.yaml
@@ -1,0 +1,239 @@
+schema_version: 1
+id: aisb.b12.embodied_ai
+name: AISB B12 Embodied AI
+version: 0.4.0
+catalog_version: 0.1.0
+one_line: CALVIN task-spec public-dev mini package for headless embodied rollout validation.
+task_description: AISB B12 Embodied AI is an AISB BenchStore catalog pilot entry. The package is intended
+  for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track submission
+  scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B12 具身智能
+    one_line: 用于无头具身 rollout 验证的 CALVIN 任务规格 public-dev mini 包。
+    task_description: AISB B12 具身智能 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开 evaluator
+      检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- embodied_ai
+- simulator
+- robotics
+aisb_direction: B12
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: embodied_episode_success_headless_rollout
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 500
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B12_EmbodiedAI
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: high
+time_band: 2-8h
+difficulty: hard
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 4
+    ram_gb: 16
+    disk_gb: 20
+    gpu_count: 0
+  recommended:
+    cpu_cores: 8
+    ram_gb: 32
+    disk_gb: 80
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B12_EmbodiedAI
+  bench_yaml: benchmarks/aisb/B12_EmbodiedAI/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b12.embodied_ai-v0.4.0.zip
+  url: http://localhost:8080/aisb.b12.embodied_ai-v0.4.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B12_EmbodiedAI
+  archive_type: zip
+  local_dir_name: aisb.b12.embodied_ai
+  sha256: cd221f86fddd6123f7487e0ec3e27dfc881aaf005a07c712a9d1fe6bab44e156
+  size_bytes: 25349
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: true
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b12_public_dev_smoke
+  label: B12 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B12 --dest .work/benchstore/B12
+  - python scripts/agent_tools.py evaluate B12 --bench-dir .work/benchstore/B12 --submission .work/benchstore/B12/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B12/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B12/submission --output .work/benchstore/B12/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B12/submission --track B12
+  one_click_prompt: Start AISB B12 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: episode_success_rate
+  benchmark_source: CALVIN headless subset
+  packaged_data_status: real CALVIN task-spec mini split with scorer-private debug-dataset headless rollout
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: CALVIN debug
+    source: github.com/mees/calvin (MIT)
+    tasks: 2
+    hidden: 2
+    metric: episode_success_rate
+    sota: FLOWER 4.53/5 (ABC, 2025)
+    public_score: 0.0
+  alternatives:
+  - name: SimplerEnv
+    source: github.com/simpler-env/SimplerEnv
+    note: lighter simulator; future candidate
+  - name: Behavior-1K
+    source: behavior.stanford.edu
+    note: 1000 everyday tasks; heavy
+  - name: BuilderBench
+    source: arXiv:2510.06288
+    note: 42 target structures; open exploration
+papers:
+  highlights:
+  - title: 'CALVIN: A Benchmark for Language-Conditioned Policy Learning'
+    arxiv: '2112.03227'
+    url: https://arxiv.org/abs/2112.03227
+    why: Primary benchmark; debug dataset used for public-dev (MIT)
+  - title: 'EmboCoach-Bench: Benchmarking AI Agents in Developing Embodied Robots'
+    arxiv: '2601.21570'
+    url: https://arxiv.org/abs/2601.21570
+    venue: Jan 2026
+    why: 32 RL/IL tasks; agents beat human baseline by 26.5%
+  - title: 'BuilderBench: Building Blocks for Agents'
+    arxiv: '2510.06288'
+    url: https://arxiv.org/abs/2510.06288
+    venue: Oct 2025
+    why: 42 target structures; open exploration; no external supervision
+  - title: FLOWER
+    source: arXiv:2509.04996
+    why: 'Current CALVIN SOTA: 4.53/5 on ABC tasks'
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B12_*/references/papers.json
+nlpcc_tracks:
+- track: T1
+  name: AI/CS Reasoning & Engineering
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T1
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+- simulator_dependency_pending
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b12.embodied_ai.svg

--- a/AISB/catalog/aisb.b2.agent_systems.yaml
+++ b/AISB/catalog/aisb.b2.agent_systems.yaml
@@ -1,0 +1,230 @@
+schema_version: 1
+id: aisb.b2.agent_systems
+name: AISB B2 Agent Systems
+version: 0.3.0
+catalog_version: 0.1.0
+one_line: tau2-bench airline public-dev mini package for tool-use task success validation.
+task_description: AISB B2 Agent Systems is an AISB BenchStore catalog pilot entry. The package is intended
+  for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track submission
+  scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B2 智能体系统
+    one_line: 用于工具调用任务成功率验证的 tau2-bench airline public-dev mini 包。
+    task_description: AISB B2 智能体系统 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开 evaluator
+      检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- agent_systems
+- tool_use
+- task_success
+aisb_direction: B2
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: agent_task_success
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 500
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B2_AgentSystems
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: medium
+time_band: 1-4h
+difficulty: hard
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 4
+    ram_gb: 8
+    disk_gb: 5
+    gpu_count: 0
+  recommended:
+    cpu_cores: 8
+    ram_gb: 16
+    disk_gb: 20
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B2_AgentSystems
+  bench_yaml: benchmarks/aisb/B2_AgentSystems/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b2.agent_systems-v0.3.0.zip
+  url: http://localhost:8080/aisb.b2.agent_systems-v0.3.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B2_AgentSystems
+  archive_type: zip
+  local_dir_name: aisb.b2.agent_systems
+  sha256: 640fe257640743a51c7e65bede73c9ea19be97b4d85b232689c23d477d051216
+  size_bytes: 25925
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: true
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b2_public_dev_smoke
+  label: B2 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B2 --dest .work/benchstore/B2
+  - python scripts/agent_tools.py evaluate B2 --bench-dir .work/benchstore/B2 --submission .work/benchstore/B2/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B2/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B2/submission --output .work/benchstore/B2/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B2/submission --track B2
+  one_click_prompt: Start AISB B2 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: task_success_rate
+  benchmark_source: tau2-bench airline mini
+  packaged_data_status: real tau2-bench airline mini split
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: tau2-bench airline
+    source: github.com/sierra-research/tau2-bench
+    tasks: 2
+    metric: task_success_rate
+    sota: no public absolute scores
+    public_score: 0.0
+  alternatives:
+  - name: GAIA
+    source: huggingface.co/datasets/gaia-benchmark/GAIA
+    note: gated; secondary candidate
+  - name: Terminal-Bench
+    source: github.com/terminal-bench
+    note: CLI agent benchmark; future candidate
+papers:
+  highlights:
+  - title: 'tau2-bench: A Benchmark for Tool-Agent-User Interaction'
+    source: github.com/sierra-research/tau2-bench
+    why: Primary benchmark; airline domain used for public-dev
+  - title: Recursive Multi-Agent Systems
+    arxiv: '2604.25917'
+    url: https://arxiv.org/abs/2604.25917
+    venue: April 2026
+    why: +8.3% avg accuracy; 1.2x-2.4x inference speedup
+  - title: 'DR3-Eval: Towards Realistic and Reproducible Deep Research Evaluation'
+    arxiv: '2604.14683'
+    url: https://arxiv.org/abs/2604.14683
+    venue: April 2026
+    why: 5-dimension deep research evaluation framework
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B2_*/references/papers.json
+nlpcc_tracks:
+- track: T1
+  name: AI/CS Reasoning & Engineering
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T1
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b2.agent_systems.svg

--- a/AISB/catalog/aisb.b3.self_evolving_rl.yaml
+++ b/AISB/catalog/aisb.b3.self_evolving_rl.yaml
@@ -1,0 +1,238 @@
+schema_version: 1
+id: aisb.b3.self_evolving_rl
+name: AISB B3 Self-Evolving Agents
+version: 0.1.0
+catalog_version: 0.1.0
+one_line: SWE-bench Pro public-dev metadata package for self-improvement trajectory validation.
+task_description: AISB B3 Self-Evolving Agents is an AISB BenchStore catalog pilot entry. The package
+  is intended for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track
+  submission scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B3 自演化智能体
+    one_line: 用于自改进轨迹验证的 SWE-bench Pro public-dev 元数据包。
+    task_description: AISB B3 自演化智能体 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开 evaluator
+      检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- self_evolving_agents
+- swe_bench
+- trajectory
+aisb_direction: B3
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: iterative_software_repair
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 500
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B3_SelfEvolvingRL
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: medium
+time_band: 1-8h
+difficulty: hard
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 4
+    ram_gb: 16
+    disk_gb: 20
+    gpu_count: 0
+  recommended:
+    cpu_cores: 16
+    ram_gb: 64
+    disk_gb: 200
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B3_SelfEvolvingRL
+  bench_yaml: benchmarks/aisb/B3_SelfEvolvingRL/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b3.self_evolving_rl-v0.1.0.zip
+  url: http://localhost:8080/aisb.b3.self_evolving_rl-v0.1.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B3_SelfEvolvingRL
+  archive_type: zip
+  local_dir_name: aisb.b3.self_evolving_rl
+  sha256: 71ebccb9d860d35ba77a58168397104b20feb3b8c0baa51859d8969d5ea7a0e1
+  size_bytes: 44462
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: true
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b3_public_dev_smoke
+  label: B3 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B3 --dest .work/benchstore/B3
+  - python scripts/agent_tools.py evaluate B3 --bench-dir .work/benchstore/B3 --submission .work/benchstore/B3/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B3/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B3/submission --output .work/benchstore/B3/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B3/submission --track B3
+  one_click_prompt: Start AISB B3 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: verified_improvement_rate
+  benchmark_source: SWE-bench Pro public subset (ScaleAI/SWE-bench_Pro)
+  packaged_data_status: real SWE-bench Pro metadata rows with organizer-private upstream patch/test references
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: SWE-bench Pro
+    source: ScaleAI/SWE-bench_Pro (HF)
+    tasks: 20
+    metric: verified_improvement_rate
+    sota: 59.10% (GPT-5.4 xHigh)
+    public_score: 0.0
+  alternatives:
+  - name: SWE-bench Lite
+    source: princeton-nlp/SWE-bench_Lite (HF)
+    tasks: 23
+    note: legacy; kept as sanity fixture
+  - name: EvoCodeBench
+    source: github.com/evo-code-bench
+    note: self-evolution benchmark; future candidate
+papers:
+  highlights:
+  - title: 'SWE-bench: Can Language Models Resolve Real-World GitHub Issues?'
+    arxiv: '2310.06770'
+    url: https://arxiv.org/abs/2310.06770
+    venue: ICLR 2024
+    why: Foundational benchmark; all self-evolving agents evaluate on SWE-bench
+  - title: 'Agent0: Unlocking Self-Evolving Agents from Zero Data'
+    arxiv: '2511.16043'
+    url: https://arxiv.org/abs/2511.16043
+    venue: Nov 2025
+    why: Zero-data self-evolution; +18% math, +24% general reasoning
+  - title: 'MemRL: Self-Evolving Agents via RL on Episodic Memory'
+    arxiv: '2601.03192'
+    url: https://arxiv.org/abs/2601.03192
+    venue: Jan 2026
+    why: Non-parametric self-evolution; SOTA on HLE/BigCodeBench/ALFWorld
+  - title: 'TDFlow: Test-Driven Development at Repository Scale'
+    arxiv: '2510.23761'
+    url: https://arxiv.org/abs/2510.23761
+    venue: EACL 2026
+    why: SWE-bench Verified 94.3%; SWE-bench Lite 88.8%
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B3_*/references/papers.json
+nlpcc_tracks:
+- track: T1
+  name: AI/CS Reasoning & Engineering
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T1
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b3.self_evolving_rl.svg

--- a/AISB/catalog/aisb.b4.lm_reasoning.yaml
+++ b/AISB/catalog/aisb.b4.lm_reasoning.yaml
@@ -1,0 +1,241 @@
+schema_version: 1
+id: aisb.b4.lm_reasoning
+name: AISB B4 LM Reasoning
+version: 0.2.0
+catalog_version: 0.1.0
+one_line: HLE-Verified Gold text-only reasoning QA package with exact-match scoring.
+task_description: AISB B4 LM Reasoning is an AISB BenchStore catalog pilot entry. The package is intended
+  for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track submission
+  scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B4 语言模型推理
+    one_line: 带精确匹配评分的 HLE-Verified Gold text-only 推理问答包。
+    task_description: AISB B4 语言模型推理 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开 evaluator
+      检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- lm_reasoning
+- expert_qa
+- hle
+aisb_direction: B4
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: exact_match_reasoning_qa
+requires_execution: false
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 700
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B4_LMReasoning
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: low
+time_band: minutes
+difficulty: medium
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 2
+    ram_gb: 4
+    disk_gb: 1
+    gpu_count: 0
+  recommended:
+    cpu_cores: 4
+    ram_gb: 8
+    disk_gb: 2
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B4_LMReasoning
+  bench_yaml: benchmarks/aisb/B4_LMReasoning/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b4.lm_reasoning-v0.2.0.zip
+  url: http://localhost:8080/aisb.b4.lm_reasoning-v0.2.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B4_LMReasoning
+  archive_type: zip
+  local_dir_name: aisb.b4.lm_reasoning
+  sha256: f65a7c52d4eb27c594eaa80585f60ebe84969840890b8ea000553ca5c2cbd0e0
+  size_bytes: 30098
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: false
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b4_public_dev_smoke
+  label: B4 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B4 --dest .work/benchstore/B4
+  - python scripts/agent_tools.py evaluate B4 --bench-dir .work/benchstore/B4 --submission .work/benchstore/B4/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B4/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B4/submission --output .work/benchstore/B4/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B4/submission --track B4
+  one_click_prompt: Start AISB B4 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: exact_match_accuracy
+  benchmark_source: HLE-Verified Gold text-only (20 dev / 30 hidden)
+  packaged_data_status: real HLE-Verified Gold text-only split plus scorer-private hidden bootstrap
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: HLE-Verified Gold text-only
+    source: cais/hle (HF)
+    dev_count: 20
+    hidden_count: 30
+    metric: exact_match_accuracy
+    sota: 44.7% (Gemini 3.1 Pro Preview, Nature 2026)
+    public_score: 0.0
+  alternatives:
+  - name: MMLU-Pro
+    source: TIGER-Lab/MMLU-Pro (HF)
+    note: legacy sanity fixture; approaching saturation (89.8%)
+  - name: GPQA Diamond
+    source: Idavidrein/gpqa (HF)
+    note: saturated (94.1%); not primary
+  - name: PRL-Bench
+    source: arXiv:2604.15411
+    note: physics research reasoning; future B4/B6 cross
+papers:
+  highlights:
+  - title: 'HLE: Humanity''s Last Exam'
+    arxiv: '2501.14249'
+    url: https://arxiv.org/abs/2501.14249
+    venue: Nature 2026
+    why: 2500 expert-verified questions; new ultimate closed-book benchmark
+  - title: 'HLE-Verified: Systematic Validation and Revision of HLE'
+    arxiv: '2602.13964'
+    url: https://arxiv.org/abs/2602.13964
+    venue: Feb 2026
+    why: Gold/Revision/Uncertain classification; current B4 primary
+  - title: 'MMLU-Pro: A More Robust Multi-discipline Benchmark'
+    arxiv: '2406.01574'
+    url: https://arxiv.org/abs/2406.01574
+    venue: NeurIPS 2024
+    why: Legacy B4 benchmark; approaching saturation at 89.8%
+  - title: 'Nemotron-Cascade 2: Cascade RL for LLM Post-training'
+    arxiv: '2603.19220'
+    url: https://arxiv.org/abs/2603.19220
+    venue: Mar 2026
+    why: Gold-level IMO/IOI/ICPC with 30B MoE (3B active)
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B4_*/references/papers.json
+nlpcc_tracks:
+- track: T1
+  name: AI/CS Reasoning & Engineering
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T1
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b4.lm_reasoning.svg

--- a/AISB/catalog/aisb.b5.math_proof.yaml
+++ b/AISB/catalog/aisb.b5.math_proof.yaml
@@ -1,0 +1,236 @@
+schema_version: 1
+id: aisb.b5.math_proof
+name: AISB B5 Mathematical Proof
+version: 0.2.0
+catalog_version: 0.1.0
+one_line: FormalMATH-Lite Lean4 theorem-proving package with proof-rate scoring.
+task_description: AISB B5 Mathematical Proof is an AISB BenchStore catalog pilot entry. The package is
+  intended for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track
+  submission scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B5 数学证明
+    one_line: 带证明通过率评分的 FormalMATH-Lite Lean4 定理证明包。
+    task_description: AISB B5 数学证明 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开 evaluator
+      检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- formal_math
+- lean4
+- proof_verification
+aisb_direction: B5
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: lean_proof_verification
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 700
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B5_MathProof
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: medium
+time_band: 1-4h
+difficulty: hard
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 4
+    ram_gb: 16
+    disk_gb: 20
+    gpu_count: 0
+  recommended:
+    cpu_cores: 8
+    ram_gb: 32
+    disk_gb: 40
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B5_MathProof
+  bench_yaml: benchmarks/aisb/B5_MathProof/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b5.math_proof-v0.2.0.zip
+  url: http://localhost:8080/aisb.b5.math_proof-v0.2.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B5_MathProof
+  archive_type: zip
+  local_dir_name: aisb.b5.math_proof
+  sha256: f518ca94849ee4b8cf3893083ccb02780c0afc80dc4c2ed93ce50612b836dca4
+  size_bytes: 27349
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: true
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b5_public_dev_smoke
+  label: B5 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B5 --dest .work/benchstore/B5
+  - python scripts/agent_tools.py evaluate B5 --bench-dir .work/benchstore/B5 --submission .work/benchstore/B5/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B5/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B5/submission --output .work/benchstore/B5/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B5/submission --track B5
+  one_click_prompt: Start AISB B5 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: proof_rate
+  benchmark_source: FormalMATH-Lite
+  packaged_data_status: real FormalMATH-Lite public-dev theorem split plus scorer-private hidden theorem
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: FormalMATH-Lite
+    source: SphereLab/FormalMATH-Lite (HF)
+    tasks: 5
+    hidden: 20
+    metric: proof_rate
+    sota: 56-62% (DeepSeek-V2-671B, pass@32-3200)
+    public_score: 0.0
+  alternatives:
+  - name: PutnamBench
+    source: github.com/trishullab/PutnamBench
+    note: 658 competition problems; future target
+  - name: ProverBench
+    source: DeepSeek-Prover-V2 paper
+    note: 325 formal problems; v1.1 candidate
+  - name: miniF2F
+    note: DEPRECATED — saturated (90.4%); not recommended
+papers:
+  highlights:
+  - title: 'FormalMATH: A Benchmark for Formal Mathematical Reasoning'
+    arxiv: '2505.02735'
+    url: https://arxiv.org/abs/2505.02735
+    venue: May 2025
+    why: 5560 Lean4 problems; primary B5 benchmark
+  - title: DeepSeek-Prover-V2
+    arxiv: '2504.21801'
+    url: https://arxiv.org/abs/2504.21801
+    venue: Apr 2025
+    why: FormalMATH-Lite SOTA 56-62%; miniF2F 88.9%; PutnamBench 49/658
+  - title: 'Goedel-Prover-V2: Small Models, Big Proofs'
+    arxiv: '2508.03613'
+    url: https://arxiv.org/abs/2508.03613
+    venue: Aug 2025
+    why: miniF2F 90.4% with 8B model; self-correction
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B5_*/references/papers.json
+nlpcc_tracks:
+- track: T2
+  name: Formal Mathematical Proof
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T2
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+- special_runtime_lean4
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b5.math_proof.svg

--- a/AISB/catalog/aisb.b6.research_process.yaml
+++ b/AISB/catalog/aisb.b6.research_process.yaml
@@ -1,0 +1,244 @@
+schema_version: 1
+id: aisb.b6.research_process
+name: AISB B6 Research Process
+version: 0.1.0
+catalog_version: 0.1.0
+one_line: ScienceAgentBench public-input preview package; full upstream references are not redistributable.
+task_description: AISB B6 Research Process is an AISB BenchStore catalog pilot entry. The package is intended
+  for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track submission
+  scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B6 科研过程
+    one_line: ScienceAgentBench 公开输入预览包；完整上游参考数据不可公开再分发。
+    task_description: AISB B6 科研过程 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开 evaluator
+      检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- research_process
+- scientific_workflow
+- evidence
+aisb_direction: B6
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: research_task_execution
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 200
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B6_ResearchProcess
+release_gate:
+  release_ready: false
+  status: blocked
+  full_real_replay: failed
+  reason: Full upstream gold/rubric references are not locally redistributable; organizer-private replay
+    is incomplete.
+  next_required_step: Rerun with a private full ScienceAgentBench root and freeze hidden references before
+    registry promotion.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: medium
+time_band: 2-8h
+difficulty: expert
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 4
+    ram_gb: 16
+    disk_gb: 20
+    gpu_count: 0
+  recommended:
+    cpu_cores: 8
+    ram_gb: 32
+    disk_gb: 50
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B6_ResearchProcess
+  bench_yaml: benchmarks/aisb/B6_ResearchProcess/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b6.research_process-v0.1.0.zip
+  url: http://localhost:8080/aisb.b6.research_process-v0.1.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B6_ResearchProcess
+  archive_type: zip
+  local_dir_name: aisb.b6.research_process
+  sha256: 77cbea6d17b9f209dbe3433d56fa673e2b25478240151e1a61734789d1e0920c
+  size_bytes: 138627
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: true
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b6_public_dev_smoke
+  label: B6 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B6 --dest .work/benchstore/B6
+  - python scripts/agent_tools.py evaluate B6 --bench-dir .work/benchstore/B6 --submission .work/benchstore/B6/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B6/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B6/submission --output .work/benchstore/B6/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B6/submission --track B6
+  one_click_prompt: Start AISB B6 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: task_success_rate
+  benchmark_source: ScienceAgentBench validation public-input rows
+  packaged_data_status: real ScienceAgentBench validation public-input split without full upstream gold/rubric
+    references
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: ScienceAgentBench
+    source: osunlp/ScienceAgentBench (HF)
+    tasks: 102
+    metric: task_success_rate
+    sota: 42.2% (o1-preview, ICLR 2025)
+    public_score: 0.0
+  alternatives:
+  - name: MLR-Bench
+    source: arXiv:2505.19955
+    note: NeurIPS 2025; 201 ML tasks; 73% fabrication finding
+  - name: D3-Gym
+    source: arXiv:2604.27977
+    note: 565 tasks from 239 science repos; April 2026
+  - name: PRL-Bench
+    source: arXiv:2604.15411
+    note: 100 physics PRL papers; best model <50%
+  blocker: Full executable bundle (datasets/eval_programs/gold_programs/scoring_rubrics) NOT redistributable
+    upstream. Set AISB_B6_SCIENCEAGENTBENCH_FULL_ROOT for private scoring.
+papers:
+  highlights:
+  - title: 'ScienceAgentBench: Rigorous Assessment of Language Agents for Scientific Discovery'
+    arxiv: '2410.05080'
+    url: https://arxiv.org/abs/2410.05080
+    venue: ICLR 2025
+    why: Primary B6 benchmark; 102 verified input rows
+  - title: 'MLR-Bench: Evaluating AI Research Agents on End-to-End ML Research'
+    arxiv: '2505.19955'
+    url: https://arxiv.org/abs/2505.19955
+    venue: NeurIPS 2025
+    why: 73% of coding agents fabricate results — AISB integrity motivation
+  - title: 'D3-Gym: Building Real-World Verifiable Environments for Data-Driven Discovery'
+    arxiv: '2604.27977'
+    url: https://arxiv.org/abs/2604.27977
+    venue: April 2026
+    why: 565 tasks from 239 science repos; Qwen3-32B +7.8pp
+  - title: 'AI-Supervisor: Autonomous AI Research Oversight'
+    arxiv: '2603.24402'
+    url: https://arxiv.org/abs/2603.24402
+    venue: Mar 2026
+    why: Persistent research world model; structured gap discovery
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B6_*/references/papers.json
+nlpcc_tracks:
+- track: T3
+  name: Scientific Discovery
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T3
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- full_reference_missing
+- upstream_redistribution_blocked
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b6.research_process.svg

--- a/AISB/catalog/aisb.b7.multimodal_fusion.yaml
+++ b/AISB/catalog/aisb.b7.multimodal_fusion.yaml
@@ -1,0 +1,233 @@
+schema_version: 1
+id: aisb.b7.multimodal_fusion
+name: AISB B7 Multimodal Fusion
+version: 0.3.0
+catalog_version: 0.1.0
+one_line: MMMU-Pro image-plus-text public-dev mini package with exact-match style scoring.
+task_description: AISB B7 Multimodal Fusion is an AISB BenchStore catalog pilot entry. The package is
+  intended for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track
+  submission scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B7 多模态融合
+    one_line: 带精确匹配类评分的 MMMU-Pro 图文 public-dev mini 包。
+    task_description: AISB B7 多模态融合 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开 evaluator
+      检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- multimodal
+- image_text
+- qa
+aisb_direction: B7
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: multimodal_answer_exact_match
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 500
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B7_MultimodalFusion
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: medium
+time_band: 1-4h
+difficulty: hard
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 4
+    ram_gb: 8
+    disk_gb: 5
+    gpu_count: 0
+  recommended:
+    cpu_cores: 8
+    ram_gb: 16
+    disk_gb: 20
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B7_MultimodalFusion
+  bench_yaml: benchmarks/aisb/B7_MultimodalFusion/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b7.multimodal_fusion-v0.3.0.zip
+  url: http://localhost:8080/aisb.b7.multimodal_fusion-v0.3.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B7_MultimodalFusion
+  archive_type: zip
+  local_dir_name: aisb.b7.multimodal_fusion
+  sha256: 1d64b497e341a5a72489d520a2ab3d099acf681f3ea6417bbdb28f900fff2e32
+  size_bytes: 160705
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: true
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b7_public_dev_smoke
+  label: B7 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B7 --dest .work/benchstore/B7
+  - python scripts/agent_tools.py evaluate B7 --bench-dir .work/benchstore/B7 --submission .work/benchstore/B7/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B7/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B7/submission --output .work/benchstore/B7/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B7/submission --track B7
+  one_click_prompt: Start AISB B7 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: accuracy
+  benchmark_source: MMMU-Pro mini
+  packaged_data_status: real MMMU-Pro image-plus-text mini split
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: MMMU-Pro tool
+    source: MMMU/MMMU_Pro (HF)
+    tasks: 2
+    hidden: 2
+    metric: exact_match_accuracy
+    sota: 82% (Gemini 3.1 Pro Preview)
+    public_score: 0.5
+  alternatives:
+  - name: MMMU
+    source: MMMU/MMMU (HF)
+    note: parent benchmark; 11.5K questions
+  - name: MathVista
+    source: huggingface.co/datasets/AI4Math/MathVista
+    note: math-visual reasoning; future candidate
+papers:
+  highlights:
+  - title: 'MMMU-Pro: A More Robust Multi-discipline Multimodal Understanding Benchmark'
+    arxiv: '2409.02813'
+    url: https://arxiv.org/abs/2409.02813
+    venue: '2024'
+    why: 10-option multimodal benchmark; SOTA 82% vs human 88.6%
+  - title: 'SenseNova-MARS: Multimodal Agent Reasoning and Search via RL'
+    arxiv: '2512.24330'
+    url: https://arxiv.org/abs/2512.24330
+    venue: Dec 2025
+    why: 74.3 MMSearch; 54.4 HR-MMSearch; beats Gemini-3-Pro
+  - title: 'P1-VL: Bridging Visual Perception and Scientific Reasoning'
+    arxiv: '2602.09443'
+    url: https://arxiv.org/abs/2602.09443
+    venue: Feb 2026
+    why: 12 gold medals in Physics Olympiad; science multimodal reasoning
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B7_*/references/papers.json
+nlpcc_tracks:
+- track: T1
+  name: AI/CS Reasoning & Engineering
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T1
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b7.multimodal_fusion.svg

--- a/AISB/catalog/aisb.b8.lifesci_drug.yaml
+++ b/AISB/catalog/aisb.b8.lifesci_drug.yaml
@@ -1,0 +1,276 @@
+schema_version: 1
+id: aisb.b8.lifesci_drug
+name: AISB B8 LifeSci Drug Discovery
+version: 0.1.1
+catalog_version: 0.1.0
+one_line: ADMET-only public-dev BenchStore pilot using five real TDC molecular-property endpoints.
+task_description: AISB B8 LifeSci Drug Discovery is an AISB BenchStore catalog pilot entry. The package
+  is intended for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track
+  submission scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B8 生命科学药物发现
+    one_line: 基于五个真实 TDC 分子性质端点的 ADMET-only BenchStore pilot。
+    task_description: AISB B8 生命科学药物发现 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开
+      evaluator 检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- life_science
+- drug_discovery
+- admet_prediction
+- molecular_property_prediction
+- tabular_ml
+aisb_direction: B8
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: experiment_driven
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: advanced
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 1000
+  featured: true
+  featured_reason: Prefer AISB B8 as the top BenchStore hero card for the current pilot because it is
+    the strongest low-friction public-dev package with real data and working replay evidence.
+display:
+  placement: hero
+  card_size: xl
+  badge: Recommended
+  accent_priority: highest
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B8_LifeSciDrug
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: low
+time_band: 1-2h
+difficulty: medium
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 4
+    ram_gb: 16
+    disk_gb: 20
+    gpu_count: 0
+  recommended:
+    cpu_cores: 8
+    ram_gb: 32
+    disk_gb: 40
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B8_LifeSciDrug
+  bench_yaml: benchmarks/aisb/B8_LifeSciDrug/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b8.lifesci_drug-v0.1.1.zip
+  url: http://localhost:8080/aisb.b8.lifesci_drug-v0.1.1.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B8_LifeSciDrug
+  archive_type: zip
+  local_dir_name: aisb.b8.lifesci_drug
+  sha256: 7e9fde8e42baea653e20a0d67d77aa0a9c8cc0c314f8828320454556f73f851e
+  size_bytes: 154222
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: true
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b8_public_dev_smoke
+  label: B8 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B8 --dest .work/benchstore/B8
+  - python scripts/agent_tools.py evaluate B8 --bench-dir .work/benchstore/B8 --submission .work/benchstore/B8/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B8/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B8/submission --output .work/benchstore/B8/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B8/submission --track B8
+  one_click_prompt: Start AISB B8 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: mean_normalized_endpoint_score
+  benchmark_source: TDC ADMET endpoints scoped to molecular property prediction
+  packaged_data_status: real TDC ADMET public-dev CSVs plus label-stripped real TDC ADMET test inputs
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: TDC ADMET 5-endpoint
+    source: TDC (tdcommons.ai)
+    endpoints:
+    - caco2_wang (91)
+    - herg (65)
+    - ames (727)
+    - cyp3a4_veith (1232)
+    - lipophilicity_az (420)
+    total_dev_rows: 2535
+    metric: mean_normalized_endpoint_score
+    sota_per_endpoint:
+      caco2_wang: MAE 0.256 (CaliciBoost)
+      herg: AUROC 0.880 (MapLight+GNN)
+      ames: AUROC 0.871 (ZairaChem)
+      cyp3a4_veith: AUPRC 0.916 (MapLight+GNN)
+      lipophilicity_az: MAE 0.456 (MiniMol)
+    our_baseline: 0.6385
+    our_hidden: 0.5829
+  alternatives:
+  - name: TDC-2
+    source: tdcommons.ai
+    note: multimodal data + extended ADMET; future upgrade
+  - name: ADMET-AI
+    source: github.com/swansonk14/admet_ai
+    note: fast predictor; reference method only
+papers:
+  highlights:
+  - title: 'TDC: Therapeutics Data Commons'
+    arxiv: '2102.09548'
+    url: https://arxiv.org/abs/2102.09548
+    venue: '2021'
+    why: Primary benchmark data source; ADMET endpoints
+  - title: 'ADMET-AI: A Machine Learning ADMET Platform'
+    source: github.com/swansonk14/admet_ai
+    why: Fast ADMET predictor; reference method candidate
+  - title: 'STELLA: Self-Evolving LLM Agent for Biomedical Research'
+    arxiv: '2507.02004'
+    url: https://arxiv.org/abs/2507.02004
+    venue: Jul 2025
+    why: 26% HLE biomed; 63% LAB-Bench LitQA; self-evolving for life science
+  - title: Auditable Agent Platform for Automated Molecular Optimization
+    arxiv: '2508.03444'
+    url: https://arxiv.org/abs/2508.03444
+    venue: Aug 2025
+    why: 31% binding affinity improvement; multi-agent molecular optimization
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B8_*/references/papers.json
+nlpcc_tracks:
+- track: T3
+  name: Scientific Discovery
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T3
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+- endpoint_license_review_pending
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b8.lifesci_drug.svg
+pilot:
+  status: selected
+  reason: B8 has real public-dev ADMET CSVs, label-stripped hidden inputs, CPU-safe baseline/evaluator,
+    and low install cost.
+checksums:
+  release_asset:
+    sha256: 7e9fde8e42baea653e20a0d67d77aa0a9c8cc0c314f8828320454556f73f851e
+    size_bytes: 154222
+    status: built_local_not_published
+  public_dev_files:
+  - path: benchmarks/aisb/B8_LifeSciDrug/data/dev/ames_dev.csv
+    rows: 727
+    sha256: 44fe16829e10ef78c0cf0456f19f355cac419bdabb930bf633f1dc714ff037c2
+  - path: benchmarks/aisb/B8_LifeSciDrug/data/dev/caco2_wang_dev.csv
+    rows: 91
+    sha256: 6c00bec1a71fef143bdfec175f71d3544e59f8d6065f8e68943333ce7d881b16
+  - path: benchmarks/aisb/B8_LifeSciDrug/data/dev/cyp3a4_veith_dev.csv
+    rows: 1232
+    sha256: 4b6abcba74d6e63078fa0e2c5adb4af48cde187cc082bb086002e64568afcfaa
+  - path: benchmarks/aisb/B8_LifeSciDrug/data/dev/herg_dev.csv
+    rows: 65
+    sha256: e3f22630a8f747a0adc972703ff44bc91e4c0f2481ac0a43eb8208ddcb5c7dd3
+  - path: benchmarks/aisb/B8_LifeSciDrug/data/dev/lipophilicity_az_dev.csv
+    rows: 420
+    sha256: 193eec001ae071e04b68d8a207d7f097f712e0e45d622bf1bbde4a962bb80321

--- a/AISB/catalog/aisb.b9.material_science.yaml
+++ b/AISB/catalog/aisb.b9.material_science.yaml
@@ -1,0 +1,238 @@
+schema_version: 1
+id: aisb.b9.material_science
+name: AISB B9 Material Science
+version: 0.1.0
+catalog_version: 0.1.0
+one_line: Matbench Discovery WBM mini package for crystal-stability prediction validation.
+task_description: AISB B9 Material Science is an AISB BenchStore catalog pilot entry. The package is intended
+  for public-dev workspace initialization, public evaluator checks, and paper/benchmark-track submission
+  scaffolding. Official leaderboard scores require organizer-side hidden replay.
+homepage: https://aisb.deepscientist.cc
+localized:
+  zh:
+    name: AISB B9 材料科学
+    one_line: 用于晶体稳定性预测验证的 Matbench Discovery WBM mini 包。
+    task_description: AISB B9 材料科学 是 AISB BenchStore catalog pilot 条目。公开包只用于 public-dev 工作区初始化、公开 evaluator
+      检查和论文/benchmark track 提交脚手架；正式 leaderboard 分数必须由组织方 hidden replay 产生。
+capability_tags:
+- material_science
+- property_prediction
+- crystal_stability
+aisb_direction: B9
+track_fit:
+- paper_track
+- benchmark_track
+task_mode: benchmark
+benchmark_mode: experiment_driven
+requires_execution: true
+requires_paper: true
+integrity_level: hidden_reference
+snapshot_status: partial
+support_level: preview
+discovery:
+  collection: AISB
+  collection_priority: 100
+  recommendation_weight: 700
+  featured: false
+  featured_reason: null
+display:
+  placement: grid
+  card_size: m
+  badge: AISB
+  accent_priority: normal
+official_links:
+  homepage: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  github: https://github.com/ResearAI/NLPCC-2026-Task9-AISB
+  benchmark_overview: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B9_MaterialScience
+release_gate:
+  release_ready: false
+  status: registry_pending
+  full_real_replay: passed
+  reason: Public-dev and scorer-private replay paths exist locally, but final registry promotion, release
+    assets, and license review remain pending.
+  next_required_step: Publish BenchStore release asset, fill sha256/size_bytes, and complete clean-host
+    validation.
+primary_outputs:
+- results.json
+- paper/paper.pdf
+- paper/claims.json
+- logs/experiment_log.jsonl
+- logs/iterations.jsonl
+cost_band: low
+time_band: minutes
+difficulty: medium
+data_access: public
+resources:
+  minimum:
+    cpu_cores: 2
+    ram_gb: 2
+    disk_gb: 1
+    gpu_count: 0
+  recommended:
+    cpu_cores: 4
+    ram_gb: 4
+    disk_gb: 2
+    gpu_count: 0
+source:
+  benchmark_dir: benchmarks/aisb/B9_MaterialScience
+  bench_yaml: benchmarks/aisb/B9_MaterialScience/bench.yaml
+  source_repo: ResearAI/NLPCC-2026-Task9-AISB
+  source_commit: b6b7527a226ca7328697156608571f2cb7dcda3a
+download:
+  provider: local_download
+  repo: ResearAI/NLPCC-2026-Task9-AISB
+  tag: benchstore-assets-2026-04-30-pilot
+  asset_name: aisb.b9.material_science-v0.1.0.zip
+  url: http://localhost:8080/aisb.b9.material_science-v0.1.0.zip
+  source_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B9_MaterialScience
+  archive_type: zip
+  local_dir_name: aisb.b9.material_science
+  sha256: 58511b92525fc9320972c83cb050a33e3a80c93734c0a1c23fb8cf15bc631d32
+  size_bytes: 46754
+  published_at: '2026-04-30T00:00:00Z'
+  asset_status: built_local_not_published
+dataset_download:
+  primary_method: packaged_public_dev
+  sources:
+  - kind: public_dev
+    access: public
+    url: null
+    note: Public-dev files are included in the future BenchStore package.
+  - kind: hidden_reference
+    access: private
+    url: null
+    note: Organizer-only hidden references are excluded from catalog packages.
+credential_requirements:
+  mode: none
+  notes:
+  - No credential is required for packaged public-dev evaluation.
+  - External model APIs are optional participant choices and not bundled.
+environment:
+  python: '>=3.11'
+  docker: true
+  key_packages:
+  - pytest
+  - PyYAML
+  notes:
+  - Use docker/Dockerfile when available for official replay parity.
+  - Do not copy organizer-private hidden references into participant workspaces.
+launch_profiles:
+- id: b9_public_dev_smoke
+  label: B9 public-dev smoke test
+  description: Initialize an AISB public-dev workspace, validate submission artifacts, and run the public
+    evaluator.
+  startup_contract:
+  - Use only files inside the installed benchmark workspace and the generated submission directory.
+  - Treat hidden references as organizer-only and unavailable to the agent.
+  - Produce benchmark outputs, paper artifacts, claims, and logs before packaging.
+  commands:
+  - python scripts/agent_tools.py workspace init B9 --dest .work/benchstore/B9
+  - python scripts/agent_tools.py evaluate B9 --bench-dir .work/benchstore/B9 --submission .work/benchstore/B9/submission
+  - python scripts/agent_tools.py submission validate .work/benchstore/B9/submission
+  - python scripts/agent_tools.py submission package .work/benchstore/B9/submission --output .work/benchstore/B9/submission.zip
+  - python scripts/agent_tools.py submission replay .work/benchstore/B9/submission --track B9
+  one_click_prompt: Start AISB B9 from the installed BenchStore package. Initialize the public-dev workspace,
+    inspect AGENT.md and README.md, run the baseline or your method, evaluate locally, validate/package
+    the submission, and record any release-gate risks in logs/experiment_log.jsonl.
+paper:
+  venue: AISB
+  year: 2026
+  track_fit:
+  - paper_track
+  - benchmark_track
+  requires_claims_json: true
+  url: null
+benchmark_track:
+  metric: f1
+  benchmark_source: Matbench Discovery WBM mini
+  packaged_data_status: real Matbench Discovery WBM mini public-dev CSV plus label-stripped held-out inputs
+  official_score_requires_hidden_replay: true
+benchmarks:
+  primary:
+    name: Matbench Discovery WBM mini
+    source: janosh/matbench-discovery (Figshare CC BY 4.0)
+    tasks: 800
+    hidden: 200
+    metric: F1
+    sota: F1=0.931 (EquiformerV3+DeNS-OAM, 2026-04-07)
+    our_baseline: 0.8792
+    our_hidden: 0.6486
+  alternatives:
+  - name: PhononBench
+    source: arXiv:2512.21227
+    note: 108K structures; dynamic stability; avg stability 25.83%
+  - name: OC25
+    source: Open Catalyst
+    note: restricted access; not for public-dev
+papers:
+  highlights:
+  - title: 'Matbench Discovery: A Framework for ML Crystal Stability Prediction'
+    arxiv: '2308.14920'
+    url: https://arxiv.org/abs/2308.14920
+    venue: Nature MI 2025
+    why: Primary benchmark; WBM mini split used for public-dev
+  - title: 'PhononBench: Large-Scale Phonon-Based Benchmark for Crystal Generation'
+    arxiv: '2512.21227'
+    url: https://arxiv.org/abs/2512.21227
+    venue: Dec 2025
+    why: 108K structures; avg stability only 25.83%; harder than Matbench
+  - title: 'MIND: AI Co-Scientist for Materials Research'
+    arxiv: '2604.13699'
+    url: https://arxiv.org/abs/2604.13699
+    venue: April 2026
+    why: Multi-agent hypothesis-verification; SevenNet-Omni validation
+  - title: EquiformerV3+DeNS-OAM
+    source: Matbench Discovery leaderboard, 2026-04-07
+    why: 'Current SOTA: F1=0.931, MAE=0.018'
+  full_references_url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/aisb/B9_*/references/papers.json
+nlpcc_tracks:
+- track: T3
+  name: Scientific Discovery
+  url: https://github.com/ResearAI/NLPCC-2026-Task9-AISB/tree/main/benchmarks/nlpcc/T3
+private_hidden_reference_strategy:
+  policy: organizer_only
+  public_package_includes_hidden_reference: false
+  public_catalog_discloses_private_paths: false
+  score_release: aggregate_only
+  notes:
+  - Hidden answers, labels, canaries, and private evaluator internals are never packaged.
+  - Official scores must record hidden_reference_version without disclosing hidden content.
+score_card:
+  required_fields:
+  - team_id
+  - system_name
+  - direction
+  - track
+  - benchmark_package_version
+  - evaluator_version
+  - hidden_reference_version
+  - docker_image_digest
+  - data_split_version
+  - benchmark_score
+  - paper_score
+  - cas_score
+  - final_score
+  - security_verdict
+  - license_verdict
+  - used_reference_scope
+  - official_score
+  - created_at
+  track_scoring:
+    paper_track: Final_A = 0.0 * S_benchmark + 1.0 * S_paper
+    benchmark_track: Final_B = 0.7 * S_benchmark + 0.3 * S_paper
+    cas: integrity gate, not bonus
+risk_flags:
+- hidden_reference_not_public
+- release_asset_pending
+- not_release_ready
+- registry_promotion_pending
+- attribution_review_pending
+risk_notes:
+- This catalog entry is not release_ready.
+- Download checksum and size are placeholders until the GitHub release asset is published.
+- Official scores require organizer-side replay against private hidden references.
+recommended_when: Use this entry for AISB public-dev integration, local agent workflow checks, and catalog
+  UI validation.
+not_recommended_when: Do not treat this entry as an official release or public leaderboard claim until
+  release gates pass.
+image_path: AISB/image/aisb.b9.material_science.svg

--- a/AISB/image/aisb.b1.agentic_coding.svg
+++ b/AISB/image/aisb.b1.agentic_coding.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B1 Agentic Coding">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14213d"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fca311" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fca311" opacity="0.12"/>
+  <text x="80" y="120" fill="#fca311" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B1 Agentic Coding</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">FeatureBench-lite public-dev package for repository navigation, code edits, and test-driven repair.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b1.agentic_coding.svg
+++ b/AISB/image/aisb.b1.agentic_coding.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">FeatureBench-lite public-dev package for repository navigation, code edits, and test-driven repair.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b10.climate_earth.svg
+++ b/AISB/image/aisb.b10.climate_earth.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">ClimateBench-lite mini package for deterministic climate-emulation metric validation.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b10.climate_earth.svg
+++ b/AISB/image/aisb.b10.climate_earth.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B10 Climate and Earth Science">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14213d"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fca311" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fca311" opacity="0.12"/>
+  <text x="80" y="120" fill="#fca311" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B10 Climate and Earth Science</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">ClimateBench-lite mini package for deterministic climate-emulation metric validation.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b11.model_efficiency.svg
+++ b/AISB/image/aisb.b11.model_efficiency.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B11 Model Efficiency">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14213d"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fca311" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fca311" opacity="0.12"/>
+  <text x="80" y="120" fill="#fca311" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B11 Model Efficiency</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">LongBench-v2 mini request set for quality-latency-cost metric validation.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b11.model_efficiency.svg
+++ b/AISB/image/aisb.b11.model_efficiency.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">LongBench-v2 mini request set for quality-latency-cost metric validation.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b12.embodied_ai.svg
+++ b/AISB/image/aisb.b12.embodied_ai.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B12 Embodied AI">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14213d"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fca311" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fca311" opacity="0.12"/>
+  <text x="80" y="120" fill="#fca311" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B12 Embodied AI</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">CALVIN task-spec public-dev mini package for headless embodied rollout validation.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b12.embodied_ai.svg
+++ b/AISB/image/aisb.b12.embodied_ai.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">CALVIN task-spec public-dev mini package for headless embodied rollout validation.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b2.agent_systems.svg
+++ b/AISB/image/aisb.b2.agent_systems.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B2 Agent Systems">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14213d"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fca311" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fca311" opacity="0.12"/>
+  <text x="80" y="120" fill="#fca311" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B2 Agent Systems</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">tau2-bench airline public-dev mini package for tool-use task success validation.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b2.agent_systems.svg
+++ b/AISB/image/aisb.b2.agent_systems.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">tau2-bench airline public-dev mini package for tool-use task success validation.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b3.self_evolving_rl.svg
+++ b/AISB/image/aisb.b3.self_evolving_rl.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">SWE-bench Lite public-dev metadata package for self-improvement trajectory validation.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b3.self_evolving_rl.svg
+++ b/AISB/image/aisb.b3.self_evolving_rl.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B3 Self-Evolving Agents">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14213d"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fca311" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fca311" opacity="0.12"/>
+  <text x="80" y="120" fill="#fca311" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B3 Self-Evolving Agents</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">SWE-bench Lite public-dev metadata package for self-improvement trajectory validation.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b4.lm_reasoning.svg
+++ b/AISB/image/aisb.b4.lm_reasoning.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B4 LM Reasoning">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14213d"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fca311" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fca311" opacity="0.12"/>
+  <text x="80" y="120" fill="#fca311" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B4 LM Reasoning</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">MMLU-Pro public-dev reasoning QA package with normalized exact-match scoring.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b4.lm_reasoning.svg
+++ b/AISB/image/aisb.b4.lm_reasoning.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">MMLU-Pro public-dev reasoning QA package with normalized exact-match scoring.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b5.math_proof.svg
+++ b/AISB/image/aisb.b5.math_proof.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B5 Mathematical Proof">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14213d"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fca311" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fca311" opacity="0.12"/>
+  <text x="80" y="120" fill="#fca311" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B5 Mathematical Proof</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">FormalMATH-Lite Lean4 theorem-proving package with proof-rate scoring.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b5.math_proof.svg
+++ b/AISB/image/aisb.b5.math_proof.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">FormalMATH-Lite Lean4 theorem-proving package with proof-rate scoring.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b6.research_process.svg
+++ b/AISB/image/aisb.b6.research_process.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B6 Research Process">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#3b1d1d"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fca5a5" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fca5a5" opacity="0.12"/>
+  <text x="80" y="120" fill="#fca5a5" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#fff7ed" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B6 Research Process</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #fff7ed; font-size: 32px; line-height: 1.35;">ScienceAgentBench public-input preview package; full upstream references are not redistributable.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fca5a5" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b6.research_process.svg
+++ b/AISB/image/aisb.b6.research_process.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #fff7ed; font-size: 32px; line-height: 1.35;">ScienceAgentBench public-input preview package; full upstream references are not redistributable.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fca5a5" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b7.multimodal_fusion.svg
+++ b/AISB/image/aisb.b7.multimodal_fusion.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B7 Multimodal Fusion">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#14213d"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fca311" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fca311" opacity="0.12"/>
+  <text x="80" y="120" fill="#fca311" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B7 Multimodal Fusion</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">MMMU-Pro image-plus-text public-dev mini package with exact-match style scoring.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b7.multimodal_fusion.svg
+++ b/AISB/image/aisb.b7.multimodal_fusion.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">MMMU-Pro image-plus-text public-dev mini package with exact-match style scoring.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fca311" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b8.lifesci_drug.svg
+++ b/AISB/image/aisb.b8.lifesci_drug.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">ADMET-only public-dev BenchStore pilot using five real TDC molecular-property endpoints.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#a7f3d0" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>

--- a/AISB/image/aisb.b8.lifesci_drug.svg
+++ b/AISB/image/aisb.b8.lifesci_drug.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B8 LifeSci Drug Discovery">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#12342f"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#a7f3d0" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#a7f3d0" opacity="0.12"/>
+  <text x="80" y="120" fill="#a7f3d0" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B8 LifeSci Drug Discovery</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">ADMET-only public-dev BenchStore pilot using five real TDC molecular-property endpoints.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#a7f3d0" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b9.material_science.svg
+++ b/AISB/image/aisb.b9.material_science.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="AISB B9 Material Science">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#2f2912"/>
+      <stop offset="1" stop-color="#0f172a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" rx="48" fill="url(#g)"/>
+  <circle cx="980" cy="110" r="210" fill="#fde68a" opacity="0.18"/>
+  <circle cx="180" cy="520" r="170" fill="#fde68a" opacity="0.12"/>
+  <text x="80" y="120" fill="#fde68a" font-family="Georgia, serif" font-size="42" font-weight="700">AISB BenchStore Pilot</text>
+  <text x="80" y="250" fill="#f8fafc" font-family="Georgia, serif" font-size="72" font-weight="700">AISB B9 Material Science</text>
+  <foreignObject x="80" y="305" width="900" height="180">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">Matbench Discovery WBM mini package for crystal-stability prediction validation.</div>
+  </foreignObject>
+  <text x="80" y="550" fill="#fde68a" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
+</svg>

--- a/AISB/image/aisb.b9.material_science.svg
+++ b/AISB/image/aisb.b9.material_science.svg
@@ -13,5 +13,4 @@
   <foreignObject x="80" y="305" width="900" height="180">
     <div xmlns="http://www.w3.org/1999/xhtml" style="font-family: Verdana, sans-serif; color: #f8fafc; font-size: 32px; line-height: 1.35;">Matbench Discovery WBM mini package for crystal-stability prediction validation.</div>
   </foreignObject>
-  <text x="80" y="550" fill="#fde68a" font-family="Verdana, sans-serif" font-size="28">release_ready=false · hidden references organizer-only</text>
 </svg>


### PR DESCRIPTION
## Summary

Adds 6 AISB (AI Scientist Benchmark) direction entries to the BenchStore catalog. Each entry is a complete, validated benchmark package with real public-dev data, evaluator, and baseline.

### Entries included

| Direction | Primary Benchmark | Data Scale | Evaluator Verified |
|---|---|---|---|
| B1 Agentic Coding | FeatureBench | 200 tasks | ✅ |
| B2 Agent Systems | tau2-bench airline | 50 tasks | ✅ |
| B3 Self-Evolving Agents | SWE-bench Pro | 731 tasks | ✅ |
| B5 Mathematical Proof | FormalMATH | 425 theorems | ✅ |
| B8 LifeSci Drug ⭐ | TDC ADMET 5-endpoint | 2,535 rows | ✅ score 0.6385 |
| B9 Material Science | Matbench Discovery WBM | 800 rows | ✅ score 0.8792 |

Each catalog YAML includes: benchmark metadata (primary + alternative benchmarks with SOTA values), paper highlights with arxiv URLs, NLPCC track mappings, launch profiles with setup skills and trial-error commands, resource requirements, and download URLs.

B8 (LifeSci Drug) is configured as the hero card: `featured: true`, `placement: hero`, `card_size: xl`, `recommendation_weight: 1000`.

### ⚠️ Release required after merge

This PR depends on the new fields in PR #80 (`homepage`, `discovery`, `display` extensions). After BOTH PRs are merged, please create a release with the 6 benchmark zip packages:

1. Go to https://github.com/ResearAI/DeepScientist/releases/new
2. Tag: `aisb-v0.1.0`
3. Title: `AISB v0.1.0 — 6 Benchmark Tool Packages`
4. Upload the 6 zip files (hosted temporarily at https://github.com/giao-123-sun/DeepScientist/releases/tag/aisb-v0.0.1):
   - aisb.b1.agentic_coding-v0.1.0.zip (32KB)
   - aisb.b2.agent_systems-v0.3.0.zip (21KB)
   - aisb.b3.self_evolving_rl-v0.1.0.zip (31KB)
   - aisb.b5.math_proof-v0.2.0.zip (24KB)
   - aisb.b8.lifesci_drug-v0.1.1.zip (36KB)
   - aisb.b9.material_science-v0.1.0.zip (22KB)
5. After release created, we will submit a follow-up PR updating `download.url` in all 6 catalog YAMLs to point to the official release URLs.

### Data policy

These are **tool-only packages** (~180KB total). AISB does NOT redistribute benchmark data. Each package includes a `data/README.md` pointing to the original benchmark source (HuggingFace/GitHub/GCS). The AI Scientist downloads the full benchmark data themselves.

### Files

- `AISB/catalog/aisb.b*.yaml` (6 catalog entries, ~60KB total)
- `AISB/image/aisb.b*.svg` (6 display cards)