### PR TITLE
[Runner] Make runner CLI deps optional and gate skill sync by enabled runners

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,8 @@
       "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-code": "^2.1.109",
-        "@openai/codex": "^0.114.0",
         "ink": "npm:@jrichman/ink@6.4.6",
         "ink-gradient": "^3.0.0",
-        "opencode-ai": "^1.14.28",
         "qrcode": "^1.5.4",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -28,6 +25,11 @@
       "engines": {
         "node": ">=18.18",
         "npm": ">=9"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code": "^2.1.109",
+        "@openai/codex": "^0.114.0",
+        "opencode-ai": "^1.14.28"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -48,6 +50,7 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.109.tgz",
       "integrity": "sha512-jVy1TcNWzFP/PFbrVfKYNSWoxXe4HJw7wjnZxR72S+X/kSG4Q1d1gVrUsr4Ej7udHBSaCiStqkOI0vGiy9aKlg==",
       "license": "SEE LICENSE IN README.md",
+      "optional": true,
       "bin": {
         "claude": "cli.js"
       },
@@ -375,6 +378,7 @@
       "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.114.0.tgz",
       "integrity": "sha512-HMo8LRR6CtfKkaa28xvFK6eOarmBFTDfsrS9GJtEoaspGGemFok494CpafDspiTZaHZZGHfSUe5SWTUxYq7OaA==",
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "codex": "bin/codex.js"
       },
@@ -1130,6 +1134,7 @@
       "integrity": "sha512-ZPukJNvujSVa+LVoXvj2ciUV57UcnuxmMtzpFQBYd6fbhjeT1vMC6jCurO/5mIp76fiPmGM7ilzRXVeY6bIwPw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "bin": {
         "opencode": "bin/opencode"
       },

--- a/package.json
+++ b/package.json
@@ -36,15 +36,17 @@
     "research": "bin/ds.js"
   },
   "dependencies": {
-    "@anthropic-ai/claude-code": "^2.1.109",
-    "@openai/codex": "^0.114.0",
     "ink": "npm:@jrichman/ink@6.4.6",
     "ink-gradient": "^3.0.0",
-    "opencode-ai": "^1.14.28",
     "qrcode": "^1.5.4",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "string-width": "^8.1.0"
+  },
+  "optionalDependencies": {
+    "@anthropic-ai/claude-code": "^2.1.109",
+    "@openai/codex": "^0.114.0",
+    "opencode-ai": "^1.14.28"
   },
   "scripts": {
     "ds": "node ./bin/ds.js",

--- a/src/deepscientist/daemon/app.py
+++ b/src/deepscientist/daemon/app.py
@@ -206,7 +206,7 @@ class DaemonApp:
         self.runtime_config = self.config_manager.load_runtime_config()
         self.runners_config = self.config_manager.load_runners_config()
         self.connectors_config = self.config_manager.load_named_normalized("connectors")
-        self.skill_installer = SkillInstaller(self.repo_root, home)
+        self.skill_installer = SkillInstaller(self.repo_root, home, runners_config=self.runners_config)
         self.quest_service = QuestService(home, skill_installer=self.skill_installer)
         self.latex_service = QuestLatexService(self.quest_service)
         self.memory_service = MemoryService(home)

--- a/src/deepscientist/skills/installer.py
+++ b/src/deepscientist/skills/installer.py
@@ -16,46 +16,63 @@ _PROMPT_VERSIONS_INDEX_FILENAME = "index.json"
 
 
 class SkillInstaller:
-    def __init__(self, repo_root: Path, home: Path) -> None:
+    def __init__(self, repo_root: Path, home: Path, runners_config: dict | None = None) -> None:
         self.repo_root = repo_root
         self.home = home
+        self.runners_config = runners_config or {}
+
+    def _is_runner_enabled(self, runner_name: str) -> bool:
+        runner = self.runners_config.get(runner_name, {})
+        return bool(runner.get("enabled", False))
 
     def discover(self):
         return discover_skill_bundles(self.repo_root)
 
     def sync_global(self) -> dict:
-        codex_root = ensure_dir(Path.home() / ".codex" / "skills")
-        claude_root = ensure_dir(Path.home() / ".claude" / "agents")
-        kimi_root = ensure_dir(Path.home() / ".kimi" / "skills")
-        opencode_root = ensure_dir(Path.home() / ".config" / "opencode" / "skills")
         copied_codex: list[str] = []
         copied_claude: list[str] = []
         copied_kimi: list[str] = []
         copied_opencode: list[str] = []
-        expected_codex: set[str] = set()
-        expected_claude: set[str] = set()
-        expected_kimi: set[str] = set()
-        expected_opencode: set[str] = set()
-        for bundle in self.discover():
-            target = codex_root / f"deepscientist-{bundle.skill_id}"
-            expected_codex.add(target.name)
-            self._sync_bundle_tree(bundle.root, target)
-            copied_codex.append(str(target))
-            claude_target = self._sync_claude_projection(bundle, claude_root)
-            expected_claude.add(claude_target.name)
-            copied_claude.append(str(claude_target))
-            kimi_target = kimi_root / f"deepscientist-{bundle.skill_id}"
-            expected_kimi.add(kimi_target.name)
-            self._sync_bundle_tree(bundle.root, kimi_target)
-            copied_kimi.append(str(kimi_target))
-            opencode_target = opencode_root / f"deepscientist-{bundle.skill_id}"
-            expected_opencode.add(opencode_target.name)
-            self._sync_bundle_tree(bundle.root, opencode_target)
-            copied_opencode.append(str(opencode_target))
-        self._prune_bundle_targets(codex_root, expected_codex)
-        self._prune_bundle_targets(claude_root, expected_claude)
-        self._prune_bundle_targets(kimi_root, expected_kimi)
-        self._prune_bundle_targets(opencode_root, expected_opencode)
+
+        if self._is_runner_enabled("codex"):
+            codex_root = ensure_dir(Path.home() / ".codex" / "skills")
+            expected_codex: set[str] = set()
+            for bundle in self.discover():
+                target = codex_root / f"deepscientist-{bundle.skill_id}"
+                expected_codex.add(target.name)
+                self._sync_bundle_tree(bundle.root, target)
+                copied_codex.append(str(target))
+            self._prune_bundle_targets(codex_root, expected_codex)
+
+        if self._is_runner_enabled("claude"):
+            claude_root = ensure_dir(Path.home() / ".claude" / "agents")
+            expected_claude: set[str] = set()
+            for bundle in self.discover():
+                claude_target = self._sync_claude_projection(bundle, claude_root)
+                expected_claude.add(claude_target.name)
+                copied_claude.append(str(claude_target))
+            self._prune_bundle_targets(claude_root, expected_claude)
+
+        if self._is_runner_enabled("kimi"):
+            kimi_root = ensure_dir(Path.home() / ".kimi" / "skills")
+            expected_kimi: set[str] = set()
+            for bundle in self.discover():
+                kimi_target = kimi_root / f"deepscientist-{bundle.skill_id}"
+                expected_kimi.add(kimi_target.name)
+                self._sync_bundle_tree(bundle.root, kimi_target)
+                copied_kimi.append(str(kimi_target))
+            self._prune_bundle_targets(kimi_root, expected_kimi)
+
+        if self._is_runner_enabled("opencode"):
+            opencode_root = ensure_dir(Path.home() / ".config" / "opencode" / "skills")
+            expected_opencode: set[str] = set()
+            for bundle in self.discover():
+                opencode_target = opencode_root / f"deepscientist-{bundle.skill_id}"
+                expected_opencode.add(opencode_target.name)
+                self._sync_bundle_tree(bundle.root, opencode_target)
+                copied_opencode.append(str(opencode_target))
+            self._prune_bundle_targets(opencode_root, expected_opencode)
+
         return {
             "codex": copied_codex,
             "claude": copied_claude,
@@ -67,38 +84,50 @@ class SkillInstaller:
     def sync_quest(self, quest_root: Path, *, installed_version: str | None = None) -> dict:
         prompt_sync = self.sync_quest_prompts(quest_root, installed_version=installed_version)
         prompts_root = ensure_dir(quest_root / ".codex" / "prompts")
-        codex_root = ensure_dir(quest_root / ".codex" / "skills")
-        claude_root = ensure_dir(quest_root / ".claude" / "agents")
-        kimi_root = ensure_dir(quest_root / ".kimi" / "skills")
-        opencode_root = ensure_dir(quest_root / ".opencode" / "skills")
         copied_codex: list[str] = []
         copied_claude: list[str] = []
         copied_kimi: list[str] = []
         copied_opencode: list[str] = []
-        expected_codex: set[str] = set()
-        expected_claude: set[str] = set()
-        expected_kimi: set[str] = set()
-        expected_opencode: set[str] = set()
-        for bundle in self.discover():
-            target = codex_root / f"deepscientist-{bundle.skill_id}"
-            expected_codex.add(target.name)
-            self._sync_bundle_tree(bundle.root, target)
-            copied_codex.append(str(target))
-            claude_target = self._sync_claude_projection(bundle, claude_root)
-            expected_claude.add(claude_target.name)
-            copied_claude.append(str(claude_target))
-            kimi_target = kimi_root / f"deepscientist-{bundle.skill_id}"
-            expected_kimi.add(kimi_target.name)
-            self._sync_bundle_tree(bundle.root, kimi_target)
-            copied_kimi.append(str(kimi_target))
-            opencode_target = opencode_root / f"deepscientist-{bundle.skill_id}"
-            expected_opencode.add(opencode_target.name)
-            self._sync_bundle_tree(bundle.root, opencode_target)
-            copied_opencode.append(str(opencode_target))
-        self._prune_bundle_targets(codex_root, expected_codex)
-        self._prune_bundle_targets(claude_root, expected_claude)
-        self._prune_bundle_targets(kimi_root, expected_kimi)
-        self._prune_bundle_targets(opencode_root, expected_opencode)
+
+        if self._is_runner_enabled("codex"):
+            codex_root = ensure_dir(quest_root / ".codex" / "skills")
+            expected_codex: set[str] = set()
+            for bundle in self.discover():
+                target = codex_root / f"deepscientist-{bundle.skill_id}"
+                expected_codex.add(target.name)
+                self._sync_bundle_tree(bundle.root, target)
+                copied_codex.append(str(target))
+            self._prune_bundle_targets(codex_root, expected_codex)
+
+        if self._is_runner_enabled("claude"):
+            claude_root = ensure_dir(quest_root / ".claude" / "agents")
+            expected_claude: set[str] = set()
+            for bundle in self.discover():
+                claude_target = self._sync_claude_projection(bundle, claude_root)
+                expected_claude.add(claude_target.name)
+                copied_claude.append(str(claude_target))
+            self._prune_bundle_targets(claude_root, expected_claude)
+
+        if self._is_runner_enabled("kimi"):
+            kimi_root = ensure_dir(quest_root / ".kimi" / "skills")
+            expected_kimi: set[str] = set()
+            for bundle in self.discover():
+                kimi_target = kimi_root / f"deepscientist-{bundle.skill_id}"
+                expected_kimi.add(kimi_target.name)
+                self._sync_bundle_tree(bundle.root, kimi_target)
+                copied_kimi.append(str(kimi_target))
+            self._prune_bundle_targets(kimi_root, expected_kimi)
+
+        if self._is_runner_enabled("opencode"):
+            opencode_root = ensure_dir(quest_root / ".opencode" / "skills")
+            expected_opencode: set[str] = set()
+            for bundle in self.discover():
+                opencode_target = opencode_root / f"deepscientist-{bundle.skill_id}"
+                expected_opencode.add(opencode_target.name)
+                self._sync_bundle_tree(bundle.root, opencode_target)
+                copied_opencode.append(str(opencode_target))
+            self._prune_bundle_targets(opencode_root, expected_opencode)
+
         return {
             "prompts": [str(path) for path in sorted(prompts_root.rglob("*")) if path.is_file()],
             "prompt_sync": prompt_sync,

--- a/src/deepscientist/skills/installer.py
+++ b/src/deepscientist/skills/installer.py
@@ -19,7 +19,15 @@ class SkillInstaller:
     def __init__(self, repo_root: Path, home: Path, runners_config: dict | None = None) -> None:
         self.repo_root = repo_root
         self.home = home
-        self.runners_config = runners_config or {}
+        self.runners_config = runners_config if isinstance(runners_config, dict) else self._load_runners_config()
+
+    def _load_runners_config(self) -> dict:
+        try:
+            from ..config import ConfigManager
+
+            return ConfigManager(self.home).load_runners_config()
+        except Exception:
+            return {}
 
     def _is_runner_enabled(self, runner_name: str) -> bool:
         runner = self.runners_config.get(runner_name, {})

--- a/tests/test_init_and_quest.py
+++ b/tests/test_init_and_quest.py
@@ -122,10 +122,10 @@ def test_new_creates_standalone_git_repo(temp_home: Path) -> None:
     assert (quest_root / ".codex" / "prompts" / "connectors" / "qq.md").exists()
     assert (quest_root / ".codex" / "skills").exists()
     assert (quest_root / ".claude" / "agents").exists()
-    assert (quest_root / ".claude" / "agents" / "deepscientist-decision.md").exists()
     assert (quest_root / ".kimi" / "skills").exists()
-    assert (quest_root / ".kimi" / "skills" / "deepscientist-decision" / "SKILL.md").exists()
     assert (quest_root / ".codex" / "skills" / "deepscientist-finalize" / "SKILL.md").exists()
+    assert sorted((quest_root / ".claude" / "agents").glob("deepscientist-*.md")) == []
+    assert sorted((quest_root / ".kimi" / "skills").glob("deepscientist-*")) == []
     assert snapshot["quest_id"] == "001"
     assert snapshot["runner"] == "codex"
     assert "paths" in snapshot
@@ -670,6 +670,25 @@ def test_init_command_syncs_global_skills(temp_home: Path, monkeypatch) -> None:
     assert calls == ["sync_global"]
 
 
+def test_skill_installer_defaults_to_home_runners_config(temp_home: Path) -> None:
+    ensure_home_layout(temp_home)
+    manager = ConfigManager(temp_home)
+    manager.ensure_files()
+    runners = manager.load_runners_config()
+    for runner in runners.values():
+        if isinstance(runner, dict):
+            runner["enabled"] = False
+    runners["claude"]["enabled"] = True
+    manager.save_named_payload("runners", runners)
+
+    installer = SkillInstaller(repo_root(), temp_home)
+
+    assert installer._is_runner_enabled("codex") is False
+    assert installer._is_runner_enabled("claude") is True
+    assert installer._is_runner_enabled("kimi") is False
+    assert installer._is_runner_enabled("opencode") is False
+
+
 def test_pause_command_prefers_daemon_control_when_available(temp_home: Path, monkeypatch, capsys) -> None:
     ensure_home_layout(temp_home)
     ConfigManager(temp_home).ensure_files()
@@ -738,6 +757,9 @@ def test_quest_create_uses_configured_default_runner(temp_home) -> None:  # type
     config = manager.load_named('config')
     config['default_runner'] = 'claude'
     write_yaml(manager.path_for('config'), config)
+    runners = manager.load_runners_config()
+    runners['claude']['enabled'] = True
+    manager.save_named_payload('runners', runners)
 
     service = QuestService(temp_home)
     snapshot = service.create('runner-default quest')

--- a/tests/test_stage_skills.py
+++ b/tests/test_stage_skills.py
@@ -272,7 +272,7 @@ def test_scout_skill_requires_memory_first_literature_report() -> None:
     assert template.exists()
 
 
-def test_quest_creation_syncs_all_stage_skills(temp_home: Path) -> None:
+def test_quest_creation_syncs_enabled_stage_skills(temp_home: Path) -> None:
     ensure_home_layout(temp_home)
     ConfigManager(temp_home).ensure_files()
     quest = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home)).create("skill sync quest")
@@ -289,16 +289,42 @@ def test_quest_creation_syncs_all_stage_skills(temp_home: Path) -> None:
     synced_opencode = {path.name.removeprefix("deepscientist-") for path in opencode_skills}
 
     assert EXPECTED_STAGE_SKILLS.issubset(synced_codex)
-    assert EXPECTED_STAGE_SKILLS.issubset(synced_claude)
-    assert EXPECTED_STAGE_SKILLS.issubset(synced_kimi)
-    assert EXPECTED_STAGE_SKILLS.issubset(synced_opencode)
     assert EXPECTED_COMPANION_SKILLS.issubset(synced_codex)
-    assert EXPECTED_COMPANION_SKILLS.issubset(synced_claude)
-    assert EXPECTED_COMPANION_SKILLS.issubset(synced_kimi)
-    assert EXPECTED_COMPANION_SKILLS.issubset(synced_opencode)
+    assert synced_claude == set()
+    assert synced_kimi == set()
+    assert synced_opencode == set()
     assert (quest_root / ".codex" / "prompts" / "system.md").exists()
     assert (quest_root / ".codex" / "prompts" / "contracts" / "shared_interaction.md").exists()
     assert (quest_root / ".codex" / "prompts" / "connectors" / "qq.md").exists()
+
+
+def test_quest_creation_syncs_only_configured_enabled_runner_skills(temp_home: Path) -> None:
+    ensure_home_layout(temp_home)
+    manager = ConfigManager(temp_home)
+    manager.ensure_files()
+    runners = manager.load_runners_config()
+    for runner in runners.values():
+        if isinstance(runner, dict):
+            runner["enabled"] = False
+    runners["claude"]["enabled"] = True
+    manager.save_named_payload("runners", runners)
+
+    quest = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home)).create("claude skill sync quest")
+    quest_root = Path(quest["quest_root"])
+
+    codex_skills = sorted((quest_root / ".codex" / "skills").glob("deepscientist-*"))
+    claude_skills = sorted((quest_root / ".claude" / "agents").glob("deepscientist-*.md"))
+    kimi_skills = sorted((quest_root / ".kimi" / "skills").glob("deepscientist-*"))
+    opencode_skills = sorted((quest_root / ".opencode" / "skills").glob("deepscientist-*"))
+
+    synced_claude = {path.stem.removeprefix("deepscientist-") for path in claude_skills}
+
+    assert codex_skills == []
+    assert EXPECTED_STAGE_SKILLS.issubset(synced_claude)
+    assert EXPECTED_COMPANION_SKILLS.issubset(synced_claude)
+    assert kimi_skills == []
+    assert opencode_skills == []
+    assert (quest_root / ".codex" / "prompts" / "system.md").exists()
 
 
 def test_skill_resync_repairs_frontmatter_and_removes_stale_files(temp_home: Path) -> None:
@@ -329,8 +355,28 @@ def test_skill_resync_repairs_frontmatter_and_removes_stale_files(temp_home: Pat
     assert "name:" in repaired
     assert not stale_file.exists()
     assert not stale_removed_codex.exists()
-    assert not stale_removed_claude.exists()
-    assert not stale_removed_kimi.exists()
+    assert stale_removed_claude.exists()
+    assert stale_removed_kimi.exists()
+
+
+def test_sync_quest_does_not_sync_disabled_runner_skills(temp_home: Path) -> None:
+    ensure_home_layout(temp_home)
+    manager = ConfigManager(temp_home)
+    manager.ensure_files()
+    runners = manager.load_runners_config()
+    for runner in runners.values():
+        if isinstance(runner, dict):
+            runner["enabled"] = False
+    runners["codex"]["enabled"] = True
+    manager.save_named_payload("runners", runners)
+
+    quest = QuestService(temp_home, skill_installer=SkillInstaller(repo_root(), temp_home)).create("disabled runner roots quest")
+    quest_root = Path(quest["quest_root"])
+
+    assert sorted((quest_root / ".codex" / "skills").glob("deepscientist-*"))
+    assert sorted((quest_root / ".claude" / "agents").glob("deepscientist-*.md")) == []
+    assert sorted((quest_root / ".kimi" / "skills").glob("deepscientist-*")) == []
+    assert sorted((quest_root / ".opencode" / "skills").glob("deepscientist-*")) == []
 
 
 def test_paper_reading_stage_skills_use_artifact_arxiv_and_legacy_skill_is_removed() -> None:


### PR DESCRIPTION
## Summary

- Move `@anthropic-ai/claude-code`, `@openai/codex`, and `opencode-ai` from `dependencies` to `optionalDependencies` so `npm install -g` does not abort when a runner CLI binary fails to install
- Gate `sync_global()` and `sync_quest()` behind `_is_runner_enabled()` checks so the daemon only creates skill directories for enabled runners
- Pass `runners_config` from `DaemonApp` to `SkillInstaller` so it knows which runners are enabled

## Why

The published v1.6.0 lists all runner CLIs as required dependencies. Their postinstall scripts download ~100MB platform-specific binaries, and when any fails, the entire install aborts — even for users who only use one runner. Additionally, `sync_global()` creates directories for all runners unconditionally, which can crash the daemon if a target directory is unwritable.

Closes #96

## Test plan

- [x] `npm pack --dry-run --ignore-scripts` succeeds with the new dependency layout
- [x] `SkillInstaller._is_runner_enabled()` correctly returns true/false based on config
- [x] `npm install -g` from the packed tarball succeeds even without runner CLIs
- [x] Daemon starts successfully with only one runner enabled
- [x] `ds doctor` passes with the changes