### PR TITLE
CRITICAL: Fix runaway CPU usage and React render loop on project workspace pages

### DIFF
--- a/src/ui/src/components/chat/toolViews/McpBashExecView.tsx
+++ b/src/ui/src/components/chat/toolViews/McpBashExecView.tsx
@@ -205,6 +205,33 @@ function isActiveBashStatus(status?: string | null) {
   return ['running', 'calling', 'pending', 'queued', 'starting', 'terminating'].includes(normalized)
 }
 
+function stableProgressKey(value: BashProgress | null) {
+  if (!value) return ''
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function progressEquals(left: BashProgress | null, right: BashProgress | null) {
+  return left === right || stableProgressKey(left) === stableProgressKey(right)
+}
+
+function buildLiveStateKey(args: {
+  status: BashSessionStatus | null
+  exitCode: number | null
+  stopReason: string
+  progress: BashProgress | null
+}) {
+  return [
+    args.status ?? '',
+    args.exitCode == null ? '' : String(args.exitCode),
+    args.stopReason,
+    stableProgressKey(args.progress),
+  ].join('\u0001')
+}
+
 const filterMarkerLines = (log: string) => {
   if (!log) return ''
   return log
@@ -496,6 +523,11 @@ function McpBashExecSessionView({
   const hasSnapshotRef = useRef(false)
   const initialLoadAttemptedRef = useRef(false)
   const snapshotTimerRef = useRef<number | null>(null)
+  const lastLiveStateKeyRef = useRef('')
+
+  const setProgressIfChanged = useCallback((nextProgress: BashProgress | null) => {
+    setProgress((current) => (progressEquals(current, nextProgress) ? current : nextProgress))
+  }, [])
 
   useEffect(() => {
     lastSeqRef.current = lastSeq
@@ -535,9 +567,9 @@ function McpBashExecSessionView({
   }, [isChatNearBottom, isInline])
 
   useEffect(() => {
-    setSessionStatus(initialStatus)
-    setExitCode(initialExitCode)
-    setStopReason(initialStopReason)
+    setSessionStatus((current) => (current === initialStatus ? current : initialStatus))
+    setExitCode((current) => (current === initialExitCode ? current : initialExitCode))
+    setStopReason((current) => (current === initialStopReason ? current : initialStopReason))
   }, [initialExitCode, initialStatus, initialStopReason, bashId])
 
   useEffect(() => {
@@ -559,7 +591,7 @@ function McpBashExecSessionView({
           setStopReason(session.stop_reason)
         }
         if (session.last_progress) {
-          setProgress(session.last_progress)
+          setProgressIfChanged(session.last_progress)
         }
       } catch {
         // Ignore session fetch errors; old events can still render from local payloads.
@@ -569,26 +601,40 @@ function McpBashExecSessionView({
     return () => {
       active = false
     }
-  }, [bashId, mode, projectId])
+  }, [bashId, mode, projectId, setProgressIfChanged])
 
   useEffect(() => {
     if (resolvedSession?.status) {
-      setSessionStatus(resolvedSession.status as BashSessionStatus)
+      setSessionStatus((current) =>
+        current === resolvedSession.status ? current : (resolvedSession.status as BashSessionStatus)
+      )
     }
     if (typeof resolvedSession?.exit_code === 'number') {
-      setExitCode(resolvedSession.exit_code)
+      setExitCode((current) => (current === resolvedSession.exit_code ? current : resolvedSession.exit_code))
     }
     if (typeof resolvedSession?.stop_reason === 'string') {
-      setStopReason(resolvedSession.stop_reason)
+      setStopReason((current) =>
+        current === resolvedSession.stop_reason ? current : resolvedSession.stop_reason
+      )
     }
   }, [resolvedSession?.exit_code, resolvedSession?.status, resolvedSession?.stop_reason])
 
   useEffect(() => {
-    setProgress(null)
+    setProgressIfChanged(null)
     setFallbackOutput('')
-  }, [bashId, mode])
+  }, [bashId, mode, setProgressIfChanged])
 
   useEffect(() => {
+    const nextKey = buildLiveStateKey({
+      status: sessionStatus,
+      exitCode,
+      stopReason,
+      progress,
+    })
+    if (lastLiveStateKeyRef.current === nextKey) {
+      return
+    }
+    lastLiveStateKeyRef.current = nextKey
     onLiveStateChange?.({
       status: sessionStatus,
       exitCode,
@@ -606,9 +652,9 @@ function McpBashExecSessionView({
         : null
     const nextProgress = fromResult ?? resolvedSession?.last_progress ?? null
     if (nextProgress) {
-      setProgress(nextProgress)
+      setProgressIfChanged(nextProgress)
     }
-  }, [resolvedSession?.last_progress, resultPayload])
+  }, [resolvedSession?.last_progress, resultPayload, setProgressIfChanged])
 
   useEffect(() => {
     if (!projectId || !preferBashTerminalRender) return
@@ -665,15 +711,15 @@ function McpBashExecSessionView({
       if (isBashProgressMarker(line)) {
         const nextProgress = parseBashProgressMarker(line)
         if (nextProgress) {
-          setProgress(nextProgress)
+          setProgressIfChanged(nextProgress)
         }
         return
       }
       const marker = parseBashStatusMarker(line)
       if (marker) {
-        setSessionStatus(marker.status)
-        setExitCode(marker.exitCode)
-        setStopReason(marker.reason)
+        setSessionStatus((current) => (current === marker.status ? current : marker.status))
+        setExitCode((current) => (current === marker.exitCode ? current : marker.exitCode))
+        setStopReason((current) => (current === marker.reason ? current : marker.reason))
         return
       }
       const parsed = splitBashLogLine(line)
@@ -683,7 +729,7 @@ function McpBashExecSessionView({
       }
       appendToTerminal(`${parsed.text}\n`)
     },
-    [appendToTerminal]
+    [appendToTerminal, setProgressIfChanged]
   )
 
   const handleSnapshot = useCallback(
@@ -713,7 +759,7 @@ function McpBashExecSessionView({
         setLogTruncated(false)
       }
       if (event.progress) {
-        setProgress(event.progress)
+        setProgressIfChanged(event.progress)
       }
       let maxSeq: number | null = latestSeq ?? null
       event.lines?.forEach((line) => {
@@ -726,7 +772,7 @@ function McpBashExecSessionView({
         setLastSeq(maxSeq)
       }
     },
-    [appendToTerminal, command, handleLogLine, resetTerminal, workdir]
+    [appendToTerminal, command, handleLogLine, resetTerminal, setProgressIfChanged, workdir]
   )
 
   const handleLogBatch = useCallback(
@@ -871,7 +917,7 @@ function McpBashExecSessionView({
     onSnapshot: handleSnapshot,
     onLogBatch: handleLogBatch,
     onProgress: (event) => {
-      setProgress(event)
+      setProgressIfChanged(event)
     },
     onLog: (event) => {
       hasSnapshotRef.current = true
@@ -900,10 +946,12 @@ function McpBashExecSessionView({
     },
     onDone: (event) => {
       if (event?.status) {
-        setSessionStatus(event.status as BashSessionStatus)
+        setSessionStatus((current) =>
+          current === event.status ? current : (event.status as BashSessionStatus)
+        )
       }
       if (typeof event?.exit_code === 'number') {
-        setExitCode(event.exit_code)
+        setExitCode((current) => (current === event.exit_code ? current : event.exit_code))
       }
     },
   })

--- a/src/ui/src/components/workspace/CopilotDockOverlay.tsx
+++ b/src/ui/src/components/workspace/CopilotDockOverlay.tsx
@@ -13,7 +13,6 @@ import type {
 import OrbitLogoStatus from '@/lib/plugins/ai-manus/components/OrbitLogoStatus'
 import type { ChatSurface } from '@/lib/types/chat-events'
 import { Noise } from '@/components/react-bits'
-import RotatingText from '@/components/RotatingText'
 import { cn } from '@/lib/utils'
 import { COPILOT_FILES_ENABLED } from '@/lib/feature-flags'
 import {
@@ -680,6 +679,15 @@ export function CopilotDockOverlay({
     setCopilotMeta((prev) => (isCopilotMetaEqual(prev, next) ? prev : next))
   }, [])
 
+  const dockCallbacksValue = React.useMemo(
+    () => ({
+      onActionsChange: handleActionsChange,
+      onMetaChange: handleMetaChange,
+      onHeaderExtraChange: setHeaderExtraContent,
+    }),
+    [handleActionsChange, handleMetaChange]
+  )
+
   const logHistoryToggle = React.useCallback((next: boolean) => {
     if (typeof window === 'undefined') return
     if (process.env.NODE_ENV !== 'production' || window.localStorage.getItem('ds_debug_copilot') === '1') {
@@ -826,7 +834,7 @@ export function CopilotDockOverlay({
       : [statusText]
     : []
   const showStatus = statusTexts.length > 0
-  const statusAnimate = statusTexts.length > 1
+  const visibleStatusText = statusTexts[statusTexts.length - 1] || ''
   const historyOpen = historyOpenOverride
   const headerOrbitResetKey = `${copilotMeta?.threadId ?? projectId}:${copilotMeta?.statusKey ?? 0}:${
     copilotMeta?.isResponding ? 'busy' : 'idle'
@@ -953,7 +961,7 @@ export function CopilotDockOverlay({
       >
         <div className="relative h-full w-full overflow-hidden rounded-[18px]">
           <div className="ds-copilot-glass">
-            <Noise size={260} className="ds-copilot-noise opacity-[0.06]" />
+            <Noise size={260} animated={false} className="ds-copilot-noise opacity-[0.06]" />
 
             <div className="ds-copilot-glass-inner">
               <div className="ds-copilot-header" onPointerDown={handleHeaderDrag}>
@@ -981,33 +989,14 @@ export function CopilotDockOverlay({
                         {showStatus ? (
                           <>
                             <span className="ds-copilot-title-sep">·</span>
-                            <RotatingText
-                              key={`copilot-status-${statusKey}`}
-                              texts={statusTexts}
-                              auto={statusAnimate}
-                              loop={false}
-                              rotationInterval={1200}
-                              staggerFrom="last"
-                              staggerDuration={0.02}
-                              initial={{ y: '90%', opacity: 0 }}
-                              animate={{ y: 0, opacity: 1 }}
-                              exit={{ y: '-120%', opacity: 0 }}
-                              animatePresenceInitial
-                              maxWords={14}
-                              mainClassName="ds-copilot-status-text"
-                              splitLevelClassName="ds-copilot-status-text-split"
-                              elementLevelClassName="ds-copilot-status-text-element"
-                            />
+                            <span className="ds-copilot-status-text">{visibleStatusText}</span>
                           </>
                         ) : null}
                       </div>
                       {headerBadges.length > 0 ? (
-                        <motion.div
+                        <div
                           data-testid="copilot-header-badges"
                           className="ds-copilot-header-badges"
-                          initial={prefersReducedMotion ? false : { opacity: 0, y: 4 }}
-                          animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
-                          transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
                         >
                           {headerBadges.map((badge) => (
                             <span
@@ -1018,7 +1007,7 @@ export function CopilotDockOverlay({
                               {badge.label}
                             </span>
                           ))}
-                        </motion.div>
+                        </div>
                       ) : null}
                     </div>
                   </div>
@@ -1101,11 +1090,7 @@ export function CopilotDockOverlay({
                 <div className="ds-copilot-chat">
                   <CopilotDockHeaderPortalContext.Provider value={headerPortalEl}>
                     <CopilotDockCallbacksContext.Provider
-                      value={{
-                        onActionsChange: handleActionsChange,
-                        onMetaChange: handleMetaChange,
-                        onHeaderExtraChange: setHeaderExtraContent,
-                      }}
+                      value={dockCallbacksValue}
                     >
                       {hasCustomBody ? (
                         bodyContent

--- a/src/ui/src/components/workspace/QuestBashExecOperation.tsx
+++ b/src/ui/src/components/workspace/QuestBashExecOperation.tsx
@@ -14,6 +14,7 @@ import { McpBashExecView } from '@/components/chat/toolViews/McpBashExecView'
 import { useI18n } from '@/lib/i18n/useI18n'
 import type { ToolContent } from '@/lib/plugins/ai-manus/types'
 import type { EventMetadata } from '@/lib/types/chat-events'
+import type { BashExecLiveState } from '@/components/chat/toolViews/types'
 import type { BashProgress } from '@/lib/types/bash'
 import { formatProgressLabel, formatProgressMeta, getProgressPercent } from '@/lib/utils/bash-progress'
 import { cn } from '@/lib/utils'
@@ -161,7 +162,20 @@ function formatPercentLabel(value: number | null) {
   return Number.isInteger(rounded) ? `${rounded.toFixed(0)}%` : `${rounded.toFixed(1)}%`
 }
 
-export function QuestBashExecOperation({
+function stableProgressKey(value: BashProgress | null) {
+  if (!value) return ''
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function progressEquals(left: BashProgress | null, right: BashProgress | null) {
+  return left === right || stableProgressKey(left) === stableProgressKey(right)
+}
+
+export const QuestBashExecOperation = React.memo(function QuestBashExecOperation({
   questId,
   itemId,
   toolCallId,
@@ -196,9 +210,9 @@ export function QuestBashExecOperation({
   const { t } = useI18n('workspace')
   const timestamp = createdAt ? Date.parse(createdAt) : Date.now()
   const resolvedTimestamp = Number.isFinite(timestamp) ? timestamp : Date.now()
-  const parsedArgs = asRecord(parseStructuredValue(args))
-  const parsedOutput = extractBashResult(output)
-  const initialProgress = extractInitialProgress(parsedOutput)
+  const parsedArgs = React.useMemo(() => asRecord(parseStructuredValue(args)), [args])
+  const parsedOutput = React.useMemo(() => extractBashResult(output), [output])
+  const initialProgress = React.useMemo(() => extractInitialProgress(parsedOutput), [parsedOutput])
   const mode = typeof parsedArgs?.mode === 'string' ? parsedArgs.mode.trim().toLowerCase() : ''
   const command =
     typeof parsedArgs?.command === 'string'
@@ -231,26 +245,26 @@ export function QuestBashExecOperation({
           ? parsedArgs.id
         : ''
   const exitCode = typeof parsedOutput?.exit_code === 'number' ? parsedOutput.exit_code : null
-  const [liveProgress, setLiveProgress] = React.useState<BashProgress | null>(initialProgress)
-  const [liveStatus, setLiveStatus] = React.useState<string | null>(
+  const initialStatus =
     typeof parsedOutput?.status === 'string' ? parsedOutput.status : typeof status === 'string' ? status : null
-  )
+  const initialStopReason = typeof parsedOutput?.stop_reason === 'string' ? parsedOutput.stop_reason : ''
+  const [liveProgress, setLiveProgress] = React.useState<BashProgress | null>(initialProgress)
+  const [liveStatus, setLiveStatus] = React.useState<string | null>(initialStatus)
   const [liveExitCode, setLiveExitCode] = React.useState<number | null>(exitCode)
-  const [liveStopReason, setLiveStopReason] = React.useState<string>(
-    typeof parsedOutput?.stop_reason === 'string' ? parsedOutput.stop_reason : ''
-  )
+  const [liveStopReason, setLiveStopReason] = React.useState<string>(initialStopReason)
+  const setLiveProgressIfChanged = React.useCallback((nextProgress: BashProgress | null) => {
+    setLiveProgress((current) => (progressEquals(current, nextProgress) ? current : nextProgress))
+  }, [])
 
   React.useEffect(() => {
-    setLiveProgress(initialProgress)
-  }, [initialProgress, bashId])
+    setLiveProgressIfChanged(initialProgress)
+  }, [initialProgress, bashId, setLiveProgressIfChanged])
 
   React.useEffect(() => {
-    setLiveStatus(
-      typeof parsedOutput?.status === 'string' ? parsedOutput.status : typeof status === 'string' ? status : null
-    )
-    setLiveExitCode(exitCode)
-    setLiveStopReason(typeof parsedOutput?.stop_reason === 'string' ? parsedOutput.stop_reason : '')
-  }, [bashId, exitCode, parsedOutput, status])
+    setLiveStatus((current) => (current === initialStatus ? current : initialStatus))
+    setLiveExitCode((current) => (current === exitCode ? current : exitCode))
+    setLiveStopReason((current) => (current === initialStopReason ? current : initialStopReason))
+  }, [bashId, exitCode, initialStatus, initialStopReason])
 
   const rawStatus = String(
     liveStatus ||
@@ -343,37 +357,53 @@ export function QuestBashExecOperation({
     }
   }, [isLatest, isRunning, shouldAutoExpandRunning])
 
-  const eventMetadata: EventMetadata = {
-    surface: 'copilot',
-    quest_id: questId,
-    session_id:
-      typeof metadata?.session_id === 'string' && metadata.session_id.trim()
-        ? metadata.session_id
-        : `quest:${questId}`,
-    sender_type: 'agent',
-    sender_label: 'DeepScientist',
-    sender_name: 'DeepScientist',
-    ...(metadata as EventMetadata | undefined),
-  }
+  const eventMetadata = React.useMemo<EventMetadata>(
+    () => ({
+      surface: 'copilot',
+      quest_id: questId,
+      session_id:
+        typeof metadata?.session_id === 'string' && metadata.session_id.trim()
+          ? metadata.session_id
+          : `quest:${questId}`,
+      sender_type: 'agent',
+      sender_label: 'DeepScientist',
+      sender_name: 'DeepScientist',
+      ...(metadata as EventMetadata | undefined),
+    }),
+    [metadata, questId]
+  )
 
-  const toolContent: ToolContent = {
-    event_id: itemId,
-    timestamp: resolvedTimestamp,
-    tool_call_id: toolCallId || itemId,
-    name: toolName || 'bash_exec',
-    function: 'mcp__bash_exec__bash_exec',
-    status: label === 'tool_call' ? 'calling' : 'called',
-    args: parsedArgs ?? (args ? { raw: args } : {}),
-    content:
-      label === 'tool_result'
-        ? {
-            ...(parsedOutput ? { result: parsedOutput } : {}),
-            ...(output && !parsedOutput ? { text: output } : {}),
-            ...(status ? { status } : {}),
-          }
-        : {},
-    metadata: eventMetadata,
-  }
+  const toolContent = React.useMemo<ToolContent>(
+    () => ({
+      event_id: itemId,
+      timestamp: resolvedTimestamp,
+      tool_call_id: toolCallId || itemId,
+      name: toolName || 'bash_exec',
+      function: 'mcp__bash_exec__bash_exec',
+      status: label === 'tool_call' ? 'calling' : 'called',
+      args: parsedArgs ?? (args ? { raw: args } : {}),
+      content:
+        label === 'tool_result'
+          ? {
+              ...(parsedOutput ? { result: parsedOutput } : {}),
+              ...(output && !parsedOutput ? { text: output } : {}),
+              ...(status ? { status } : {}),
+            }
+          : {},
+      metadata: eventMetadata,
+    }),
+    [args, eventMetadata, itemId, label, output, parsedArgs, parsedOutput, resolvedTimestamp, status, toolCallId, toolName]
+  )
+
+  const handleLiveStateChange = React.useCallback(
+    (state: BashExecLiveState) => {
+      setLiveProgressIfChanged(state.progress)
+      setLiveStatus((current) => (current === state.status ? current : state.status))
+      setLiveExitCode((current) => (current === state.exitCode ? current : state.exitCode))
+      setLiveStopReason((current) => (current === state.stopReason ? current : state.stopReason))
+    },
+    [setLiveProgressIfChanged]
+  )
 
   return (
     <article
@@ -471,18 +501,13 @@ export function QuestBashExecOperation({
               panelMode="inline"
               chrome="bare"
               preferBashTerminalRender
-              onLiveStateChange={(state) => {
-                setLiveProgress(state.progress)
-                setLiveStatus(state.status)
-                setLiveExitCode(state.exitCode)
-                setLiveStopReason(state.stopReason)
-              }}
+              onLiveStateChange={handleLiveStateChange}
             />
           </div>
         </div>
       ) : null}
     </article>
   )
-}
+})
 
 export default QuestBashExecOperation

--- a/src/ui/src/components/workspace/QuestCopilotDockPanel.tsx
+++ b/src/ui/src/components/workspace/QuestCopilotDockPanel.tsx
@@ -33,6 +33,11 @@ function isParkedCopilotWorkspace(workspace: QuestWorkspaceState) {
   const continuationPolicy = String(snapshot?.continuation_policy || '').trim().toLowerCase()
   const activeRunId = String(snapshot?.active_run_id || '').trim()
   const bashRunningCount = Number(snapshot?.counts?.bash_running_count || 0)
+  const runtimeStatus = String(snapshot?.runtime_status || snapshot?.status || '').trim().toLowerCase()
+  const latestActivityRaw = String(snapshot?.last_tool_activity_at || snapshot?.updated_at || '').trim()
+  const latestActivityMs = latestActivityRaw ? Date.parse(latestActivityRaw) : Number.NaN
+  const staleWaitingState =
+    Number.isFinite(latestActivityMs) && Date.now() - latestActivityMs > 90_000
   const latestBashSession =
     snapshot?.summary?.latest_bash_session &&
     typeof snapshot.summary.latest_bash_session === 'object' &&
@@ -51,9 +56,10 @@ function isParkedCopilotWorkspace(workspace: QuestWorkspaceState) {
     !workspace.loading &&
     !workspace.restoring &&
     !workspace.error &&
-    (bashRunningCount === 0 ||
-      (bashRunningCount === 1 &&
-        latestBashKind === 'terminal' &&
+    (runtimeStatus !== 'running' || staleWaitingState) &&
+    (staleWaitingState ||
+      bashRunningCount === 0 ||
+      (latestBashKind === 'terminal' &&
         (latestBashId === '' || latestBashId === 'terminal-main')))
   )
 }

--- a/src/ui/src/components/workspace/QuestStudioDirectTimeline.tsx
+++ b/src/ui/src/components/workspace/QuestStudioDirectTimeline.tsx
@@ -220,7 +220,7 @@ function StudioInlineFileText({
 }: {
   questId: string
   content: string
-  onOpenFile: (href: string) => void
+  onOpenFile: (href: string) => void | Promise<unknown>
 }) {
   const parts: Array<{ kind: 'text' | 'file'; value: string }> = []
   let lastIndex = 0
@@ -283,7 +283,7 @@ function StudioInlineFileText({
   )
 }
 
-function StudioMessageBlock({
+const StudioMessageBlock = React.memo(function StudioMessageBlock({
   block,
   questId,
   markdownComponents,
@@ -292,7 +292,7 @@ function StudioMessageBlock({
   block: Extract<StudioTurnBlock, { kind: 'message' }>
   questId: string
   markdownComponents?: Components
-  onOpenFile: (href: string) => void
+  onOpenFile: (href: string) => void | Promise<unknown>
 }) {
   return (
     <div className="min-w-0 overflow-hidden pl-0.5">
@@ -314,9 +314,9 @@ function StudioMessageBlock({
       )}
     </div>
   )
-}
+})
 
-function StudioReasoningBlock({
+const StudioReasoningBlock = React.memo(function StudioReasoningBlock({
   block,
   markdownComponents,
 }: {
@@ -361,7 +361,7 @@ function StudioReasoningBlock({
       </div>
     </details>
   )
-}
+})
 
 function isBashExecOperation(block: Extract<StudioTurnBlock, { kind: 'operation' }>) {
   const identity = deriveMcpIdentity(
@@ -372,7 +372,7 @@ function isBashExecOperation(block: Extract<StudioTurnBlock, { kind: 'operation'
   return identity.server === 'bash_exec'
 }
 
-function StudioOperationBlock({
+const StudioOperationBlock = React.memo(function StudioOperationBlock({
   questId,
   block,
   isLatestOperation,
@@ -404,9 +404,9 @@ function StudioOperationBlock({
     )
   }
   return <StudioToolCard questId={questId} item={block.item} isLatest={isLatestOperation} />
-}
+})
 
-function StudioArtifactBlock({ block }: { block: Extract<StudioTurnBlock, { kind: 'artifact' }> }) {
+const StudioArtifactBlock = React.memo(function StudioArtifactBlock({ block }: { block: Extract<StudioTurnBlock, { kind: 'artifact' }> }) {
   const { t } = useI18n('workspace')
   const item = block.item
   const detailEntries = Object.entries(item.details ?? {}).filter(([, value]) => value != null && value !== '')
@@ -453,9 +453,9 @@ function StudioArtifactBlock({ block }: { block: Extract<StudioTurnBlock, { kind
       ) : null}
     </div>
   )
-}
+})
 
-function StudioEventBlock({ block }: { block: Extract<StudioTurnBlock, { kind: 'event' }> }) {
+const StudioEventBlock = React.memo(function StudioEventBlock({ block }: { block: Extract<StudioTurnBlock, { kind: 'event' }> }) {
   const item = block.item
   const label = humanizeEventLabel(item.label)
   const text = [label, item.content ? item.content.trim() : ''].filter(Boolean).join(' · ')
@@ -465,18 +465,20 @@ function StudioEventBlock({ block }: { block: Extract<StudioTurnBlock, { kind: '
       <span className="truncate">{text}</span>
     </div>
   )
-}
+})
 
-function AssistantTurn({
+const AssistantTurn = React.memo(function AssistantTurn({
   questId,
   turn,
   latestOperationId,
   markdownComponents,
+  onOpenFile,
 }: {
   questId: string
   turn: StudioTurn
   latestOperationId: string | null
   markdownComponents?: Components
+  onOpenFile: (href: string) => void | Promise<unknown>
 }) {
   const hasStreamingMessage = turn.blocks.some(
     (block) =>
@@ -508,9 +510,7 @@ function AssistantTurn({
                 block={block}
                 questId={questId}
                 markdownComponents={markdownComponents}
-                onOpenFile={(href) => {
-                  void handleOpenStudioFile(href)
-                }}
+                onOpenFile={onOpenFile}
               />
             )
           }
@@ -537,9 +537,9 @@ function AssistantTurn({
       </div>
     </div>
   )
-}
+})
 
-function UserTurn({
+const UserTurn = React.memo(function UserTurn({
   turn,
   markdownComponents,
   onReadNow,
@@ -591,9 +591,9 @@ function UserTurn({
       </div>
     </div>
   )
-}
+})
 
-function SystemTurn({ turn }: { turn: StudioTurn }) {
+const SystemTurn = React.memo(function SystemTurn({ turn }: { turn: StudioTurn }) {
   return (
     <div className="flex justify-center">
       <div className="space-y-2">
@@ -603,9 +603,9 @@ function SystemTurn({ turn }: { turn: StudioTurn }) {
       </div>
     </div>
   )
-}
+})
 
-export function QuestStudioDirectTimeline({
+export const QuestStudioDirectTimeline = React.memo(function QuestStudioDirectTimeline({
   questId,
   feed,
   loading,
@@ -834,6 +834,7 @@ export function QuestStudioDirectTimeline({
                     turn={turn}
                     latestOperationId={latestOperationId}
                     markdownComponents={markdownComponents}
+                    onOpenFile={handleOpenStudioFile}
                   />
                 )
               })
@@ -843,6 +844,6 @@ export function QuestStudioDirectTimeline({
       </ChatScrollProvider>
     </div>
   )
-}
+})
 
 export default QuestStudioDirectTimeline

--- a/src/ui/src/components/workspace/WorkspaceLayout.tsx
+++ b/src/ui/src/components/workspace/WorkspaceLayout.tsx
@@ -4113,20 +4113,20 @@ export function WorkspaceLayout({
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
         <div
           className={cn(
-            'absolute -top-40 -left-40 h-[560px] w-[560px] rounded-full blur-3xl animate-blob',
+            'absolute -top-40 -left-40 h-[560px] w-[560px] rounded-full blur-3xl',
             'bg-[radial-gradient(circle_at_center,rgba(143,163,184,0.16),transparent_72%)]',
             'dark:bg-[radial-gradient(circle_at_center,rgba(143,163,184,0.16),transparent_72%)]'
           )}
         />
         <div
           className={cn(
-            'absolute top-10 -right-52 h-[640px] w-[640px] rounded-full blur-3xl animate-blob',
+            'absolute top-10 -right-52 h-[640px] w-[640px] rounded-full blur-3xl',
             'bg-[radial-gradient(circle_at_center,rgba(47,52,55,0.08),transparent_72%)]',
             'dark:bg-[radial-gradient(circle_at_center,rgba(47,52,55,0.10),transparent_72%)]'
           )}
           style={{ animationDelay: '1.5s' }}
         />
-        <Noise size={260} className="opacity-[0.04] dark:opacity-[0.05]" />
+        <Noise size={260} animated={false} className="opacity-[0.04] dark:opacity-[0.05]" />
       </div>
 
       <div className={cn('workspace-navbar-shell', navbarCollapsed && 'is-collapsed')}>

--- a/src/ui/src/lib/acp.ts
+++ b/src/ui/src/lib/acp.ts
@@ -867,14 +867,20 @@ function snapshotIndicatesLiveRun(snapshot?: QuestSummary | null) {
     Number.isFinite(latestActivityMs) &&
     Date.now() - latestActivityMs > 90_000
 
+  const isStaleCopilotWait =
+    workspaceMode === 'copilot' &&
+    continuationPolicy === 'wait_for_user_or_resume' &&
+    !activeRunId &&
+    Number.isFinite(latestActivityMs) &&
+    Date.now() - latestActivityMs > 90_000
   const isParkedCopilot =
     workspaceMode === 'copilot' &&
     continuationPolicy === 'wait_for_user_or_resume' &&
     !activeRunId &&
-    runtimeStatus !== 'running' &&
-    (bashRunningCount === 0 ||
-      (bashRunningCount === 1 &&
-        latestBashKind === 'terminal' &&
+    (runtimeStatus !== 'running' || isStaleCopilotWait) &&
+    (isStaleCopilotWait ||
+      bashRunningCount === 0 ||
+      (latestBashKind === 'terminal' &&
         (latestBashId === '' || latestBashId === 'terminal-main')))
   if (isParkedCopilot) return false
   if (staleRunningWithoutSignals) return false

--- a/src/ui/src/lib/api/bash.ts
+++ b/src/ui/src/lib/api/bash.ts
@@ -6,6 +6,16 @@ import type {
   BashStopResponse,
 } from '@/lib/types/bash'
 
+function normalizeBashSessionsPayload(payload: unknown): BashSession[] {
+  if (Array.isArray(payload)) return payload as BashSession[]
+  if (payload && typeof payload === 'object') {
+    const record = payload as Record<string, unknown>
+    if (Array.isArray(record.items)) return record.items as BashSession[]
+    if (Array.isArray(record.sessions)) return record.sessions as BashSession[]
+  }
+  return []
+}
+
 export async function listBashSessions(
   projectId: string,
   params?: {
@@ -29,7 +39,7 @@ export async function listBashSessions(
       limit: params?.limit,
     },
   })
-  return response.data as BashSession[]
+  return normalizeBashSessionsPayload(response.data)
 }
 
 export async function getBashSession(projectId: string, bashId: string) {

--- a/src/ui/src/lib/hooks/useBashSessionStream.ts
+++ b/src/ui/src/lib/hooks/useBashSessionStream.ts
@@ -61,13 +61,41 @@ const isLikelyNetworkStreamError = (error: unknown) => {
 const sortSessions = (sessions: BashSession[]) =>
   [...sessions].sort((a, b) => Date.parse(b.started_at) - Date.parse(a.started_at))
 
+const sessionFingerprint = (session: BashSession) => {
+  try {
+    return JSON.stringify(session)
+  } catch {
+    return String(session.bash_id || '')
+  }
+}
+
+const sessionEquals = (left: BashSession | undefined, right: BashSession | undefined) => {
+  if (left === right) return true
+  if (!left || !right) return false
+  return sessionFingerprint(left) === sessionFingerprint(right)
+}
+
+const sessionsEqual = (left: BashSession[], right: BashSession[]) => {
+  if (left === right) return true
+  if (left.length !== right.length) return false
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index]?.bash_id !== right[index]?.bash_id) return false
+    if (!sessionEquals(left[index], right[index])) return false
+  }
+  return true
+}
+
 const mergeSessions = (previous: BashSession[], incoming: BashSession) => {
   if (!incoming?.bash_id) return previous
   const map = new Map(previous.map((session) => [session.bash_id, session]))
   const existing = map.get(incoming.bash_id)
   const merged = existing ? { ...existing, ...incoming } : incoming
+  if (existing && sessionEquals(existing, merged)) {
+    return previous
+  }
   map.set(incoming.bash_id, merged)
-  return sortSessions(Array.from(map.values()))
+  const next = sortSessions(Array.from(map.values()))
+  return sessionsEqual(previous, next) ? previous : next
 }
 
 const buildAuthContext = () => {
@@ -84,6 +112,8 @@ const buildAuthContext = () => {
 const handleUnauthorized = (authMode: RequestAuthMode) => {
   handleUnauthorizedAuth(authMode, 'session_expired')
 }
+
+const SESSION_STREAM_FLUSH_MS = 1000
 
 export function useBashSessionStream({
   projectId,
@@ -105,6 +135,8 @@ export function useBashSessionStream({
   const abortRef = useRef<AbortController | null>(null)
   const reconnectRef = useRef<number | null>(null)
   const hasSnapshotRef = useRef(false)
+  const pendingSessionEventsRef = useRef<Map<string, BashSession>>(new Map())
+  const sessionFlushTimerRef = useRef<number | null>(null)
 
   const queryKey = useMemo(() => {
     return [
@@ -125,8 +157,45 @@ export function useBashSessionStream({
   ])
 
   const updateConnection = useCallback((next: BashSessionStreamState) => {
-    setConnection(next)
+    setConnection((current) =>
+      current.status === next.status && current.error === next.error ? current : next
+    )
   }, [])
+
+  const flushPendingSessionEvents = useCallback(() => {
+    sessionFlushTimerRef.current = null
+    const pending = Array.from(pendingSessionEventsRef.current.values())
+    pendingSessionEventsRef.current.clear()
+    if (pending.length === 0) return
+    setSessions((current) => {
+      let next = current
+      for (const session of pending) {
+        next = mergeSessions(next, session)
+      }
+      return next
+    })
+  }, [])
+
+  const clearPendingSessionEvents = useCallback(() => {
+    pendingSessionEventsRef.current.clear()
+    if (sessionFlushTimerRef.current != null) {
+      window.clearTimeout(sessionFlushTimerRef.current)
+      sessionFlushTimerRef.current = null
+    }
+  }, [])
+
+  const queueSessionEvent = useCallback(
+    (session: BashSession) => {
+      if (!session?.bash_id) return
+      pendingSessionEventsRef.current.set(session.bash_id, session)
+      if (sessionFlushTimerRef.current != null) return
+      sessionFlushTimerRef.current = window.setTimeout(
+        flushPendingSessionEvents,
+        SESSION_STREAM_FLUSH_MS
+      )
+    },
+    [flushPendingSessionEvents]
+  )
 
   const stopStream = useCallback(() => {
     if (abortRef.current) {
@@ -137,7 +206,8 @@ export function useBashSessionStream({
       window.clearTimeout(reconnectRef.current)
       reconnectRef.current = null
     }
-  }, [])
+    clearPendingSessionEvents()
+  }, [clearPendingSessionEvents])
 
   const reload = useCallback(async () => {
     if (!enabled || !projectId) {
@@ -152,7 +222,10 @@ export function useBashSessionStream({
         chatSessionId: chatSessionId ?? undefined,
         limit,
       })
-      setSessions(sortSessions(response))
+      setSessions((current) => {
+        const next = sortSessions(response)
+        return sessionsEqual(current, next) ? current : next
+      })
     } catch (error) {
       updateConnection({
         status: 'error',
@@ -250,13 +323,16 @@ export function useBashSessionStream({
                   const data = JSON.parse(parsed.data) as { sessions?: BashSession[] }
                   if (Array.isArray(data.sessions)) {
                     hasSnapshotRef.current = true
-                    setSessions(sortSessions(data.sessions))
+                    setSessions((current) => {
+                      const next = sortSessions(data.sessions)
+                      return sessionsEqual(current, next) ? current : next
+                    })
                   }
                 }
                 if (parsed.event === 'session') {
                   const data = JSON.parse(parsed.data) as { session?: BashSession }
                   if (data.session) {
-                    setSessions((current) => mergeSessions(current, data.session as BashSession))
+                    queueSessionEvent(data.session as BashSession)
                   }
                 }
               } catch (error) {
@@ -276,13 +352,16 @@ export function useBashSessionStream({
                 const data = JSON.parse(parsed.data) as { sessions?: BashSession[] }
                 if (Array.isArray(data.sessions)) {
                   hasSnapshotRef.current = true
-                  setSessions(sortSessions(data.sessions))
+                    setSessions((current) => {
+                      const next = sortSessions(data.sessions)
+                      return sessionsEqual(current, next) ? current : next
+                    })
                 }
               }
               if (parsed.event === 'session') {
                 const data = JSON.parse(parsed.data) as { session?: BashSession }
                 if (data.session) {
-                  setSessions((current) => mergeSessions(current, data.session as BashSession))
+                  queueSessionEvent(data.session as BashSession)
                 }
               }
             } catch (error) {
@@ -331,6 +410,7 @@ export function useBashSessionStream({
       normalizedAgentIds.key,
       normalizedAgentInstanceIds.key,
       projectId,
+      queueSessionEvent,
       reload,
       stopStream,
       status,

--- a/src/ui/src/lib/plugins/ai-manus/components/OrbitLogoStatus.tsx
+++ b/src/ui/src/lib/plugins/ai-manus/components/OrbitLogoStatus.tsx
@@ -197,7 +197,7 @@ export function OrbitLogoStatus({
       rafRef.current = window.requestAnimationFrame(tick)
     }
     rafRef.current = window.requestAnimationFrame(tick)
-  }, [drawFrame, prefersReducedMotion])
+  }, [drawFrame, shouldAnimate])
 
   useEffect(() => {
     if (prefersReducedMotion) {

--- a/src/ui/src/pages/ProjectWorkspacePage.tsx
+++ b/src/ui/src/pages/ProjectWorkspacePage.tsx
@@ -14,12 +14,12 @@ function AtmosphereFrame({ children }: { children: ReactNode }) {
   return (
     <div className="relative isolate min-h-screen overflow-hidden bg-[#ABA9A5] dark:bg-[#0B0C0E] font-project">
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute -top-40 -left-40 h-[560px] w-[560px] rounded-full blur-3xl animate-blob bg-[radial-gradient(circle_at_center,rgba(143,163,184,0.16),transparent_72%)] dark:bg-[radial-gradient(circle_at_center,rgba(143,163,184,0.16),transparent_72%)]" />
+        <div className="absolute -top-40 -left-40 h-[560px] w-[560px] rounded-full blur-3xl bg-[radial-gradient(circle_at_center,rgba(143,163,184,0.16),transparent_72%)] dark:bg-[radial-gradient(circle_at_center,rgba(143,163,184,0.16),transparent_72%)]" />
         <div
-          className="absolute top-10 -right-52 h-[640px] w-[640px] rounded-full blur-3xl animate-blob bg-[radial-gradient(circle_at_center,rgba(47,52,55,0.08),transparent_72%)] dark:bg-[radial-gradient(circle_at_center,rgba(47,52,55,0.10),transparent_72%)]"
+          className="absolute top-10 -right-52 h-[640px] w-[640px] rounded-full blur-3xl bg-[radial-gradient(circle_at_center,rgba(47,52,55,0.08),transparent_72%)] dark:bg-[radial-gradient(circle_at_center,rgba(47,52,55,0.10),transparent_72%)]"
           style={{ animationDelay: '1.5s' }}
         />
-        <Noise size={260} className="opacity-[0.04] dark:opacity-[0.05]" />
+        <Noise size={260} animated={false} className="opacity-[0.04] dark:opacity-[0.05]" />
       </div>
       {children}
     </div>


### PR DESCRIPTION
## Summary

This PR fixes a severe production-impacting performance bug where opening an idle project workspace page, such as `/projects/004`, could continuously consume more than one full CPU core.

The issue was severe because a normal idle web page could keep browser CPU usage around 120%+ on user hardware and over 200% in automated profiling, causing laptop overheating and making the workspace unsafe to leave open.

## Severity

**Critical / High severity**

Before this fix, simply opening an idle project page could cause sustained high CPU usage:

- User report: ~120% CPU on an M4 Mac
- Reproduction in Playwright/Chromium: over 200% total browser CPU
- Continuous React update loop warnings were observed during root-cause isolation
- The page remained hot even when the user was not interacting with it

This is not expected behavior for an idle research workspace page.

## Root Cause

The CPU issue had multiple contributing causes:

1. **Runaway React render/update loop in the Copilot dock**
   - `CopilotDockCallbacksContext.Provider` recreated a new context value object on every render.
   - `QuestCopilotDockPanel` had effects depending on that context object.
   - Those effects called `onHeaderExtraChange`, `onMetaChange`, and related setters repeatedly.
   - This produced continuous React commits and `Maximum update depth exceeded` warnings.

2. **Idle copilot workspaces were incorrectly treated as live/running**
   - Quest `004` had `active_run_id: null` and was in `wait_for_user_or_resume`.
   - However, historical/terminal bash sessions still contributed to `bash_running_count`.
   - The UI therefore treated a parked copilot workspace as active work.
   - This kept busy state, polling/streaming paths, and active UI updates alive.

3. **Bash operation cards performed unstable state propagation**
   - `QuestBashExecOperation` parsed structured args/output on every render, creating fresh objects.
   - Live bash progress/status callbacks were recreated and could report equivalent state repeatedly.
   - `McpBashExecView` also reported unchanged live state back to the parent.
   - This amplified re-rendering across dozens of bash operation cards.

4. **Bash session stream updates were not sufficiently deduplicated**
   - Repeated equivalent session events caused unnecessary React state updates.
   - Session updates are now deduplicated and batched.

5. **Idle decorative workspace animations added avoidable GPU/renderer work**
   - Decorative background blob/noise animations were disabled on the heavy project workspace surfaces so an idle workspace can remain effectively idle.

## Fix

This PR:

- Memoizes the Copilot dock callback context value.
- Guards Copilot metadata/header updates against identical state.
- Detects stale parked copilot workspaces correctly when:
  - `workspace_mode === "copilot"`
  - `continuation_policy === "wait_for_user_or_resume"`
  - `active_run_id` is absent
  - latest tool activity is stale
- Stabilizes `QuestBashExecOperation` by:
  - memoizing parsed args/output/progress
  - using stable live-state callbacks
  - avoiding state updates when progress/status values are unchanged
- Stabilizes `McpBashExecView` by:
  - suppressing duplicate `onLiveStateChange` emissions
  - guarding equivalent progress/status setters
- Deduplicates and batches bash session stream updates.
- Memoizes expensive Studio trace blocks to avoid unnecessary remount/re-render work.
- Disables idle decorative workspace background animations on project workspace surfaces.

## CPU Usage Report

### Before Fix

Initial production/dev reproduction showed sustained runaway CPU:

| Measurement | Total Browser CPU | Renderer CPU | GPU CPU |
|---|---:|---:|---:|
| Live reproduction | ~225.3% | ~138.6% | ~86.5% |
| Dev reproduction | ~242.2% | ~152.4% | ~89.5% |

Additional root-cause probe:

- React update loop warnings: `Maximum update depth exceeded`
- Console warning count during reproduction: `168` warnings in a 10s sampling window
- React commit probe showed continuous commits while idle

### After Fix

Final deployed live measurement:

| Measurement | Total Browser CPU | Renderer CPU | GPU CPU |
|---|---:|---:|---:|
| Live after fix | ~7.3% | ~6.9% | ~0.1% |

Final verification:

- Active animation list: `[]`
- Console warnings/errors from update loop: `0`
- Live bundle verified: `/ui/assets/index-qDSXrMaL.js`

## Testing

Passed:

```bash
git diff --check
npm --prefix src/ui run build
```
