### PR TITLE
fix: support multiple Feishu connections

### DIFF
--- a/docs/en/18_FEISHU_CONNECTOR_GUIDE.md
+++ b/docs/en/18_FEISHU_CONNECTOR_GUIDE.md
@@ -6,6 +6,7 @@ The current open-source runtime prefers the built-in long-connection path:
 
 - no public event callback is required for the recommended setup
 - the main credentials are `app_id` and `app_secret`
+- multiple Feishu app connections can be configured as separate `profiles`
 - direct messages can auto-bind to the latest active quest when enabled
 
 ## 1. What Feishu support includes
@@ -30,6 +31,10 @@ This means Feishu already fits the same quest-binding model as the other connect
 8. Save the connector.
 9. Send one real message to the bot.
 10. Return to DeepScientist and confirm that the target conversation has been discovered.
+
+For multiple Feishu apps, add one enabled entry per app under `profiles`. Each
+profile needs a unique `profile_id`, unique `app_id`, and its own `app_secret`
+or `app_secret_env`.
 
 ## 2.1 Settings page at a glance
 
@@ -63,6 +68,7 @@ Main fields:
 - `groups`
 - `require_mention_in_groups`
 - `auto_bind_dm_to_active_quest`
+- `profiles`
 
 For the full field reference, see [01 Settings Reference](./01_SETTINGS_REFERENCE.md).
 

--- a/docs/zh/18_FEISHU_CONNECTOR_GUIDE.md
+++ b/docs/zh/18_FEISHU_CONNECTOR_GUIDE.md
@@ -6,6 +6,7 @@
 
 - 不需要公网 event callback
 - 核心凭据是 `app_id` 和 `app_secret`
+- 可以把多个 Feishu 应用连接配置成独立的 `profiles`
 - 如果启用自动绑定，私聊可以自动跟随最新活跃 quest
 
 ## 1. Feishu 支持包含什么
@@ -31,6 +32,10 @@
 9. 给 bot 发送一条真实消息。
 10. 回到 DeepScientist，确认目标会话已经被自动发现。
 
+如果要连接多个 Feishu 应用，请在 `profiles` 下为每个应用添加一个启用项。
+每个 profile 都需要唯一的 `profile_id`、唯一的 `app_id`，以及自己的
+`app_secret` 或 `app_secret_env`。
+
 ## 3. 关键配置字段
 
 主要字段包括：
@@ -49,6 +54,7 @@
 - `groups`
 - `require_mention_in_groups`
 - `auto_bind_dm_to_active_quest`
+- `profiles`
 
 完整字段说明请参考 [01 设置参考](./01_SETTINGS_REFERENCE.md)。
 

--- a/src/deepscientist/bridges/connectors.py
+++ b/src/deepscientist/bridges/connectors.py
@@ -9,7 +9,7 @@ from hashlib import sha256
 from hmac import new as hmac_new
 from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request
 
 from ..network import urlopen_with_proxy as urlopen
@@ -164,6 +164,7 @@ class SlackConnectorBridge(BaseConnectorBridge):
 
 class FeishuConnectorBridge(BaseConnectorBridge):
     name = "feishu"
+    http_max_attempts = 3
 
     def parse_webhook(self, *, method: str, headers: dict[str, str], query: dict[str, list[str]], raw_body: bytes, body: dict[str, Any] | None, config: dict[str, Any]) -> BridgeWebhookResult:
         if method != "POST":
@@ -223,27 +224,98 @@ class FeishuConnectorBridge(BaseConnectorBridge):
         app_secret = self.read_secret(config, "app_secret", "app_secret_env")
         if not app_id or not app_secret:
             return None
-        token_request = Request(
-            "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
-            data=json.dumps({"app_id": app_id, "app_secret": app_secret}).encode("utf-8"),
-            method="POST",
+        token_result = self._request_json_with_retry(
+            lambda: self._json_request(
+                "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+                {"app_id": app_id, "app_secret": app_secret},
+            )
         )
-        token_request.add_header("Content-Type", "application/json; charset=utf-8")
-        with urlopen(token_request, timeout=8) as token_response:  # noqa: S310
-            token_payload = json.loads(token_response.read().decode("utf-8"))
+        if not token_result["ok"]:
+            return {
+                "ok": False,
+                "status_code": token_result.get("status_code"),
+                "response": str(token_result.get("response") or "")[:500],
+                "error": token_result.get("error"),
+                "retry_count": token_result.get("retry_count", 0),
+                "transport": "feishu-http",
+            }
+        token_payload = token_result["payload"] if isinstance(token_result.get("payload"), dict) else {}
         tenant_access_token = str(token_payload.get("tenant_access_token") or "").strip()
         if not tenant_access_token:
-            return {"ok": False, "status_code": token_response.status, "response": json.dumps(token_payload, ensure_ascii=False)[:500], "transport": "feishu-http"}
+            return {
+                "ok": False,
+                "status_code": token_result.get("status_code"),
+                "response": json.dumps(token_payload, ensure_ascii=False)[:500],
+                "retry_count": token_result.get("retry_count", 0),
+                "transport": "feishu-http",
+            }
+        message_result = self._request_json_with_retry(
+            lambda: self._json_request(
+                "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id",
+                self.format_outbound(payload, config),
+                headers={"Authorization": f"Bearer {tenant_access_token}"},
+            )
+        )
+        return {
+            "ok": bool(message_result.get("ok")) and 200 <= int(message_result.get("status_code") or 0) < 300,
+            "status_code": message_result.get("status_code"),
+            "response": str(message_result.get("response") or "")[:500],
+            "error": message_result.get("error"),
+            "retry_count": int(token_result.get("retry_count") or 0) + int(message_result.get("retry_count") or 0),
+            "transport": "feishu-http",
+        }
+
+    @staticmethod
+    def _json_request(url: str, body: dict[str, Any], *, headers: dict[str, str] | None = None) -> Request:
         request = Request(
-            "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id",
-            data=json.dumps(self.format_outbound(payload, config), ensure_ascii=False).encode("utf-8"),
+            url,
+            data=json.dumps(body, ensure_ascii=False).encode("utf-8"),
             method="POST",
         )
         request.add_header("Content-Type", "application/json; charset=utf-8")
-        request.add_header("Authorization", f"Bearer {tenant_access_token}")
-        with urlopen(request, timeout=8) as response:  # noqa: S310
-            response_text = response.read().decode("utf-8", errors="replace")
-            return {"ok": 200 <= response.status < 300, "status_code": response.status, "response": response_text[:500], "transport": "feishu-http"}
+        for key, value in (headers or {}).items():
+            request.add_header(key, value)
+        return request
+
+    def _request_json_with_retry(self, request_factory, *, timeout: int = 8) -> dict[str, Any]:  # noqa: ANN001
+        retry_count = 0
+        last_error = ""
+        for attempt in range(self.http_max_attempts):
+            try:
+                with urlopen(request_factory(), timeout=timeout) as response:  # noqa: S310
+                    response_text = response.read().decode("utf-8", errors="replace")
+                    try:
+                        payload = json.loads(response_text)
+                    except json.JSONDecodeError:
+                        payload = {}
+                    return {
+                        "ok": True,
+                        "status_code": response.status,
+                        "response": response_text,
+                        "payload": payload,
+                        "retry_count": retry_count,
+                    }
+            except (HTTPError, URLError, TimeoutError, OSError) as exc:
+                last_error = str(exc)
+                if attempt >= self.http_max_attempts - 1:
+                    return {
+                        "ok": False,
+                        "status_code": getattr(exc, "code", None),
+                        "response": "",
+                        "payload": {},
+                        "error": last_error,
+                        "retry_count": retry_count,
+                    }
+                retry_count += 1
+                time.sleep(min(0.2 * retry_count, 1.0))
+        return {
+            "ok": False,
+            "status_code": None,
+            "response": "",
+            "payload": {},
+            "error": last_error,
+            "retry_count": retry_count,
+        }
 
 
 class WhatsAppConnectorBridge(BaseConnectorBridge):

--- a/src/deepscientist/channels/feishu_long_connection.py
+++ b/src/deepscientist/channels/feishu_long_connection.py
@@ -13,6 +13,39 @@ from ..connector_runtime import format_conversation_id, parse_conversation_id
 from ..shared import read_json, utc_now, write_json
 
 
+class _ThreadLoopProxy:
+    """Thread-safe proxy for lark SDK module-level ``loop``.
+
+    The lark_oapi SDK stores a single module-level ``loop`` and all
+    ``Client`` instances call ``loop.create_task(...)`` on it.  When
+    DeepScientist runs multiple Feishu profiles each in its own thread
+    with its own event loop, the shared module variable becomes a race.
+    This proxy replaces the module attribute so every thread sees its
+    own loop.
+    """
+
+    def __init__(self) -> None:
+        self._loops: dict[int, asyncio.AbstractEventLoop] = {}
+
+    def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loops[threading.get_ident()] = loop
+
+    def _loop(self) -> asyncio.AbstractEventLoop:
+        loop = self._loops.get(threading.get_ident())
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        return loop
+
+    def create_task(self, coro: Any) -> asyncio.Task:
+        return self._loop().create_task(coro)
+
+    def run_until_complete(self, future: Any) -> Any:
+        return self._loop().run_until_complete(future)
+
+
+_feishu_loop_proxy = _ThreadLoopProxy()
+
+
 class _FeishuEventHandler:
     def __init__(self, service: "FeishuLongConnectionService") -> None:
         self.service = service
@@ -122,7 +155,7 @@ class FeishuLongConnectionService:
         loop = asyncio.new_event_loop()
         self._loop = loop
         asyncio.set_event_loop(loop)
-        client_module.loop = loop
+        _feishu_loop_proxy.set_loop(loop)
         stop_signal = asyncio.Event()
         self._async_stop = stop_signal
         app_id = str(self.config.get("app_id") or "").strip()
@@ -252,6 +285,8 @@ class FeishuLongConnectionService:
             enum_module = import_module("lark_oapi.core.enum")
         except ImportError:
             return None
+        if not isinstance(client_module.loop, _ThreadLoopProxy):
+            client_module.loop = _feishu_loop_proxy
         return {
             "client_module": client_module,
             "client_cls": getattr(client_module, "Client"),

--- a/src/deepscientist/config/service.py
+++ b/src/deepscientist/config/service.py
@@ -922,7 +922,7 @@ Use **Test** when the file exposes runtime dependencies.
                 },
             }
             if enabled and exists and live:
-                probe = self.probe_runner_bootstrap(name, persist=False, payload=normalized_payload)
+                probe = self.probe_runner_bootstrap(name, persist=True, payload=normalized_payload)
                 item["ok"] = bool(probe.get("ok"))
                 item["warnings"] = [*warnings, *list(probe.get("warnings") or [])]
                 item["errors"] = list(probe.get("errors") or [])
@@ -1039,14 +1039,34 @@ Use **Test** when the file exposes runtime dependencies.
                 if not str(config.get("login_user_id") or "").strip():
                     warnings.append("weixin: `login_user_id` is empty. Save the scanner user id after QR login for easier diagnostics.")
             elif name == "feishu":
-                has_app_id = bool(str(config.get("app_id") or "").strip())
-                has_app_secret = self._has_secret(config, "app_secret", "app_secret_env")
                 if transport != "long_connection":
                     errors.append("feishu: `transport` must stay `long_connection`.")
-                if not has_app_id:
-                    errors.append("feishu: `transport: long_connection` requires `app_id`.")
-                if not has_app_secret:
-                    errors.append("feishu: `transport: long_connection` requires `app_secret` or `app_secret_env`.")
+                profiles = list_connector_profiles("feishu", config)
+                if profiles:
+                    seen_profile_ids: set[str] = set()
+                    seen_app_ids: set[str] = set()
+                    for profile in profiles:
+                        profile_id = str(profile.get("profile_id") or "").strip() or "unknown"
+                        app_id = str(profile.get("app_id") or "").strip()
+                        if profile_id in seen_profile_ids:
+                            errors.append(f"feishu: duplicate profile_id `{profile_id}`.")
+                        else:
+                            seen_profile_ids.add(profile_id)
+                        if not app_id:
+                            errors.append(f"feishu[{profile_id}]: requires `app_id`.")
+                        elif app_id in seen_app_ids:
+                            errors.append(f"feishu: duplicate app_id `{app_id}` across profiles.")
+                        else:
+                            seen_app_ids.add(app_id)
+                        if not self._has_secret(profile, "app_secret", "app_secret_env"):
+                            errors.append(f"feishu[{profile_id}]: requires `app_secret` or `app_secret_env`.")
+                else:
+                    has_app_id = bool(str(config.get("app_id") or "").strip())
+                    has_app_secret = self._has_secret(config, "app_secret", "app_secret_env")
+                    if not has_app_id:
+                        errors.append("feishu: `transport: long_connection` requires `app_id`.")
+                    if not has_app_secret:
+                        errors.append("feishu: `transport: long_connection` requires `app_secret` or `app_secret_env`.")
             elif name == "whatsapp":
                 if transport != "local_session":
                     errors.append("whatsapp: `transport` must stay `local_session`.")

--- a/src/deepscientist/daemon/app.py
+++ b/src/deepscientist/daemon/app.py
@@ -7045,6 +7045,16 @@ class DaemonApp:
                 zh=f"正在启动 DeepScientist，当前会先恢复 `{quest_id}` 里停滞的运行，再继续处理您的新消息。",
                 en=f"DeepScientist is starting up. I’m recovering the stalled run in `{quest_id}` first, then I’ll continue with your new message.",
             )
+        if started or auto_resumed:
+            return self._polite_copy(
+                zh=f"已经成功收到消息，DeepScientist 已经启动并开始处理 `{quest_id}` 啦。",
+                en=f"Message received successfully. DeepScientist has started and is now processing `{quest_id}`.",
+            )
+        if queued:
+            return self._polite_copy(
+                zh=f"已经成功收到消息，`{quest_id}` 当前正在运行中，这条消息也已经排进队列了。",
+                en=f"Message received successfully. `{quest_id}` is already running, and this message has been queued.",
+            )
         if not ready and has_explicit_runner_failure:
             status_line = f" 当前状态：{readiness_summary}" if readiness_summary else ""
             return self._polite_copy(
@@ -7055,16 +7065,6 @@ class DaemonApp:
                     f"DeepScientist is still offline. Please check whether the bound {runner_label} can connect normally."
                     f"{(' Current status: ' + readiness_summary) if readiness_summary else ''}"
                 ),
-            )
-        if started or auto_resumed:
-            return self._polite_copy(
-                zh=f"已经成功收到消息，DeepScientist 已经启动并开始处理 `{quest_id}` 啦。",
-                en=f"Message received successfully. DeepScientist has started and is now processing `{quest_id}`.",
-            )
-        if queued:
-            return self._polite_copy(
-                zh=f"已经成功收到消息，`{quest_id}` 当前正在运行中，这条消息也已经排进队列了。",
-                en=f"Message received successfully. `{quest_id}` is already running, and this message has been queued.",
             )
         return self._polite_copy(
             zh=f"已经成功收到消息，我会继续推进 `{quest_id}` 并同步后续进展。",

--- a/src/deepscientist/doctor.py
+++ b/src/deepscientist/doctor.py
@@ -328,9 +328,9 @@ def _check_runner(config_manager: ConfigManager, runner_name: str) -> dict[str, 
         )
 
     probe = (
-        config_manager.probe_codex_bootstrap(persist=False, payload=runners_payload)
+        config_manager.probe_codex_bootstrap(persist=True, payload=runners_payload)
         if normalized_runner == "codex"
-        else config_manager.probe_runner_bootstrap(normalized_runner, persist=False, payload=runners_payload)
+        else config_manager.probe_runner_bootstrap(normalized_runner, persist=True, payload=runners_payload)
     )
     probe_errors = [str(value) for value in probe.get("errors") or []]
     probe_warnings = [str(value) for value in probe.get("warnings") or []]

--- a/tests/test_config_testing.py
+++ b/tests/test_config_testing.py
@@ -1664,6 +1664,99 @@ def test_saving_runners_profile_invalidates_cached_codex_bootstrap_state(temp_ho
     assert state["codex_last_result"]["summary"] == "Codex runner configuration changed. A new startup probe is required."
 
 
+def test_runner_live_config_test_persists_startup_probe_state(monkeypatch, temp_home: Path) -> None:
+    ensure_home_layout(temp_home)
+    manager = ConfigManager(temp_home)
+    manager.ensure_files()
+    runners = manager.load_named("runners")
+    for runner in runners.values():
+        if isinstance(runner, dict):
+            runner["enabled"] = False
+    runners["claude"]["enabled"] = True
+    runners["claude"]["binary"] = "claude"
+
+    monkeypatch.setattr(
+        "deepscientist.config.service.resolve_runner_binary",
+        lambda _binary, *, runner_name=None: f"/tmp/fake-{runner_name or 'runner'}",
+    )
+
+    probed: list[str] = []
+
+    def fake_probe(runner_name: str, *, persist: bool = False, payload=None):  # noqa: ANN001
+        probed.append(runner_name)
+        assert persist is True
+        if runner_name != "claude":
+            return {
+                "ok": True,
+                "summary": f"{runner_name} startup probe completed.",
+                "warnings": [],
+                "errors": [],
+                "details": {"checked_at": "2026-05-13T02:15:00+00:00"},
+            }
+        config = manager.load_named_normalized("config")
+        bootstrap = config.get("bootstrap") if isinstance(config.get("bootstrap"), dict) else {}
+        readiness = bootstrap.get("runner_readiness") if isinstance(bootstrap.get("runner_readiness"), dict) else {}
+        readiness["claude"] = {
+            "ready": True,
+            "last_checked_at": "2026-05-13T02:15:00+00:00",
+            "last_result": {
+                "ok": True,
+                "summary": "Claude Code startup probe completed.",
+                "warnings": [],
+                "errors": [],
+                "guidance": [],
+            },
+        }
+        bootstrap["runner_readiness"] = readiness
+        config["bootstrap"] = bootstrap
+        manager.save_named_payload("config", config)
+        return {
+            "ok": True,
+            "summary": "Claude Code startup probe completed.",
+            "warnings": [],
+            "errors": [],
+            "details": {"checked_at": "2026-05-13T02:15:00+00:00"},
+        }
+
+    monkeypatch.setattr(manager, "probe_runner_bootstrap", fake_probe)
+
+    result = manager._test_runners_payload(runners, live=True)
+    state = manager.runner_bootstrap_state("claude")
+
+    assert result["ok"] is True
+    assert "claude" in probed
+    assert state["ready"] is True
+    assert state["last_result"]["summary"] == "Claude Code startup probe completed."
+
+
+def test_feishu_profiles_validate_profile_credentials_without_top_level_secret(temp_home: Path) -> None:
+    ensure_home_layout(temp_home)
+    manager = ConfigManager(temp_home)
+    manager.ensure_files()
+    connectors = manager.load_named("connectors")
+    connectors["feishu"]["enabled"] = True
+    connectors["feishu"]["app_id"] = ""
+    connectors["feishu"]["app_secret"] = ""
+    connectors["feishu"]["profiles"] = [
+        {
+            "profile_id": "feishu-alpha",
+            "enabled": True,
+            "app_id": "cli_alpha",
+            "app_secret": "alpha-secret",
+        },
+        {
+            "profile_id": "feishu-beta",
+            "enabled": True,
+            "app_id": "cli_beta",
+            "app_secret": "beta-secret",
+        },
+    ]
+
+    result = manager._validate_connectors_payload(connectors)
+
+    assert result["errors"] == []
+
+
 def test_default_config_includes_deepxiv_defaults(temp_home: Path) -> None:
     ensure_home_layout(temp_home)
     manager = ConfigManager(temp_home)

--- a/tests/test_connector_profiles.py
+++ b/tests/test_connector_profiles.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from urllib.error import URLError
 
 import pytest
 
+from deepscientist.bridges.connectors import FeishuConnectorBridge
 from deepscientist.config import ConfigManager
 from deepscientist.config.models import default_connectors
 from deepscientist.connector.connector_profiles import (
@@ -568,6 +571,52 @@ def test_generic_relay_send_uses_profile_specific_credentials(
     assert captured_configs
     assert captured_configs[-1]["profile_id"] == "telegram-beta"
     assert captured_configs[-1]["bot_token"] == "beta-token"
+
+
+def test_feishu_delivery_retries_transient_urlopen_error(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class _Response:
+        def __init__(self, status: int, payload: dict) -> None:
+            self.status = status
+            self._payload = payload
+
+        def __enter__(self):  # noqa: ANN001
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):  # noqa: ANN001
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload, ensure_ascii=False).encode("utf-8")
+
+    def fake_urlopen(request, timeout=8):  # noqa: ANN001
+        url = str(getattr(request, "full_url", ""))
+        calls.append(url)
+        if len(calls) == 1:
+            raise URLError("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol")
+        if "tenant_access_token" in url:
+            return _Response(200, {"tenant_access_token": "tenant-token"})
+        return _Response(200, {"code": 0, "msg": "success"})
+
+    monkeypatch.setattr("deepscientist.bridges.connectors.urlopen", fake_urlopen)
+
+    result = FeishuConnectorBridge().deliver_direct(
+        {
+            "conversation_id": "feishu:direct:oc_123",
+            "text": "hello",
+            "attachments": [],
+        },
+        {
+            "app_id": "cli_xxx",
+            "app_secret": "secret",
+        },
+    )
+
+    assert result is not None
+    assert result["ok"] is True
+    assert result["retry_count"] == 1
+    assert len(calls) == 3
 
 
 def test_daemon_latest_connector_conversation_ids_reads_profile_runtime_files(temp_home: Path) -> None:

--- a/tests/test_feishu_long_connection.py
+++ b/tests/test_feishu_long_connection.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import sys
+from types import SimpleNamespace
 from pathlib import Path
 
 from deepscientist.channels.feishu_long_connection import FeishuLongConnectionService
@@ -8,6 +10,20 @@ from deepscientist.config import ConfigManager
 from deepscientist.daemon.app import DaemonApp
 from deepscientist.home import ensure_home_layout
 from deepscientist.shared import read_json, write_yaml
+
+
+def test_feishu_sdk_bundle_installs_thread_loop_proxy(monkeypatch) -> None:
+    client_module = SimpleNamespace(loop=object(), Client=object)
+    enum_module = SimpleNamespace(LogLevel=SimpleNamespace(INFO="info"))
+    monkeypatch.setitem(sys.modules, "lark_oapi.ws.client", client_module)
+    monkeypatch.setitem(sys.modules, "lark_oapi.core.enum", enum_module)
+
+    bundle = FeishuLongConnectionService._sdk_bundle()
+
+    assert bundle is not None
+    assert bundle["client_module"] is client_module
+    assert client_module.loop.__class__.__name__ == "_ThreadLoopProxy"
+    assert hasattr(client_module.loop, "create_task")
 
 
 def test_feishu_long_connection_reports_missing_sdk_dependency(temp_home: Path, monkeypatch) -> None:

--- a/tests/test_generic_connectors.py
+++ b/tests/test_generic_connectors.py
@@ -782,6 +782,60 @@ def test_generic_connector_ack_reports_stalled_startup(temp_home: Path, monkeypa
     assert "正在启动 DeepScientist" in str(response["reply"]["payload"]["text"] or "")
 
 
+def test_generic_connector_ack_prefers_started_state_over_stale_runner_readiness(
+    temp_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(temp_home / "user-home"))
+    ensure_home_layout(temp_home)
+    ConfigManager(temp_home).ensure_files()
+    _enable_system_connectors(temp_home, "whatsapp")
+    quest = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home)).create("stale readiness ack quest")
+    quest_id = quest["quest_id"]
+    app = DaemonApp(temp_home)
+    conversation_id = "whatsapp:direct:+15550006667"
+    channel = app._channel_with_bindings("whatsapp")
+    channel.bind_conversation(conversation_id, quest_id)
+    app.sessions.bind(quest_id, conversation_id)
+    app.quest_service.bind_source(quest_id, conversation_id)
+    monkeypatch.setattr(
+        app,
+        "submit_user_message",
+        lambda *args, **kwargs: {
+            "scheduled": True,
+            "started": True,
+            "queued": False,
+            "reason": "user_message",
+            "auto_resumed": False,
+        },
+    )
+    monkeypatch.setattr(app, "_runner_name_for", lambda snapshot: "claude")
+    monkeypatch.setattr(
+        app.config_manager,
+        "runner_bootstrap_state",
+        lambda runner_name: {
+            "runner": runner_name,
+            "ready": False,
+            "last_result": {"summary": "Claude Code runner configuration changed. A new startup probe is required."},
+        },
+    )
+
+    response = app.handle_connector_inbound(
+        "whatsapp",
+        {
+            "chat_type": "direct",
+            "sender_id": "+15550006667",
+            "sender_name": "Researcher",
+            "text": "Please continue.",
+        },
+    )
+
+    text_payload = str(response["reply"]["payload"]["text"] or "")
+    assert response["accepted"] is True
+    assert "已经成功收到消息" in text_payload
+    assert "DeepScientist 仍然不在线哟" not in text_payload
+
+
 def test_generic_connector_ack_reports_runner_offline(temp_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     ensure_home_layout(temp_home)
     ConfigManager(temp_home).ensure_files()


### PR DESCRIPTION
## Summary
- support multiple Feishu long-connection profiles without cross-thread event loop collisions
- validate Feishu profile credentials independently and retry transient Feishu HTTP delivery failures
- prevent stale runner readiness from overriding successful connector start/queue acknowledgements

## Tests
- HOME=/private/tmp/deepscientist-test-home runtime/python-env/bin/python -m pytest tests/test_feishu_long_connection.py::test_feishu_sdk_bundle_installs_thread_loop_proxy tests/test_connector_profiles.py::test_feishu_delivery_retries_transient_urlopen_error tests/test_config_testing.py::test_runner_live_config_test_persists_startup_probe_state tests/test_config_testing.py::test_feishu_profiles_validate_profile_credentials_without_top_level_secret tests/test_generic_connectors.py::test_generic_connector_ack_prefers_started_state_over_stale_runner_readiness
- runtime/python-env/bin/python -m compileall src/deepscientist
- git diff --check

Fixes #89