### PR TITLE
[Connector] Fix Discord outbound delivery blocked by Cloudflare 1010

### DIFF
--- a/src/deepscientist/bridges/connectors.py
+++ b/src/deepscientist/bridges/connectors.py
@@ -407,6 +407,7 @@ class DiscordConnectorBridge(BaseConnectorBridge):
         request = Request(f"https://discord.com/api/v10/channels/{channel_id}/messages", data=json.dumps(formatted, ensure_ascii=False).encode("utf-8"), method="POST")
         request.add_header("Content-Type", "application/json; charset=utf-8")
         request.add_header("Authorization", f"Bot {token}")
+        request.add_header("User-Agent", "DiscordBot (https://github.com/ResearAI/DeepScientist, 1.5.17)")
         with urlopen(request, timeout=8) as response:  # noqa: S310
             response_text = response.read().decode("utf-8", errors="replace")
             return {"ok": 200 <= response.status < 300, "status_code": response.status, "response": response_text[:500], "transport": "discord-http"}


### PR DESCRIPTION
## Summary

- `DiscordConnectorBridge.deliver_direct()` was missing a `User-Agent` header, causing Cloudflare (Discord's frontend) to block outbound requests with HTTP 403 / error code 1010
- Inbound messages via WebSocket gateway worked because `DiscordGatewayService._http_json()` already sets the correct User-Agent
- Adds `User-Agent: DiscordBot (https://github.com/ResearAI/DeepScientist, 1.5.17)` to match the gateway's existing header

## Why

Without a custom User-Agent, Python's `urllib` sends `Python-urllib/3.x` as the default, which Discord/Cloudflare blacklists. All outbound agent responses were silently dropped — recorded in `outbox.jsonl` with `"ok": false` but never surfaced to the user.

## Test plan

- [x] Direct API test: `urlopen` with User-Agent → HTTP 200 (message delivered)
- [x] Direct API test: `urlopen` without User-Agent → HTTP 403 / error code 1010
- [x] Full relay path test: `GenericRelayChannel.send()` through `_deliver_to_channel()` → `ok: True, status_code: 200` after fix
- [x] `pytest tests/test_connector_bridges.py` — 19 passed, no regressions
- [x] Restart daemon and verify agent responses appear in Discord end-to-end

Note: 1 pre-existing test failure in `test_config_testing.py` (unrelated codex runner probe test).

Closes: #94